### PR TITLE
Utility container + claude-usage widget

### DIFF
--- a/claude_rts/Dockerfile.util
+++ b/claude_rts/Dockerfile.util
@@ -1,0 +1,29 @@
+# claude-rts utility container
+# Purpose: background tasks, monitoring, status probing (NOT coding or LLM calls)
+# Stays alive via sleep infinity, commands executed via docker exec
+
+FROM python:3.11-slim
+
+# Install Node.js (needed for claude CLI, which claude-usage-plz spawns)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install claude CLI (required by claude-usage-plz)
+RUN npm install -g @anthropic-ai/claude-code
+
+# Install claude-usage-plz
+RUN pip install --no-cache-dir claude-usage-plz
+
+# Create profiles mount point
+RUN mkdir -p /profiles
+
+# Non-root user for safety
+RUN useradd -m -s /bin/bash util
+USER util
+WORKDIR /home/util
+
+# Stay alive, awaiting exec commands
+CMD ["sleep", "infinity"]

--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -23,6 +23,13 @@ DEFAULT_CONFIG = {
     "default_canvas": "main",
     "theme": "catppuccin-mocha",
     "startup_script": "discover-devcontainers",
+    "util_container": {
+        "name": "claude-rts-util",
+        "image": "claude-rts-util:latest",
+        "auto_start": True,
+        "auto_stop": False,
+        "mounts": {},
+    },
 }
 
 # Allowed canvas name pattern: alphanumeric, hyphens, underscores

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -16,6 +16,7 @@ _start_time = time.monotonic()
 from .config import read_config, write_config, list_canvases, read_canvas, write_canvas, delete_canvas
 from .discovery import discover_hubs
 from .startup import run_startup
+from .util_container import ensure_util_container, is_util_running, list_profiles, probe_usage
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
@@ -205,6 +206,67 @@ async def widget_system_info_handler(request: web.Request) -> web.Response:
     return web.json_response(data)
 
 
+# ── Claude usage widget ──────────────────────────────────────────────────────
+
+# Cache: {profile_name: {data: {...}, timestamp: float}}
+_usage_cache: dict[str, dict] = {}
+_USAGE_CACHE_TTL = 60  # seconds
+
+
+async def widget_claude_usage_handler(request: web.Request) -> web.Response:
+    """Return Claude usage data for all profiles.
+
+    Probes each profile via claude-usage-plz in the utility container.
+    Results cached for 60s since each probe takes 15-20s.
+    """
+    force = request.query.get("force", "").lower() in ("1", "true")
+
+    if not await is_util_running():
+        return web.json_response({
+            "status": "error",
+            "error": "Utility container not running. Start it from config.",
+            "profiles": [],
+        })
+
+    profiles = await list_profiles()
+    if not profiles:
+        return web.json_response({
+            "status": "ok",
+            "profiles": [],
+            "message": "No profiles found in /profiles/. Mount ~/.claude-profiles/ to the utility container.",
+        })
+
+    now = time.monotonic()
+    results = []
+
+    for profile in profiles:
+        cached = _usage_cache.get(profile)
+        if cached and not force and (now - cached["timestamp"]) < _USAGE_CACHE_TTL:
+            results.append({"profile": profile, **cached["data"], "cached": True})
+            continue
+
+        claude_dir = f"/profiles/{profile}/.claude"
+        usage = await probe_usage(claude_dir)
+        if usage:
+            _usage_cache[profile] = {"data": usage, "timestamp": now}
+            results.append({"profile": profile, **usage, "cached": False})
+        else:
+            results.append({"profile": profile, "error": "probe failed", "cached": False})
+
+    return web.json_response({"status": "ok", "profiles": results})
+
+
+async def widget_claude_usage_status_handler(request: web.Request) -> web.Response:
+    """Lightweight status check: is utility container running, how many profiles."""
+    running = await is_util_running()
+    profiles = await list_profiles() if running else []
+    return web.json_response({
+        "util_running": running,
+        "profile_count": len(profiles),
+        "profiles": profiles,
+    })
+
+
 async def exec_websocket_handler(request: web.Request) -> web.WebSocketResponse:
     """WebSocket handler that spawns a PTY for an arbitrary command."""
     cmd = request.query.get("cmd", "").strip()
@@ -292,7 +354,18 @@ def create_app() -> web.Application:
     app.router.add_put("/api/canvases/{name}", canvas_put_handler)
     app.router.add_delete("/api/canvases/{name}", canvas_delete_handler)
     app.router.add_get("/api/widgets/system-info", widget_system_info_handler)
+    app.router.add_get("/api/widgets/claude-usage", widget_claude_usage_handler)
+    app.router.add_get("/api/widgets/claude-usage/status", widget_claude_usage_status_handler)
     app.router.add_get("/ws/exec", exec_websocket_handler)
+
+    # Start utility container in background on app startup
+    async def on_startup(app: web.Application) -> None:
+        try:
+            await ensure_util_container()
+        except Exception:
+            logger.warning("Failed to start utility container (non-fatal)")
+
+    app.on_startup.append(on_startup)
     app.router.add_get("/ws/{hub}", websocket_handler)
     logger.info("Application routes registered")
     return app

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -387,6 +387,37 @@
   .widget-body .widget-label { color: #a6adc8; }
   .widget-body .widget-value { color: #cdd6f4; font-family: monospace; }
 
+  /* ── Usage bar ── */
+  .usage-bar-container {
+    width: 100%; height: 8px; background: #313244; border-radius: 4px; overflow: hidden;
+    margin-top: 4px;
+  }
+  .usage-bar {
+    height: 100%; border-radius: 4px; transition: width 0.3s ease;
+  }
+  .usage-profile {
+    padding: 8px 0;
+    border-bottom: 1px solid #313244;
+  }
+  .usage-profile:last-child { border-bottom: none; }
+  .usage-profile-name {
+    font-weight: 600; color: #cdd6f4; font-size: 13px; margin-bottom: 6px;
+  }
+  .usage-metric {
+    display: flex; justify-content: space-between; align-items: center;
+    font-size: 12px; margin-bottom: 2px;
+  }
+  .usage-metric-label { color: #a6adc8; }
+  .usage-metric-value { color: #cdd6f4; font-family: monospace; }
+  .usage-reset { color: #585b70; font-size: 11px; }
+  .usage-refresh-btn {
+    background: #313244; border: 1px solid #45475a; color: #a6adc8;
+    padding: 3px 10px; border-radius: 4px; cursor: pointer; font-size: 11px;
+    margin-top: 8px;
+  }
+  .usage-refresh-btn:hover { background: #45475a; color: #cdd6f4; }
+  .usage-status { color: #585b70; font-size: 11px; text-align: center; padding: 8px 0; }
+
   /* ── Control group badge ── */
   .control-group-badge {
     font-size: 10px;
@@ -1283,6 +1314,64 @@ const WIDGET_REGISTRY = {
         body.innerHTML = rows.map(([label, value]) =>
           `<div class="widget-row"><span class="widget-label">${label}</span><span class="widget-value">${value}</span></div>`
         ).join('');
+        card.updateState('working');
+      } catch (err) {
+        body.innerHTML = `<div class="widget-row"><span class="widget-label" style="color:#f38ba8">Error: ${err.message}</span></div>`;
+        card.updateState('dead');
+      }
+    },
+  },
+  'claude-usage': {
+    label: 'Claude Usage',
+    defaultRefreshInterval: 60000,
+    async render(body, card) {
+      function usageColor(pct) {
+        if (pct == null) return '#585b70';
+        if (pct < 50) return '#a6e3a1';
+        if (pct < 80) return '#f9e2af';
+        return '#f38ba8';
+      }
+      function renderBar(pct) {
+        const color = usageColor(pct);
+        const width = pct != null ? Math.min(100, Math.max(0, pct)) : 0;
+        return `<div class="usage-bar-container"><div class="usage-bar" style="width:${width}%;background:${color}"></div></div>`;
+      }
+      function renderMetric(label, pct, resets) {
+        const pctStr = pct != null ? `${pct}%` : 'N/A';
+        const resetStr = resets ? `<span class="usage-reset">resets ${resets}</span>` : '';
+        return `<div class="usage-metric"><span class="usage-metric-label">${label}</span><span class="usage-metric-value">${pctStr}</span></div>${renderBar(pct)}${resetStr ? `<div style="text-align:right">${resetStr}</div>` : ''}`;
+      }
+      try {
+        const resp = await fetch('/api/widgets/claude-usage');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (data.status === 'error') {
+          body.innerHTML = `<div class="usage-status">${data.error}</div>`;
+          card.updateState('dead');
+          return;
+        }
+        if (!data.profiles || data.profiles.length === 0) {
+          body.innerHTML = `<div class="usage-status">${data.message || 'No profiles found.'}<br><br>Mount ~/.claude-profiles/ to the utility container.</div>`;
+          card.updateState('idle');
+          return;
+        }
+        let html = '';
+        for (const p of data.profiles) {
+          html += `<div class="usage-profile">`;
+          html += `<div class="usage-profile-name">${p.profile}${p.cached ? ' <span class="usage-reset">(cached)</span>' : ''}</div>`;
+          if (p.error) {
+            html += `<div class="usage-metric"><span class="usage-metric-label" style="color:#f38ba8">${p.error}</span></div>`;
+          } else {
+            html += renderMetric('5h window', p.five_hour_pct, p.five_hour_resets);
+            html += renderMetric('7d window', p.seven_day_pct, p.seven_day_resets);
+            if (p.sonnet_week_pct != null) {
+              html += renderMetric('Sonnet weekly', p.sonnet_week_pct, p.sonnet_week_resets);
+            }
+          }
+          html += `</div>`;
+        }
+        html += `<button class="usage-refresh-btn" onclick="this.closest('[data-card-id]')||void 0;fetch('/api/widgets/claude-usage?force=1').then(()=>{const c=cards.find(c=>c.widgetType==='claude-usage');if(c)c.render();})">Refresh now</button>`;
+        body.innerHTML = html;
         card.updateState('working');
       } catch (err) {
         body.innerHTML = `<div class="widget-row"><span class="widget-label" style="color:#f38ba8">Error: ${err.message}</span></div>`;

--- a/claude_rts/util_container.py
+++ b/claude_rts/util_container.py
@@ -1,0 +1,185 @@
+"""Manage the claude-rts utility container.
+
+The utility container is a lightweight Linux container for background tasks,
+monitoring, and status probing. It is NOT for coding or LLM calls.
+
+It stays alive via `sleep infinity` and commands are executed via `docker exec`.
+"""
+
+import asyncio
+import json
+import pathlib
+import shutil
+
+from loguru import logger
+
+from .config import read_config
+
+DOCKERFILE = pathlib.Path(__file__).parent / "Dockerfile.util"
+DEFAULT_CONTAINER_NAME = "claude-rts-util"
+DEFAULT_IMAGE_NAME = "claude-rts-util:latest"
+
+
+def _get_config() -> dict:
+    """Get utility container config with defaults."""
+    config = read_config()
+    util = config.get("util_container", {})
+    return {
+        "name": util.get("name", DEFAULT_CONTAINER_NAME),
+        "image": util.get("image", DEFAULT_IMAGE_NAME),
+        "auto_start": util.get("auto_start", True),
+        "auto_stop": util.get("auto_stop", False),
+        "mounts": util.get("mounts", {}),
+    }
+
+
+async def _run(cmd: str, timeout: float = 30) -> tuple[int, str, str]:
+    """Run a shell command and return (returncode, stdout, stderr)."""
+    proc = await asyncio.create_subprocess_shell(
+        cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        return -1, "", "timeout"
+    return proc.returncode, stdout.decode(errors="replace").strip(), stderr.decode(errors="replace").strip()
+
+
+async def is_util_running() -> bool:
+    """Check if the utility container is running."""
+    cfg = _get_config()
+    rc, stdout, _ = await _run(
+        f'docker.exe ps --filter "name=^/{cfg["name"]}$" --format "{{{{.Status}}}}"'
+    )
+    return rc == 0 and "Up" in stdout
+
+
+async def build_image() -> bool:
+    """Build the utility container image if not already built."""
+    cfg = _get_config()
+    # Check if image exists
+    rc, stdout, _ = await _run(f'docker.exe images -q {cfg["image"]}')
+    if rc == 0 and stdout.strip():
+        logger.debug("Utility image {} already exists", cfg["image"])
+        return True
+
+    logger.info("Building utility container image {}...", cfg["image"])
+    rc, stdout, stderr = await _run(
+        f'docker.exe build -t {cfg["image"]} -f "{DOCKERFILE}" "{DOCKERFILE.parent}"',
+        timeout=300,
+    )
+    if rc != 0:
+        logger.error("Failed to build utility image: {}", stderr)
+        return False
+    logger.info("Utility image built successfully")
+    return True
+
+
+async def start_container() -> bool:
+    """Start the utility container. Builds image if needed."""
+    cfg = _get_config()
+
+    if await is_util_running():
+        logger.debug("Utility container '{}' already running", cfg["name"])
+        return True
+
+    # Build image if needed
+    if not await build_image():
+        return False
+
+    # Build mount args
+    mount_args = ""
+    for host_path, container_path in cfg["mounts"].items():
+        # Expand ~ in host path
+        expanded = host_path.replace("~", str(pathlib.Path.home()))
+        if pathlib.Path(expanded).exists():
+            mount_args += f' -v "{expanded}:{container_path}"'
+            logger.info("Mounting {} -> {}", expanded, container_path)
+        else:
+            logger.warning("Mount source does not exist, skipping: {}", expanded)
+
+    # Remove old stopped container if exists
+    await _run(f'docker.exe rm -f {cfg["name"]}')
+
+    # Start container
+    cmd = f'docker.exe run -d --name {cfg["name"]}{mount_args} {cfg["image"]}'
+    logger.info("Starting utility container: {}", cmd)
+    rc, stdout, stderr = await _run(cmd, timeout=60)
+    if rc != 0:
+        logger.error("Failed to start utility container: {}", stderr)
+        return False
+
+    logger.info("Utility container '{}' started (id: {})", cfg["name"], stdout[:12])
+    return True
+
+
+async def stop_container() -> bool:
+    """Stop the utility container."""
+    cfg = _get_config()
+    rc, _, stderr = await _run(f'docker.exe stop {cfg["name"]}')
+    if rc != 0:
+        logger.warning("Failed to stop utility container: {}", stderr)
+        return False
+    await _run(f'docker.exe rm {cfg["name"]}')
+    logger.info("Utility container '{}' stopped", cfg["name"])
+    return True
+
+
+async def exec_in_util(cmd: str, timeout: float = 60) -> tuple[int, str]:
+    """Execute a command in the utility container.
+
+    Returns (returncode, stdout). Raises RuntimeError if container not running.
+    """
+    cfg = _get_config()
+
+    if not await is_util_running():
+        raise RuntimeError(f"Utility container '{cfg['name']}' is not running")
+
+    full_cmd = f'docker.exe exec {cfg["name"]} {cmd}'
+    logger.debug("exec_in_util: {}", cmd)
+    rc, stdout, stderr = await _run(full_cmd, timeout=timeout)
+    if rc != 0:
+        logger.warning("exec_in_util failed (rc={}): {}", rc, stderr)
+    return rc, stdout
+
+
+async def ensure_util_container() -> bool:
+    """Ensure the utility container is running. Start if needed.
+
+    Called during server startup if auto_start is enabled.
+    """
+    cfg = _get_config()
+    if not cfg["auto_start"]:
+        logger.info("Utility container auto_start disabled, skipping")
+        return False
+    return await start_container()
+
+
+async def list_profiles() -> list[str]:
+    """List available claude profiles in the utility container's /profiles dir."""
+    rc, stdout = await exec_in_util("ls /profiles/", timeout=10)
+    if rc != 0:
+        return []
+    return [name.strip() for name in stdout.split("\n") if name.strip()]
+
+
+async def probe_usage(claude_dir: str, timeout: float = 45) -> dict | None:
+    """Run claude-usage inside the utility container for a specific config dir.
+
+    Returns parsed JSON dict or None on failure.
+    """
+    rc, stdout = await exec_in_util(
+        f"claude-usage --claude-dir {claude_dir} --json",
+        timeout=timeout,
+    )
+    if rc != 0:
+        logger.warning("claude-usage probe failed for {}: rc={}", claude_dir, rc)
+        return None
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        logger.warning("claude-usage returned invalid JSON for {}: {}", claude_dir, exc)
+        return None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -95,5 +95,7 @@ async def test_app_has_all_routes(app):
     assert "/api/canvases/{name}" in routes
     assert "/api/startup" in routes
     assert "/api/widgets/system-info" in routes
+    assert "/api/widgets/claude-usage" in routes
+    assert "/api/widgets/claude-usage/status" in routes
     assert "/ws/exec" in routes
     assert "/ws/{hub}" in routes

--- a/tests/test_util_container.py
+++ b/tests/test_util_container.py
@@ -1,0 +1,94 @@
+"""Tests for the utility container module and claude-usage widget API."""
+
+import json
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from claude_rts.server import create_app
+
+
+@pytest.fixture
+def app():
+    return create_app()
+
+
+@pytest.fixture
+async def client(aiohttp_client, app):
+    return await aiohttp_client(app)
+
+
+# ── Claude usage widget API tests ──
+
+
+async def test_claude_usage_util_not_running(client):
+    """When utility container is not running, return error."""
+    with patch("claude_rts.server.is_util_running", new_callable=AsyncMock, return_value=False):
+        resp = await client.get("/api/widgets/claude-usage")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "error"
+    assert "not running" in data["error"]
+
+
+async def test_claude_usage_no_profiles(client):
+    """When no profiles found, return empty list."""
+    with patch("claude_rts.server.is_util_running", new_callable=AsyncMock, return_value=True), \
+         patch("claude_rts.server.list_profiles", new_callable=AsyncMock, return_value=[]):
+        resp = await client.get("/api/widgets/claude-usage")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "ok"
+    assert data["profiles"] == []
+
+
+async def test_claude_usage_with_profiles(client):
+    """When profiles exist, return usage data."""
+    mock_usage = {
+        "five_hour_pct": 42.0,
+        "five_hour_resets": "11pm (UTC)",
+        "seven_day_pct": 25.0,
+        "seven_day_resets": "Apr 7, 3pm (UTC)",
+        "sonnet_week_pct": 10.0,
+        "sonnet_week_resets": "Apr 7, 5pm (UTC)",
+    }
+    with patch("claude_rts.server.is_util_running", new_callable=AsyncMock, return_value=True), \
+         patch("claude_rts.server.list_profiles", new_callable=AsyncMock, return_value=["acct-alice"]), \
+         patch("claude_rts.server.probe_usage", new_callable=AsyncMock, return_value=mock_usage):
+        resp = await client.get("/api/widgets/claude-usage")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "ok"
+    assert len(data["profiles"]) == 1
+    assert data["profiles"][0]["profile"] == "acct-alice"
+    assert data["profiles"][0]["five_hour_pct"] == 42.0
+
+
+async def test_claude_usage_probe_failure(client):
+    """When a probe fails, return error for that profile."""
+    with patch("claude_rts.server.is_util_running", new_callable=AsyncMock, return_value=True), \
+         patch("claude_rts.server.list_profiles", new_callable=AsyncMock, return_value=["acct-bob"]), \
+         patch("claude_rts.server.probe_usage", new_callable=AsyncMock, return_value=None):
+        resp = await client.get("/api/widgets/claude-usage")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["profiles"][0]["error"] == "probe failed"
+
+
+async def test_claude_usage_status_endpoint(client):
+    """Status endpoint returns util container state."""
+    with patch("claude_rts.server.is_util_running", new_callable=AsyncMock, return_value=True), \
+         patch("claude_rts.server.list_profiles", new_callable=AsyncMock, return_value=["acct-1", "acct-2"]):
+        resp = await client.get("/api/widgets/claude-usage/status")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["util_running"] is True
+    assert data["profile_count"] == 2
+    assert data["profiles"] == ["acct-1", "acct-2"]
+
+
+async def test_app_has_claude_usage_routes(app):
+    """Verify claude-usage routes are registered."""
+    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
+    assert "/api/widgets/claude-usage" in routes
+    assert "/api/widgets/claude-usage/status" in routes


### PR DESCRIPTION
## Summary

### Utility container (#37)
- `Dockerfile.util`: Python 3.11-slim + Node.js + claude CLI + claude-usage-plz
- `util_container.py`: lifecycle management (build, start, stop, exec, health check)
- Auto-starts on server startup (configurable)
- Scoped for **ops tasks only** — NOT for coding or LLM calls
- Config: `util_container` section in config.json (name, image, mounts, auto_start)

### Claude-usage widget (#34)
- Widget renders per-profile usage bars (5h window, 7d window, sonnet weekly)
- Color-coded: green (<50%) → yellow (50-80%) → red (>80%)
- 60s cache (each probe takes 15-20s via claude-usage-plz)
- "Refresh now" button for force re-probe
- Graceful states: util not running, no profiles, probe failure
- Endpoints: `GET /api/widgets/claude-usage`, `GET /api/widgets/claude-usage/status`

Closes #34, closes #37

## Test plan
- [x] All 53 tests pass (6 new)
- [ ] Manual: build and run utility container with profiles mounted
- [ ] Manual: spawn claude-usage widget from context menu
- [ ] Manual: widget shows usage bars when profiles available
- [ ] Manual: widget shows helpful message when no profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)