### PR TITLE
WidgetCard + system-info: first dashboard widget

### DIFF
--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -3,10 +3,15 @@
 import asyncio
 import json
 import pathlib
+import platform
+import sys
+import time
 
 from aiohttp import web
 from loguru import logger
 from winpty import PtyProcess
+
+_start_time = time.monotonic()
 
 from .config import read_config, write_config, list_canvases, read_canvas, write_canvas, delete_canvas
 from .discovery import discover_hubs
@@ -183,6 +188,23 @@ async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
     return ws
 
 
+async def widget_system_info_handler(request: web.Request) -> web.Response:
+    """Return system information for the system-info widget."""
+    uptime_seconds = int(time.monotonic() - _start_time)
+    hours, remainder = divmod(uptime_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    uptime_str = f"{hours}h {minutes}m {seconds}s"
+
+    data = {
+        "hostname": platform.node(),
+        "platform": platform.platform(),
+        "python_version": sys.version.split()[0],
+        "uptime": uptime_str,
+        "uptime_seconds": uptime_seconds,
+    }
+    return web.json_response(data)
+
+
 async def exec_websocket_handler(request: web.Request) -> web.WebSocketResponse:
     """WebSocket handler that spawns a PTY for an arbitrary command."""
     cmd = request.query.get("cmd", "").strip()
@@ -269,6 +291,7 @@ def create_app() -> web.Application:
     app.router.add_get("/api/canvases/{name}", canvas_get_handler)
     app.router.add_put("/api/canvases/{name}", canvas_put_handler)
     app.router.add_delete("/api/canvases/{name}", canvas_delete_handler)
+    app.router.add_get("/api/widgets/system-info", widget_system_info_handler)
     app.router.add_get("/ws/exec", exec_websocket_handler)
     app.router.add_get("/ws/{hub}", websocket_handler)
     logger.info("Application routes registered")

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -370,6 +370,23 @@
     animation: none;
   }
 
+  /* ── Widget body ── */
+  .widget-body {
+    padding: 12px;
+    font-size: 13px;
+    color: #cdd6f4;
+    overflow-y: auto;
+  }
+  .widget-body .widget-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 4px 0;
+    border-bottom: 1px solid #313244;
+  }
+  .widget-body .widget-row:last-child { border-bottom: none; }
+  .widget-body .widget-label { color: #a6adc8; }
+  .widget-body .widget-value { color: #cdd6f4; font-family: monospace; }
+
   /* ── Control group badge ── */
   .control-group-badge {
     font-size: 10px;
@@ -724,17 +741,40 @@ function showContextMenu(sx, sy) {
       ${h.hub}${detail}
     </div>`;
   });
+
+  // Widget section
+  const widgetTypes = Object.keys(WIDGET_REGISTRY);
+  if (widgetTypes.length > 0) {
+    html += '<div class="ctx-header">Spawn widget</div>';
+    for (const wt of widgetTypes) {
+      const def = WIDGET_REGISTRY[wt];
+      html += `<div class="ctx-item" data-widget="${wt}">
+        <span class="symbol-preview">W</span>
+        ${def.label || wt}
+      </div>`;
+    }
+  }
+
   ctxMenu.innerHTML = html;
   ctxMenu.style.left = sx + 'px';
   ctxMenu.style.top = sy + 'px';
   ctxMenu.classList.add('visible');
 
-  ctxMenu.querySelectorAll('.ctx-item').forEach(item => {
+  ctxMenu.querySelectorAll('.ctx-item[data-hub]').forEach(item => {
     item.addEventListener('click', (e) => {
       e.stopPropagation();
       const hubName = item.dataset.hub;
       const hub = hubs.find(h => h.hub === hubName);
       if (hub) spawnCard(hub, ctxMenuCanvasPos.x, ctxMenuCanvasPos.y);
+      hideContextMenu();
+    });
+  });
+
+  ctxMenu.querySelectorAll('.ctx-item[data-widget]').forEach(item => {
+    item.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const widgetType = item.dataset.widget;
+      spawnWidget(widgetType, ctxMenuCanvasPos.x, ctxMenuCanvasPos.y);
       hideContextMenu();
     });
   });
@@ -1220,6 +1260,84 @@ class LoaderCard {
 }
 
 // ════════════════════════════════════════════
+// Widget registry
+// ════════════════════════════════════════════
+const WIDGET_REGISTRY = {
+  'system-info': {
+    label: 'System Info',
+    defaultRefreshInterval: 10000,
+    async render(body, card) {
+      try {
+        const resp = await fetch('/api/widgets/system-info');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        const activeTerminals = cards.filter(c => c.type === 'terminal').length;
+        const rows = [
+          ['Hostname', data.hostname],
+          ['Platform', data.platform],
+          ['Python', data.python_version],
+          ['Server uptime', data.uptime],
+          ['Active terminals', String(activeTerminals)],
+          ['Current time', new Date().toLocaleTimeString()],
+        ];
+        body.innerHTML = rows.map(([label, value]) =>
+          `<div class="widget-row"><span class="widget-label">${label}</span><span class="widget-value">${value}</span></div>`
+        ).join('');
+        card.updateState('working');
+      } catch (err) {
+        body.innerHTML = `<div class="widget-row"><span class="widget-label" style="color:#f38ba8">Error: ${err.message}</span></div>`;
+        card.updateState('dead');
+      }
+    },
+  },
+};
+
+// ════════════════════════════════════════════
+// WidgetCard subclass
+// ════════════════════════════════════════════
+class WidgetCard extends Card {
+  constructor(opts) {
+    super({ ...opts, type: 'widget', hub: opts.hub || opts.widgetType, container: '', symbol: opts.symbol || 'W' });
+    this.widgetType = opts.widgetType;
+    this.refreshInterval = opts.refreshInterval || (WIDGET_REGISTRY[opts.widgetType]?.defaultRefreshInterval) || 30000;
+    this._refreshTimer = null;
+  }
+
+  createBody() {
+    const body = document.createElement('div');
+    body.className = 'terminal-body widget-body';
+    return body;
+  }
+
+  onInit() {
+    this.render();
+    this._refreshTimer = setInterval(() => this.render(), this.refreshInterval);
+  }
+
+  onDestroy() {
+    if (this._refreshTimer) clearInterval(this._refreshTimer);
+  }
+
+  async render() {
+    const body = this.el.querySelector(`[data-body="${this.id}"]`);
+    if (!body) return;
+    const widgetDef = WIDGET_REGISTRY[this.widgetType];
+    if (widgetDef && widgetDef.render) {
+      await widgetDef.render(body, this);
+    } else {
+      body.innerHTML = `<div class="widget-row"><span class="widget-label" style="color:#f38ba8">Unknown widget: ${this.widgetType}</span></div>`;
+    }
+  }
+
+  serialize() {
+    const data = super.serialize();
+    data.widgetType = this.widgetType;
+    data.refreshInterval = this.refreshInterval;
+    return data;
+  }
+}
+
+// ════════════════════════════════════════════
 // Terminal state management
 // ════════════════════════════════════════════
 function updateCardState(id, state) {
@@ -1261,6 +1379,26 @@ function spawnCard(hub, x, y, w, h, savedControlGroups, execCmd) {
   return card;
 }
 
+function spawnWidget(widgetType, x, y, w, h) {
+  const card = new WidgetCard({
+    widgetType,
+    x,
+    y,
+    w: w || 360,
+    h: h || 280,
+    symbol: 'W',
+  });
+  card.createElement();
+  canvas.appendChild(card.el);
+  cards.push(card);
+  card.setupDrag();
+  card.setupResize();
+  card.onInit();
+  drawMinimap();
+  updateHubCount();
+  return card;
+}
+
 function destroyCard(id) {
   const idx = cards.findIndex(c => c.id === id);
   if (idx === -1) return;
@@ -1280,7 +1418,11 @@ function focusCard(id) {
 }
 
 function updateHubCount() {
-  document.getElementById('hub-count').textContent = `${hubs.length} hub(s) | ${cards.length} terminal(s)`;
+  const termCount = cards.filter(c => c.type === 'terminal').length;
+  const widgetCount = cards.filter(c => c.type === 'widget').length;
+  const parts = [`${hubs.length} hub(s)`, `${termCount} terminal(s)`];
+  if (widgetCount > 0) parts.push(`${widgetCount} widget(s)`);
+  document.getElementById('hub-count').textContent = parts.join(' | ');
 }
 
 // ════════════════════════════════════════════
@@ -1839,8 +1981,12 @@ async function switchCanvas(name) {
   const saved = await loadLayout();
   if (saved && saved.length > 0) {
     for (const s of saved) {
-      const hub = hubs.find(h => h.hub === s.hub);
-      if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec);
+      if (s.type === 'widget' && s.widgetType) {
+        spawnWidget(s.widgetType, s.x, s.y, s.w, s.h);
+      } else {
+        const hub = hubs.find(h => h.hub === s.hub);
+        if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec);
+      }
     }
     rebuildControlGroupsFromCards();
   }
@@ -1941,12 +2087,16 @@ async function switchCanvas(name) {
   if (saved && saved.length > 0) {
     // Spawn cards from saved layout
     for (const s of saved) {
-      const hub = hubs.find(h => h.hub === s.hub);
-      if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec);
+      if (s.type === 'widget' && s.widgetType) {
+        spawnWidget(s.widgetType, s.x, s.y, s.w, s.h);
+      } else {
+        const hub = hubs.find(h => h.hub === s.hub);
+        if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec);
+      }
     }
     // Spawn any new hubs not in saved layout
     for (const hub of hubs) {
-      if (!saved.some(s => s.hub === hub.hub)) {
+      if (!saved.some(s => s.hub === hub.hub && s.type !== 'widget')) {
         spawnCard(hub, 100 + Math.random() * 200, 100 + Math.random() * 200);
       }
     }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -63,6 +63,29 @@ async def test_websocket_404_for_unknown_hub(client):
     assert resp.status == 404
 
 
+async def test_widget_system_info_returns_json(client):
+    resp = await client.get("/api/widgets/system-info")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "hostname" in data
+    assert "platform" in data
+    assert "python_version" in data
+    assert "uptime" in data
+    assert "uptime_seconds" in data
+    assert isinstance(data["uptime_seconds"], int)
+    assert isinstance(data["hostname"], str)
+
+
+async def test_widget_system_info_uptime_format(client):
+    resp = await client.get("/api/widgets/system-info")
+    assert resp.status == 200
+    data = await resp.json()
+    # Uptime should match "Xh Ym Zs" format
+    assert "h " in data["uptime"]
+    assert "m " in data["uptime"]
+    assert data["uptime"].endswith("s")
+
+
 async def test_app_has_all_routes(app):
     routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
     assert "/" in routes
@@ -71,5 +94,6 @@ async def test_app_has_all_routes(app):
     assert "/api/canvases" in routes
     assert "/api/canvases/{name}" in routes
     assert "/api/startup" in routes
+    assert "/api/widgets/system-info" in routes
     assert "/ws/exec" in routes
     assert "/ws/{hub}" in routes


### PR DESCRIPTION
## Summary
- WidgetCard class extends Card with auto-refresh timer and widget type registry
- system-info widget shows hostname, platform, Python version, uptime, terminal count
- Widget registry pattern for easy addition of future widgets
- Widgets spawnable from context menu ("Spawn widget" section)
- Widgets persist in canvas layout with type and refresh interval
- `/api/widgets/system-info` endpoint for server-side data
- 2 new tests for widget API

Closes #17

## Test plan
- [x] All 47 tests pass
- [ ] Manual: can spawn system-info widget from context menu
- [ ] Manual: widget auto-refreshes data
- [ ] Manual: widget draggable and resizable
- [ ] Manual: widget persists across canvas save/load

🤖 Generated with [Claude Code](https://claude.com/claude-code)