### PR TITLE
Config and layout persistence: file-based storage with API

### DIFF
--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -1,0 +1,128 @@
+"""File-based persistence for config and canvas layouts.
+
+Config dir: ~/.claude-rts/
+Config file: ~/.claude-rts/config.json
+Canvas layouts: ~/.claude-rts/canvases/{name}.json
+"""
+
+import json
+import pathlib
+import re
+
+from loguru import logger
+
+CONFIG_DIR = pathlib.Path.home() / ".claude-rts"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+CANVASES_DIR = CONFIG_DIR / "canvases"
+
+DEFAULT_CONFIG = {
+    "copy": "ctrl-shift-c",
+    "paste": "ctrl-shift-v",
+    "rightclick": "paste",
+    "idle_threshold": 5,
+    "default_canvas": "main",
+    "theme": "catppuccin-mocha",
+}
+
+# Allowed canvas name pattern: alphanumeric, hyphens, underscores
+_CANVAS_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def ensure_dirs() -> None:
+    """Create config and canvases directories if they don't exist."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CANVASES_DIR.mkdir(parents=True, exist_ok=True)
+    logger.debug("Ensured config dirs: {}, {}", CONFIG_DIR, CANVASES_DIR)
+
+
+def _valid_canvas_name(name: str) -> bool:
+    """Return True if name is a safe canvas filename."""
+    return bool(name) and bool(_CANVAS_NAME_RE.match(name))
+
+
+# ── Config ──────────────────────────────────────────────
+
+
+def read_config() -> dict:
+    """Read config from disk, returning defaults for missing keys."""
+    ensure_dirs()
+    if CONFIG_FILE.exists():
+        try:
+            data = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+            logger.debug("Loaded config from {}", CONFIG_FILE)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to read config, using defaults: {}", exc)
+            data = {}
+    else:
+        data = {}
+
+    # Merge defaults for any missing keys
+    merged = {**DEFAULT_CONFIG, **data}
+    return merged
+
+
+def write_config(data: dict) -> dict:
+    """Write config to disk. Merges with defaults for missing keys."""
+    ensure_dirs()
+    merged = {**DEFAULT_CONFIG, **data}
+    CONFIG_FILE.write_text(json.dumps(merged, indent=2), encoding="utf-8")
+    logger.info("Wrote config to {}", CONFIG_FILE)
+    return merged
+
+
+# ── Canvases ────────────────────────────────────────────
+
+
+def list_canvases() -> list[str]:
+    """Return sorted list of saved canvas names (without .json extension)."""
+    ensure_dirs()
+    names = sorted(
+        p.stem for p in CANVASES_DIR.glob("*.json") if p.is_file()
+    )
+    logger.debug("Listed {} canvas(es)", len(names))
+    return names
+
+
+def read_canvas(name: str) -> dict | None:
+    """Read a canvas layout by name. Returns None if not found."""
+    if not _valid_canvas_name(name):
+        logger.warning("Invalid canvas name: {!r}", name)
+        return None
+    path = CANVASES_DIR / f"{name}.json"
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        logger.debug("Loaded canvas '{}' from {}", name, path)
+        return data
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to read canvas '{}': {}", name, exc)
+        return None
+
+
+def write_canvas(name: str, data: dict) -> bool:
+    """Write a canvas layout to disk. Returns True on success."""
+    if not _valid_canvas_name(name):
+        logger.warning("Invalid canvas name: {!r}", name)
+        return False
+    ensure_dirs()
+    path = CANVASES_DIR / f"{name}.json"
+    try:
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        logger.info("Wrote canvas '{}' to {}", name, path)
+        return True
+    except OSError as exc:
+        logger.error("Failed to write canvas '{}': {}", name, exc)
+        return False
+
+
+def delete_canvas(name: str) -> bool:
+    """Delete a canvas layout. Returns True if it existed and was deleted."""
+    if not _valid_canvas_name(name):
+        return False
+    path = CANVASES_DIR / f"{name}.json"
+    if path.exists():
+        path.unlink()
+        logger.info("Deleted canvas '{}'", name)
+        return True
+    return False

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -8,6 +8,7 @@ from aiohttp import web
 from loguru import logger
 from winpty import PtyProcess
 
+from .config import read_config, write_config, list_canvases, read_canvas, write_canvas
 from .discovery import discover_hubs
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
@@ -23,6 +24,50 @@ async def hubs_handler(request: web.Request) -> web.Response:
     hubs = await discover_hubs()
     logger.info("Discovered {} hub(s): {}", len(hubs), [h["hub"] for h in hubs])
     return web.json_response(hubs)
+
+
+async def config_get_handler(request: web.Request) -> web.Response:
+    logger.debug("Config read requested by {}", request.remote)
+    data = read_config()
+    return web.json_response(data)
+
+
+async def config_put_handler(request: web.Request) -> web.Response:
+    logger.info("Config update requested by {}", request.remote)
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        raise web.HTTPBadRequest(text="Invalid JSON")
+    saved = write_config(body)
+    return web.json_response(saved)
+
+
+async def canvases_list_handler(request: web.Request) -> web.Response:
+    logger.debug("Canvas list requested by {}", request.remote)
+    names = list_canvases()
+    return web.json_response(names)
+
+
+async def canvas_get_handler(request: web.Request) -> web.Response:
+    name = request.match_info["name"]
+    logger.debug("Canvas '{}' read requested by {}", name, request.remote)
+    data = read_canvas(name)
+    if data is None:
+        raise web.HTTPNotFound(text=f"Canvas '{name}' not found")
+    return web.json_response(data)
+
+
+async def canvas_put_handler(request: web.Request) -> web.Response:
+    name = request.match_info["name"]
+    logger.info("Canvas '{}' save requested by {}", name, request.remote)
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        raise web.HTTPBadRequest(text="Invalid JSON")
+    ok = write_canvas(name, body)
+    if not ok:
+        raise web.HTTPBadRequest(text=f"Invalid canvas name '{name}'")
+    return web.json_response({"status": "ok", "name": name})
 
 
 async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
@@ -114,6 +159,11 @@ def create_app() -> web.Application:
     app = web.Application()
     app.router.add_get("/", index_handler)
     app.router.add_get("/api/hubs", hubs_handler)
+    app.router.add_get("/api/config", config_get_handler)
+    app.router.add_put("/api/config", config_put_handler)
+    app.router.add_get("/api/canvases", canvases_list_handler)
+    app.router.add_get("/api/canvases/{name}", canvas_get_handler)
+    app.router.add_put("/api/canvases/{name}", canvas_put_handler)
     app.router.add_get("/ws/{hub}", websocket_handler)
-    logger.info("Application routes registered: /, /api/hubs, /ws/{{hub}}")
+    logger.info("Application routes registered")
     return app

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -1063,26 +1063,46 @@ function layoutGrid(hubList) {
 // ════════════════════════════════════════════
 // Settings
 // ════════════════════════════════════════════
-const SETTINGS_KEY = 'claude-rts-settings';
 const DEFAULT_SETTINGS = {
   copy: 'ctrl-shift-c',
   paste: 'ctrl-shift-v',
   rightclick: 'paste',
-  idle: 5,
+  idle_threshold: 5,
+  default_canvas: 'main',
+  theme: 'catppuccin-mocha',
 };
 let settings = { ...DEFAULT_SETTINGS };
 
-function loadSettings() {
+async function loadSettings() {
   try {
-    const raw = localStorage.getItem(SETTINGS_KEY);
-    if (raw) Object.assign(settings, JSON.parse(raw));
-  } catch {}
+    const resp = await fetch('/api/config');
+    if (resp.ok) {
+      const data = await resp.json();
+      // Map server keys to UI: idle_threshold -> idle for backward compat
+      settings.copy = data.copy || DEFAULT_SETTINGS.copy;
+      settings.paste = data.paste || DEFAULT_SETTINGS.paste;
+      settings.rightclick = data.rightclick || DEFAULT_SETTINGS.rightclick;
+      settings.idle_threshold = data.idle_threshold ?? DEFAULT_SETTINGS.idle_threshold;
+      settings.default_canvas = data.default_canvas || DEFAULT_SETTINGS.default_canvas;
+      settings.theme = data.theme || DEFAULT_SETTINGS.theme;
+    }
+  } catch (err) {
+    console.warn('Failed to load settings from server, using defaults:', err);
+  }
   applySettingsToUI();
   applySettingsToState();
 }
 
-function saveSettings() {
-  localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+async function saveSettings() {
+  try {
+    await fetch('/api/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(settings),
+    });
+  } catch (err) {
+    console.warn('Failed to save settings to server:', err);
+  }
   applySettingsToState();
 }
 
@@ -1090,11 +1110,11 @@ function applySettingsToUI() {
   document.getElementById('setting-copy').value = settings.copy;
   document.getElementById('setting-paste').value = settings.paste;
   document.getElementById('setting-rightclick').value = settings.rightclick;
-  document.getElementById('setting-idle').value = String(settings.idle);
+  document.getElementById('setting-idle').value = String(settings.idle_threshold);
 }
 
 function applySettingsToState() {
-  IDLE_THRESHOLD_MS = settings.idle * 1000;
+  IDLE_THRESHOLD_MS = settings.idle_threshold * 1000;
 }
 
 function resetSettings() {
@@ -1120,12 +1140,16 @@ settingsOverlay.addEventListener('click', (e) => {
 for (const sel of ['setting-copy', 'setting-paste', 'setting-rightclick', 'setting-idle']) {
   document.getElementById(sel).addEventListener('change', (e) => {
     const key = sel.replace('setting-', '');
-    settings[key] = key === 'idle' ? parseInt(e.target.value) : e.target.value;
+    if (key === 'idle') {
+      settings.idle_threshold = parseInt(e.target.value);
+    } else {
+      settings[key] = e.target.value;
+    }
     saveSettings();
   });
 }
 
-loadSettings();
+// loadSettings() is called in boot sequence below
 
 // ════════════════════════════════════════════
 // Keyboard shortcuts
@@ -1146,27 +1170,42 @@ document.addEventListener('keydown', (e) => {
 });
 
 // ════════════════════════════════════════════
-// Layout persistence (localStorage)
+// Layout persistence (server-side canvases)
 // ════════════════════════════════════════════
-const LAYOUT_KEY = 'claude-rts-layout';
+let currentCanvasName = 'main';
 
 function saveLayout() {
-  const data = cards.map(c => c.serialize());
-  localStorage.setItem(LAYOUT_KEY, JSON.stringify(data));
+  const data = {
+    name: currentCanvasName,
+    canvas_size: [CANVAS_W, CANVAS_H],
+    cards: cards.map(c => c.serialize()),
+  };
+  fetch(`/api/canvases/${encodeURIComponent(currentCanvasName)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  }).catch(err => console.warn('Failed to save layout:', err));
 }
 
-function loadLayout() {
+async function loadLayout() {
   try {
-    const raw = localStorage.getItem(LAYOUT_KEY);
-    if (!raw) return null;
-    return JSON.parse(raw);
-  } catch { return null; }
+    const resp = await fetch(`/api/canvases/${encodeURIComponent(currentCanvasName)}`);
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    return data.cards || null;
+  } catch {
+    return null;
+  }
 }
 
 // ════════════════════════════════════════════
 // Boot
 // ════════════════════════════════════════════
 (async function() {
+  // Load settings first (determines default_canvas)
+  await loadSettings();
+  currentCanvasName = settings.default_canvas || 'main';
+
   const resp = await fetch('/api/hubs');
   hubs = await resp.json();
 
@@ -1181,7 +1220,7 @@ function loadLayout() {
   });
 
   // Restore saved layout or use default grid
-  const saved = loadLayout();
+  const saved = await loadLayout();
   if (saved && saved.length > 0) {
     // Spawn cards from saved layout
     for (const s of saved) {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,217 @@
+"""Tests for config module and API endpoints."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from claude_rts.config import (
+    DEFAULT_CONFIG,
+    read_config,
+    write_config,
+    list_canvases,
+    read_canvas,
+    write_canvas,
+    delete_canvas,
+    _valid_canvas_name,
+)
+from claude_rts.server import create_app
+
+
+# ── Unit tests for config module ──────────────────────────
+
+
+@pytest.fixture
+def config_dir(tmp_path):
+    """Patch CONFIG_DIR, CONFIG_FILE, CANVASES_DIR to use tmp_path."""
+    cfg_dir = tmp_path / ".claude-rts"
+    cfg_file = cfg_dir / "config.json"
+    canvases_dir = cfg_dir / "canvases"
+    with patch("claude_rts.config.CONFIG_DIR", cfg_dir), \
+         patch("claude_rts.config.CONFIG_FILE", cfg_file), \
+         patch("claude_rts.config.CANVASES_DIR", canvases_dir):
+        yield cfg_dir, cfg_file, canvases_dir
+
+
+def test_read_config_defaults(config_dir):
+    """Returns defaults when no config file exists."""
+    data = read_config()
+    assert data == DEFAULT_CONFIG
+
+
+def test_write_and_read_config(config_dir):
+    cfg_dir, cfg_file, _ = config_dir
+    write_config({"copy": "auto-select", "idle_threshold": 10})
+    data = read_config()
+    assert data["copy"] == "auto-select"
+    assert data["idle_threshold"] == 10
+    # Defaults should fill in missing keys
+    assert data["paste"] == DEFAULT_CONFIG["paste"]
+    assert data["theme"] == DEFAULT_CONFIG["theme"]
+
+
+def test_write_config_merges_defaults(config_dir):
+    """write_config merges with defaults so file always has all keys."""
+    result = write_config({"copy": "ctrl-c-sel"})
+    assert result["copy"] == "ctrl-c-sel"
+    assert result["paste"] == DEFAULT_CONFIG["paste"]
+
+
+def test_read_config_corrupt_json(config_dir):
+    """Corrupt JSON falls back to defaults."""
+    cfg_dir, cfg_file, _ = config_dir
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg_file.write_text("not json!", encoding="utf-8")
+    data = read_config()
+    assert data == DEFAULT_CONFIG
+
+
+def test_valid_canvas_name():
+    assert _valid_canvas_name("main") is True
+    assert _valid_canvas_name("my-layout_2") is True
+    assert _valid_canvas_name("") is False
+    assert _valid_canvas_name("../etc") is False
+    assert _valid_canvas_name("foo bar") is False
+    assert _valid_canvas_name("a/b") is False
+
+
+def test_list_canvases_empty(config_dir):
+    names = list_canvases()
+    assert names == []
+
+
+def test_write_and_list_canvases(config_dir):
+    layout = {"name": "main", "canvas_size": [3840, 2160], "cards": []}
+    assert write_canvas("main", layout) is True
+    assert write_canvas("work", {"name": "work", "cards": []}) is True
+    names = list_canvases()
+    assert names == ["main", "work"]
+
+
+def test_read_canvas(config_dir):
+    layout = {"name": "test", "canvas_size": [3840, 2160], "cards": [{"hub": "hub_1"}]}
+    write_canvas("test", layout)
+    data = read_canvas("test")
+    assert data == layout
+
+
+def test_read_canvas_not_found(config_dir):
+    assert read_canvas("nonexistent") is None
+
+
+def test_read_canvas_invalid_name(config_dir):
+    assert read_canvas("../evil") is None
+
+
+def test_write_canvas_invalid_name(config_dir):
+    assert write_canvas("bad name!", {"cards": []}) is False
+
+
+def test_delete_canvas(config_dir):
+    write_canvas("deleteme", {"cards": []})
+    assert delete_canvas("deleteme") is True
+    assert read_canvas("deleteme") is None
+
+
+def test_delete_canvas_not_found(config_dir):
+    assert delete_canvas("nope") is False
+
+
+# ── API endpoint tests ────────────────────────────────────
+
+
+@pytest.fixture
+def app(config_dir):
+    return create_app()
+
+
+@pytest.fixture
+async def client(aiohttp_client, app):
+    return await aiohttp_client(app)
+
+
+async def test_get_config_returns_defaults(client, config_dir):
+    resp = await client.get("/api/config")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["copy"] == DEFAULT_CONFIG["copy"]
+    assert data["idle_threshold"] == DEFAULT_CONFIG["idle_threshold"]
+
+
+async def test_put_config(client, config_dir):
+    resp = await client.put(
+        "/api/config",
+        json={"copy": "auto-select", "idle_threshold": 30},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["copy"] == "auto-select"
+    assert data["idle_threshold"] == 30
+    assert data["paste"] == DEFAULT_CONFIG["paste"]
+
+    # Verify it persisted
+    resp2 = await client.get("/api/config")
+    data2 = await resp2.json()
+    assert data2["copy"] == "auto-select"
+
+
+async def test_put_config_invalid_json(client, config_dir):
+    resp = await client.put(
+        "/api/config",
+        data=b"not json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status == 400
+
+
+async def test_list_canvases_empty(client, config_dir):
+    resp = await client.get("/api/canvases")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == []
+
+
+async def test_put_and_get_canvas(client, config_dir):
+    layout = {
+        "name": "main",
+        "canvas_size": [3840, 2160],
+        "cards": [{"type": "terminal", "hub": "hub_1", "x": 100, "y": 100, "w": 720, "h": 480}],
+    }
+    resp = await client.put("/api/canvases/main", json=layout)
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["status"] == "ok"
+    assert result["name"] == "main"
+
+    # Read it back
+    resp2 = await client.get("/api/canvases/main")
+    assert resp2.status == 200
+    data = await resp2.json()
+    assert data["name"] == "main"
+    assert len(data["cards"]) == 1
+
+    # Should appear in list
+    resp3 = await client.get("/api/canvases")
+    names = await resp3.json()
+    assert "main" in names
+
+
+async def test_get_canvas_not_found(client, config_dir):
+    resp = await client.get("/api/canvases/nonexistent")
+    assert resp.status == 404
+
+
+async def test_put_canvas_invalid_json(client, config_dir):
+    resp = await client.put(
+        "/api/canvases/main",
+        data=b"bad",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status == 400
+
+
+async def test_app_has_config_and_canvas_routes(app):
+    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
+    assert "/api/config" in routes
+    assert "/api/canvases" in routes
+    assert "/api/canvases/{name}" in routes

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -67,4 +67,7 @@ async def test_app_has_all_routes(app):
     routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
     assert "/" in routes
     assert "/api/hubs" in routes
+    assert "/api/config" in routes
+    assert "/api/canvases" in routes
+    assert "/api/canvases/{name}" in routes
     assert "/ws/{hub}" in routes


### PR DESCRIPTION
## Summary
- New `config.py` module for file-based config and canvas layout persistence in `~/.claude-rts/`
- 5 new API endpoints: `GET/PUT /api/config`, `GET/PUT /api/canvases/{name}`, `GET /api/canvases`
- Frontend migrated from localStorage to fetch API for all persistence
- Canvas name validation prevents path traversal attacks
- 20 new tests covering config CRUD, canvas CRUD, and all API endpoints

Closes #12

## Test plan
- [x] All 35 tests pass (15 existing + 20 new)
- [ ] Manual: settings changes persist across server restart
- [ ] Manual: canvas layouts save to `~/.claude-rts/canvases/`
- [ ] Manual: first run creates default config
- [ ] Manual: API endpoints respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)