### PR TITLE
Custom startup: scriptable card sources with LoaderCard

### DIFF
--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -22,6 +22,7 @@ DEFAULT_CONFIG = {
     "idle_threshold": 5,
     "default_canvas": "main",
     "theme": "catppuccin-mocha",
+    "startup_script": "discover-devcontainers",
 }
 
 # Allowed canvas name pattern: alphanumeric, hyphens, underscores

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -10,6 +10,7 @@ from winpty import PtyProcess
 
 from .config import read_config, write_config, list_canvases, read_canvas, write_canvas, delete_canvas
 from .discovery import discover_hubs
+from .startup import run_startup
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
@@ -24,6 +25,22 @@ async def hubs_handler(request: web.Request) -> web.Response:
     hubs = await discover_hubs()
     logger.info("Discovered {} hub(s): {}", len(hubs), [h["hub"] for h in hubs])
     return web.json_response(hubs)
+
+
+async def startup_handler(request: web.Request) -> web.Response:
+    logger.info("Startup requested by {}", request.remote)
+    config = read_config()
+    script_name = config.get("startup_script", "discover-devcontainers")
+    try:
+        result = await run_startup(script_name)
+        logger.info("Startup script '{}' returned {} card(s)", script_name, len(result))
+        return web.json_response({"status": "ok", "script": script_name, "cards": result})
+    except Exception as exc:
+        logger.exception("Startup script '{}' failed", script_name)
+        return web.json_response(
+            {"status": "error", "script": script_name, "error": str(exc), "cards": []},
+            status=500,
+        )
 
 
 async def config_get_handler(request: web.Request) -> web.Response:
@@ -166,16 +183,93 @@ async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
     return ws
 
 
+async def exec_websocket_handler(request: web.Request) -> web.WebSocketResponse:
+    """WebSocket handler that spawns a PTY for an arbitrary command."""
+    cmd = request.query.get("cmd", "").strip()
+    if not cmd:
+        logger.warning("exec WebSocket: missing 'cmd' query parameter")
+        raise web.HTTPBadRequest(text="Missing 'cmd' query parameter")
+
+    logger.info("exec WebSocket request: cmd={!r}", cmd)
+
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+    logger.info("exec WebSocket established for cmd={!r}", cmd)
+
+    logger.info("Spawning PTY process: {}", cmd)
+
+    try:
+        pty = PtyProcess.spawn(cmd, dimensions=(24, 80))
+    except Exception:
+        logger.exception("Failed to spawn PTY for cmd={!r}", cmd)
+        await ws.close(code=1011, message=b"Failed to spawn terminal")
+        return ws
+
+    logger.info("PTY spawned successfully for cmd={!r}", cmd)
+
+    async def pty_read_loop():
+        """Read from PTY and forward to WebSocket."""
+        loop = asyncio.get_event_loop()
+        try:
+            while pty.isalive():
+                try:
+                    data = await loop.run_in_executor(None, pty.read)
+                    if data:
+                        await ws.send_bytes(data.encode("utf-8", errors="replace"))
+                except EOFError:
+                    logger.info("PTY EOF for cmd={!r}", cmd)
+                    break
+                except Exception:
+                    logger.exception("PTY read error for cmd={!r}", cmd)
+                    break
+        finally:
+            if not ws.closed:
+                await ws.close()
+
+    read_task = asyncio.create_task(pty_read_loop())
+
+    try:
+        async for msg in ws:
+            if msg.type == web.WSMsgType.BINARY:
+                text = msg.data.decode("utf-8", errors="replace")
+                pty.write(text)
+            elif msg.type == web.WSMsgType.TEXT:
+                try:
+                    control = json.loads(msg.data)
+                    if control.get("type") == "resize":
+                        cols = control.get("cols", 80)
+                        rows = control.get("rows", 24)
+                        logger.info("Resize exec cmd={!r}: {}x{}", cmd, cols, rows)
+                        pty.setwinsize(rows, cols)
+                except json.JSONDecodeError:
+                    logger.warning("Invalid JSON control message for exec cmd={!r}", cmd)
+            elif msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
+                break
+    except Exception:
+        logger.exception("exec WebSocket handler error for cmd={!r}", cmd)
+    finally:
+        logger.info("Cleaning up exec session cmd={!r}", cmd)
+        read_task.cancel()
+        try:
+            pty.terminate(force=True)
+        except Exception:
+            pass
+
+    return ws
+
+
 def create_app() -> web.Application:
     app = web.Application()
     app.router.add_get("/", index_handler)
     app.router.add_get("/api/hubs", hubs_handler)
+    app.router.add_get("/api/startup", startup_handler)
     app.router.add_get("/api/config", config_get_handler)
     app.router.add_put("/api/config", config_put_handler)
     app.router.add_get("/api/canvases", canvases_list_handler)
     app.router.add_get("/api/canvases/{name}", canvas_get_handler)
     app.router.add_put("/api/canvases/{name}", canvas_put_handler)
     app.router.add_delete("/api/canvases/{name}", canvas_delete_handler)
+    app.router.add_get("/ws/exec", exec_websocket_handler)
     app.router.add_get("/ws/{hub}", websocket_handler)
     logger.info("Application routes registered")
     return app

--- a/claude_rts/startup.py
+++ b/claude_rts/startup.py
@@ -1,0 +1,113 @@
+"""Startup scripts: pluggable card source discovery.
+
+Built-in scripts:
+  - discover-devcontainers: runs docker discovery, returns terminal entries
+  - from-layout: returns empty list (frontend loads from saved canvas)
+
+Custom scripts: executable files in ~/.claude-rts/startup/ that output JSON arrays.
+"""
+
+import asyncio
+import json
+import pathlib
+
+from loguru import logger
+
+from .config import CONFIG_DIR
+from .discovery import discover_hubs
+
+STARTUP_DIR = CONFIG_DIR / "startup"
+
+# Built-in script names
+BUILTIN_SCRIPTS = {"discover-devcontainers", "from-layout"}
+
+
+def ensure_startup_dir() -> None:
+    """Create startup scripts directory if it doesn't exist."""
+    STARTUP_DIR.mkdir(parents=True, exist_ok=True)
+
+
+async def run_startup(script_name: str) -> list[dict]:
+    """Run a startup script and return its JSON output.
+
+    For built-in scripts, handles them directly.
+    For custom scripts in ~/.claude-rts/startup/, executes them and parses JSON.
+
+    Returns a list of card descriptors, e.g.:
+      [{"type": "terminal", "name": "hub_1", "exec": "docker.exe exec -it ..."}]
+    """
+    if script_name == "discover-devcontainers":
+        return await _builtin_discover_devcontainers()
+    elif script_name == "from-layout":
+        return await _builtin_from_layout()
+    else:
+        return await _run_custom_script(script_name)
+
+
+async def _builtin_discover_devcontainers() -> list[dict]:
+    """Discover devcontainers and return terminal card descriptors with exec commands."""
+    hubs = await discover_hubs()
+    result = []
+    for h in hubs:
+        result.append({
+            "type": "terminal",
+            "name": h["hub"],
+            "container": h["container"],
+            "exec": f'docker.exe exec -it -u vscode {h["container"]} bash -l',
+        })
+    logger.info("discover-devcontainers: found {} hub(s)", len(result))
+    return result
+
+
+async def _builtin_from_layout() -> list[dict]:
+    """Return empty list — frontend will load from saved canvas."""
+    logger.info("from-layout: returning empty list (frontend loads saved canvas)")
+    return []
+
+
+async def _run_custom_script(script_name: str) -> list[dict]:
+    """Execute a custom startup script and parse its JSON output."""
+    ensure_startup_dir()
+
+    # Security: only allow alphanumeric, hyphens, underscores in script names
+    import re
+    if not re.match(r'^[a-zA-Z0-9_-]+$', script_name):
+        logger.error("Invalid startup script name: {!r}", script_name)
+        raise ValueError(f"Invalid startup script name: {script_name!r}")
+
+    # Look for the script in the startup directory
+    script_path = None
+    for candidate in STARTUP_DIR.iterdir():
+        if candidate.stem == script_name and candidate.is_file():
+            script_path = candidate
+            break
+
+    if script_path is None:
+        logger.error("Startup script '{}' not found in {}", script_name, STARTUP_DIR)
+        raise FileNotFoundError(f"Startup script '{script_name}' not found in {STARTUP_DIR}")
+
+    logger.info("Running custom startup script: {}", script_path)
+
+    proc = await asyncio.create_subprocess_exec(
+        str(script_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        err_msg = stderr.decode(errors="replace").strip()
+        logger.error("Startup script '{}' failed (rc={}): {}", script_name, proc.returncode, err_msg)
+        raise RuntimeError(f"Startup script '{script_name}' failed: {err_msg}")
+
+    try:
+        data = json.loads(stdout.decode())
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.error("Startup script '{}' returned invalid JSON: {}", script_name, exc)
+        raise ValueError(f"Startup script '{script_name}' returned invalid JSON: {exc}")
+
+    if not isinstance(data, list):
+        raise ValueError(f"Startup script '{script_name}' must return a JSON array")
+
+    logger.info("Custom startup script '{}' returned {} card(s)", script_name, len(data))
+    return data

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -316,6 +316,60 @@
   }
   .canvas-dropdown-action:hover { background: #313244; color: #cdd6f4; }
 
+  /* ── Loader card ── */
+  .loader-card {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #45475a;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #1e1e2e;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+    min-width: 300px;
+    min-height: 120px;
+  }
+  .loader-card .loader-titlebar {
+    height: 32px;
+    background: #313244;
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #cba6f7;
+    user-select: none;
+  }
+  .loader-card .loader-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    gap: 12px;
+  }
+  .loader-card .loader-spinner {
+    width: 24px; height: 24px;
+    border: 3px solid #313244;
+    border-top-color: #cba6f7;
+    border-radius: 50%;
+    animation: loaderSpin 0.8s linear infinite;
+  }
+  @keyframes loaderSpin {
+    to { transform: rotate(360deg); }
+  }
+  .loader-card .loader-status {
+    font-size: 12px;
+    color: #a6adc8;
+  }
+  .loader-card.error { border-color: #f38ba8; }
+  .loader-card.error .loader-titlebar { color: #f38ba8; }
+  .loader-card.error .loader-spinner {
+    border-top-color: #f38ba8;
+    animation: none;
+  }
+
   /* ── Control group badge ── */
   .control-group-badge {
     font-size: 10px;
@@ -664,9 +718,10 @@ function showContextMenu(sx, sy) {
   let html = '<div class="ctx-header">Spawn terminal</div>';
   hubs.forEach((h, i) => {
     const sym = hubSymbolMap[h.hub] || '?';
+    const detail = h.container ? ` <span style="color:#585b70;font-size:11px">(${h.container})</span>` : '';
     html += `<div class="ctx-item" data-hub="${h.hub}">
       <span class="symbol-preview">${sym}</span>
-      ${h.hub} <span style="color:#585b70;font-size:11px">(${h.container})</span>
+      ${h.hub}${detail}
     </div>`;
   });
   ctxMenu.innerHTML = html;
@@ -728,6 +783,7 @@ class Card {
     this.w = w || CARD_W;
     this.h = h || CARD_H;
     this.symbol = symbol;
+    this.execCmd = null; // overridden by subclasses if needed
     this.state = 'connecting';
     this.lastOutput = 0;
     this.controlGroupNums = []; // array of group numbers (1-9)
@@ -921,7 +977,9 @@ class Card {
   }
 
   serialize() {
-    return { hub: this.hub, x: this.x, y: this.y, w: this.w, h: this.h, type: this.type, controlGroups: this.controlGroupNums.length > 0 ? [...this.controlGroupNums] : undefined };
+    const data = { hub: this.hub, x: this.x, y: this.y, w: this.w, h: this.h, type: this.type, controlGroups: this.controlGroupNums.length > 0 ? [...this.controlGroupNums] : undefined };
+    if (this.execCmd) data.exec = this.execCmd;
+    return data;
   }
 
   destroy() {
@@ -940,6 +998,7 @@ class Card {
 class TerminalCard extends Card {
   constructor(opts) {
     super({ ...opts, type: 'terminal' });
+    this.execCmd = opts.exec || null; // custom exec command (for /ws/exec)
     this.term = null;
     this.fitAddon = null;
     this.ws = null;
@@ -989,7 +1048,10 @@ class TerminalCard extends Card {
 
   connectWs() {
     const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-    this.ws = new WebSocket(`${wsProto}//${location.host}/ws/${this.hub}`);
+    const wsUrl = this.execCmd
+      ? `${wsProto}//${location.host}/ws/exec?cmd=${encodeURIComponent(this.execCmd)}`
+      : `${wsProto}//${location.host}/ws/${this.hub}`;
+    this.ws = new WebSocket(wsUrl);
     this.ws.binaryType = 'arraybuffer';
 
     this.ws.addEventListener('open', () => {
@@ -1096,6 +1158,68 @@ class TerminalCard extends Card {
 }
 
 // ════════════════════════════════════════════
+// LoaderCard subclass
+// ════════════════════════════════════════════
+class LoaderCard {
+  constructor({ scriptName, x, y }) {
+    this.scriptName = scriptName;
+    this.x = x;
+    this.y = y;
+    this.el = null;
+    this.statusEl = null;
+    this.error = false;
+  }
+
+  createElement() {
+    const el = document.createElement('div');
+    el.className = 'loader-card';
+    el.style.left = this.x + 'px';
+    el.style.top = this.y + 'px';
+    el.style.width = '360px';
+    el.style.height = '140px';
+    el.style.zIndex = 999;
+
+    const titlebar = document.createElement('div');
+    titlebar.className = 'loader-titlebar';
+    titlebar.textContent = 'Startup';
+    el.appendChild(titlebar);
+
+    const body = document.createElement('div');
+    body.className = 'loader-body';
+
+    const spinner = document.createElement('div');
+    spinner.className = 'loader-spinner';
+    body.appendChild(spinner);
+
+    const status = document.createElement('div');
+    status.className = 'loader-status';
+    status.textContent = `Running: ${this.scriptName}`;
+    body.appendChild(status);
+    this.statusEl = status;
+
+    el.appendChild(body);
+    this.el = el;
+    return el;
+  }
+
+  setStatus(text) {
+    if (this.statusEl) this.statusEl.textContent = text;
+  }
+
+  setError(msg) {
+    this.error = true;
+    if (this.el) this.el.classList.add('error');
+    this.setStatus(msg);
+  }
+
+  destroy() {
+    if (this.el && this.el.parentNode) {
+      this.el.parentNode.removeChild(this.el);
+    }
+  }
+}
+
+// ════════════════════════════════════════════
 // Terminal state management
 // ════════════════════════════════════════════
 function updateCardState(id, state) {
@@ -1117,9 +1241,9 @@ setInterval(() => {
 // ════════════════════════════════════════════
 // Spawn a terminal card
 // ════════════════════════════════════════════
-function spawnCard(hub, x, y, w, h, savedControlGroups) {
+function spawnCard(hub, x, y, w, h, savedControlGroups, execCmd) {
   const symbol = hubSymbolMap[hub.hub] || '?';
-  const card = new TerminalCard({ hub: hub.hub, container: hub.container, x, y, w, h, symbol });
+  const card = new TerminalCard({ hub: hub.hub, container: hub.container, x, y, w, h, symbol, exec: execCmd || hub.exec || null });
   if (savedControlGroups && Array.isArray(savedControlGroups)) {
     card.controlGroupNums = [...savedControlGroups];
   }
@@ -1716,7 +1840,7 @@ async function switchCanvas(name) {
   if (saved && saved.length > 0) {
     for (const s of saved) {
       const hub = hubs.find(h => h.hub === s.hub);
-      if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups);
+      if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec);
     }
     rebuildControlGroupsFromCards();
   }
@@ -1742,8 +1866,65 @@ async function switchCanvas(name) {
   // Load canvas list
   await refreshCanvasList();
 
-  const resp = await fetch('/api/hubs');
-  hubs = await resp.json();
+  // Show a LoaderCard during startup
+  const loaderX = (CANVAS_W - 360) / 2;
+  const loaderY = (CANVAS_H - 140) / 2;
+  const scriptName = settings.startup_script || 'discover-devcontainers';
+  const loader = new LoaderCard({ scriptName, x: loaderX, y: loaderY });
+  loader.createElement();
+  canvas.appendChild(loader.el);
+
+  // Center on loader
+  const vw = viewport.clientWidth;
+  const vh = viewport.clientHeight;
+  pan.x = (vw - 360) / 2 - loaderX;
+  pan.y = (vh - 140) / 2 - loaderY;
+  applyTransform();
+
+  let startupCards = [];
+  let startupError = false;
+
+  try {
+    const resp = await fetch('/api/startup');
+    const data = await resp.json();
+    if (data.status === 'error') {
+      loader.setError(`Startup failed: ${data.error}`);
+      startupError = true;
+      // Wait a moment so user sees the error, then fall back to /api/hubs
+      await new Promise(r => setTimeout(r, 2000));
+    } else {
+      startupCards = data.cards || [];
+    }
+  } catch (err) {
+    loader.setError(`Startup failed: ${err.message}`);
+    startupError = true;
+    await new Promise(r => setTimeout(r, 2000));
+  }
+
+  // If startup returned cards, convert them to hub format
+  if (startupCards.length > 0) {
+    hubs = startupCards.map(c => ({
+      hub: c.name,
+      container: c.container || '',
+      exec: c.exec || null,
+    }));
+  } else if (startupError || startupCards.length === 0) {
+    // Fallback: try legacy /api/hubs discovery
+    loader.setStatus('Falling back to hub discovery...');
+    try {
+      const resp = await fetch('/api/hubs');
+      const hubData = await resp.json();
+      hubs = hubData.map(h => ({
+        ...h,
+        exec: `docker.exe exec -it -u vscode ${h.container} bash -l`,
+      }));
+    } catch {
+      hubs = [];
+    }
+  }
+
+  // Remove loader card
+  loader.destroy();
 
   if (hubs.length === 0) {
     document.getElementById('hub-count').textContent = 'No containers running';
@@ -1761,7 +1942,7 @@ async function switchCanvas(name) {
     // Spawn cards from saved layout
     for (const s of saved) {
       const hub = hubs.find(h => h.hub === s.hub);
-      if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups);
+      if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec);
     }
     // Spawn any new hubs not in saved layout
     for (const hub of hubs) {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,4 +70,6 @@ async def test_app_has_all_routes(app):
     assert "/api/config" in routes
     assert "/api/canvases" in routes
     assert "/api/canvases/{name}" in routes
+    assert "/api/startup" in routes
+    assert "/ws/exec" in routes
     assert "/ws/{hub}" in routes

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,89 @@
+"""Tests for the startup module and API endpoint."""
+
+import json
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from claude_rts.startup import run_startup
+
+
+async def test_discover_devcontainers_startup():
+    mock_hubs = [
+        {"hub": "hub_1", "container": "container_1"},
+        {"hub": "hub_2", "container": "container_2"},
+    ]
+    with patch("claude_rts.startup.discover_hubs", new_callable=AsyncMock, return_value=mock_hubs):
+        result = await run_startup("discover-devcontainers")
+
+    assert len(result) == 2
+    assert result[0]["type"] == "terminal"
+    assert result[0]["name"] == "hub_1"
+    assert result[0]["container"] == "container_1"
+    assert "docker.exe exec" in result[0]["exec"]
+    assert "container_1" in result[0]["exec"]
+
+
+async def test_from_layout_startup():
+    result = await run_startup("from-layout")
+    assert result == []
+
+
+async def test_custom_script_invalid_name():
+    with pytest.raises(ValueError, match="Invalid startup script name"):
+        await run_startup("../etc/passwd")
+
+
+async def test_custom_script_not_found(tmp_path):
+    with patch("claude_rts.startup.STARTUP_DIR", tmp_path):
+        with pytest.raises(FileNotFoundError, match="not found"):
+            await run_startup("nonexistent")
+
+
+# ── API endpoint tests ──
+
+
+@pytest.fixture
+def app():
+    from claude_rts.server import create_app
+    return create_app()
+
+
+@pytest.fixture
+async def client(aiohttp_client, app):
+    return await aiohttp_client(app)
+
+
+async def test_startup_api_success(client):
+    mock_hubs = [{"hub": "hub_1", "container": "c1"}]
+    with patch("claude_rts.startup.discover_hubs", new_callable=AsyncMock, return_value=mock_hubs), \
+         patch("claude_rts.server.read_config", return_value={"startup_script": "discover-devcontainers"}):
+        resp = await client.get("/api/startup")
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "ok"
+    assert data["script"] == "discover-devcontainers"
+    assert len(data["cards"]) == 1
+    assert data["cards"][0]["name"] == "hub_1"
+
+
+async def test_startup_api_from_layout(client):
+    with patch("claude_rts.server.read_config", return_value={"startup_script": "from-layout"}):
+        resp = await client.get("/api/startup")
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "ok"
+    assert data["cards"] == []
+
+
+async def test_startup_api_error_returns_500(client):
+    with patch("claude_rts.server.read_config", return_value={"startup_script": "nonexistent"}), \
+         patch("claude_rts.startup.STARTUP_DIR", __import__("pathlib").Path("/tmp/empty_startup_dir_1234")):
+        resp = await client.get("/api/startup")
+
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["status"] == "error"
+    assert data["cards"] == []


### PR DESCRIPTION
## Summary
- New `startup.py` module with pluggable startup scripts (discover-devcontainers, from-layout, custom)
- LoaderCard shows spinner during startup, error state on failure
- `/api/startup` endpoint runs configured startup script
- `/ws/exec?cmd=...` endpoint spawns PTY for arbitrary commands
- TerminalCard connects via `/ws/exec` when exec command is specified
- Custom scripts in `~/.claude-rts/startup/` output JSON card descriptors
- 7 new tests for startup module and API

Closes #16

## Test plan
- [x] All 45 tests pass
- [ ] Manual: LoaderCard appears during startup
- [ ] Manual: default discover-devcontainers works
- [ ] Manual: custom exec commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)