### PR TITLE
M5: Session persistence — PTY survives refresh with scrollback replay

### DIFF
--- a/claude_rts/__main__.py
+++ b/claude_rts/__main__.py
@@ -14,6 +14,7 @@ def main():
     parser = argparse.ArgumentParser(description="claude-rts terminal canvas")
     parser.add_argument("--port", type=int, default=3000, help="Server port (default: 3000)")
     parser.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
+    parser.add_argument("--test-mode", action="store_true", help="Enable test puppeting API")
     args = parser.parse_args()
 
     # Configure loguru: remove default handler, add our own
@@ -33,7 +34,11 @@ def main():
 
     logger.info("claude-rts starting on http://localhost:{}", args.port)
 
-    app = create_app()
+    import os
+    test_mode = args.test_mode or os.environ.get("CLAUDE_RTS_TEST_MODE", "").lower() in ("1", "true")
+    app = create_app(test_mode=test_mode)
+    if test_mode:
+        logger.info("Test mode enabled — puppeting API available")
 
     if not args.no_browser:
         async def open_browser(app):

--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -30,6 +30,10 @@ DEFAULT_CONFIG = {
         "auto_stop": False,
         "mounts": {},
     },
+    "sessions": {
+        "orphan_timeout": 300,
+        "scrollback_size": 65536,
+    },
 }
 
 # Allowed canvas name pattern: alphanumeric, hyphens, underscores

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -17,6 +17,7 @@ from .config import read_config, write_config, list_canvases, read_canvas, write
 from .discovery import discover_hubs
 from .startup import run_startup
 from .util_container import ensure_util_container, is_util_running, list_profiles, probe_usage
+from .sessions import SessionManager
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
@@ -342,8 +343,169 @@ async def exec_websocket_handler(request: web.Request) -> web.WebSocketResponse:
     return ws
 
 
-def create_app() -> web.Application:
+# ── Session-based WebSocket handlers ─────────────────────────────────────────
+
+
+async def _session_ws_input_loop(ws: web.WebSocketResponse, session, mgr: SessionManager):
+    """Shared input loop for session-based WebSocket handlers."""
+    try:
+        async for msg in ws:
+            if msg.type == web.WSMsgType.BINARY:
+                text = msg.data.decode("utf-8", errors="replace")
+                session.pty.write(text)
+            elif msg.type == web.WSMsgType.TEXT:
+                try:
+                    control = json.loads(msg.data)
+                    if control.get("type") == "resize":
+                        cols = control.get("cols", 80)
+                        rows = control.get("rows", 24)
+                        session.pty.setwinsize(rows, cols)
+                except json.JSONDecodeError:
+                    pass
+            elif msg.type in (web.WSMsgType.ERROR, web.WSMsgType.CLOSE):
+                break
+    except Exception:
+        logger.exception("Session {} WS input error", session.session_id)
+    finally:
+        mgr.detach(session.session_id, ws)
+
+
+async def session_new_handler(request: web.Request) -> web.WebSocketResponse:
+    """Create a new persistent session and attach via WebSocket."""
+    cmd = request.query.get("cmd", "").strip()
+    hub = request.query.get("hub", "")
+    if not cmd:
+        raise web.HTTPBadRequest(text="Missing 'cmd' query parameter")
+
+    mgr: SessionManager = request.app["session_manager"]
+
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+
+    try:
+        session = mgr.create_session(cmd, hub=hub or None)
+    except Exception:
+        logger.exception("Failed to create session for cmd={!r}", cmd)
+        await ws.send_str(json.dumps({"error": "Failed to spawn terminal"}))
+        await ws.close()
+        return ws
+
+    await ws.send_str(json.dumps({"session_id": session.session_id}))
+    await mgr.attach(session.session_id, ws)
+
+    # Send resize if client sends it as first message
+    await _session_ws_input_loop(ws, session, mgr)
+    return ws
+
+
+async def session_attach_handler(request: web.Request) -> web.WebSocketResponse:
+    """Attach to an existing persistent session via WebSocket."""
+    session_id = request.match_info["session_id"]
+    mgr: SessionManager = request.app["session_manager"]
+
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+
+    scrollback = await mgr.attach(session_id, ws)
+    if scrollback is None:
+        await ws.send_str(json.dumps({"error": "session_not_found"}))
+        await ws.close()
+        return ws
+
+    # Replay scrollback, then signal ready
+    if scrollback:
+        await ws.send_bytes(scrollback)
+    await ws.send_str(json.dumps({"type": "session_attached", "session_id": session_id}))
+
+    session = mgr.get_session(session_id)
+    if session:
+        await _session_ws_input_loop(ws, session, mgr)
+    return ws
+
+
+async def sessions_list_handler(request: web.Request) -> web.Response:
+    """List all active sessions."""
+    mgr: SessionManager = request.app["session_manager"]
+    return web.json_response(mgr.list_sessions())
+
+
+# ── Test puppeting API (test_mode only) ──────────────────────────────────────
+
+
+async def test_session_create(request: web.Request) -> web.Response:
+    cmd = request.query.get("cmd", "").strip()
+    hub = request.query.get("hub", "")
+    if not cmd:
+        raise web.HTTPBadRequest(text="Missing 'cmd' query parameter")
+    mgr: SessionManager = request.app["session_manager"]
+    try:
+        session = mgr.create_session(cmd, hub=hub or None)
+        return web.json_response({"session_id": session.session_id})
+    except Exception as e:
+        return web.json_response({"error": str(e)}, status=500)
+
+
+async def test_session_send(request: web.Request) -> web.Response:
+    sid = request.match_info["id"]
+    mgr: SessionManager = request.app["session_manager"]
+    session = mgr.get_session(sid)
+    if not session:
+        raise web.HTTPNotFound(text="Session not found")
+    text = await request.text()
+    session.pty.write(text)
+    return web.json_response({"status": "ok", "sent": len(text)})
+
+
+async def test_session_read(request: web.Request) -> web.Response:
+    sid = request.match_info["id"]
+    mgr: SessionManager = request.app["session_manager"]
+    session = mgr.get_session(sid)
+    if not session:
+        raise web.HTTPNotFound(text="Session not found")
+    data = session.scrollback.get_all()
+    return web.json_response({
+        "output": data.decode("utf-8", errors="replace"),
+        "size": len(data),
+        "total_written": session.scrollback.total_written,
+    })
+
+
+async def test_session_status(request: web.Request) -> web.Response:
+    sid = request.match_info["id"]
+    mgr: SessionManager = request.app["session_manager"]
+    session = mgr.get_session(sid)
+    if not session:
+        raise web.HTTPNotFound(text="Session not found")
+    now = time.monotonic()
+    return web.json_response({
+        "session_id": session.session_id,
+        "alive": session.alive,
+        "client_count": len(session.clients),
+        "scrollback_size": session.scrollback.size,
+        "age_seconds": int(now - session.created_at),
+        "idle_seconds": int(now - session.last_client_time),
+    })
+
+
+async def test_session_delete(request: web.Request) -> web.Response:
+    sid = request.match_info["id"]
+    mgr: SessionManager = request.app["session_manager"]
+    if not mgr.get_session(sid):
+        raise web.HTTPNotFound(text="Session not found")
+    mgr.destroy_session(sid)
+    return web.json_response({"status": "ok"})
+
+
+async def test_sessions_list(request: web.Request) -> web.Response:
+    mgr: SessionManager = request.app["session_manager"]
+    return web.json_response(mgr.list_sessions())
+
+
+def create_app(test_mode: bool = False) -> web.Application:
     app = web.Application()
+    app["test_mode"] = test_mode
+
+    # Static + API routes
     app.router.add_get("/", index_handler)
     app.router.add_get("/api/hubs", hubs_handler)
     app.router.add_get("/api/startup", startup_handler)
@@ -356,16 +518,46 @@ def create_app() -> web.Application:
     app.router.add_get("/api/widgets/system-info", widget_system_info_handler)
     app.router.add_get("/api/widgets/claude-usage", widget_claude_usage_handler)
     app.router.add_get("/api/widgets/claude-usage/status", widget_claude_usage_status_handler)
+
+    # Session routes (must be before /ws/{hub} catch-all)
+    app.router.add_get("/api/sessions", sessions_list_handler)
+    app.router.add_get("/ws/session/new", session_new_handler)
+    app.router.add_get("/ws/session/{session_id}", session_attach_handler)
     app.router.add_get("/ws/exec", exec_websocket_handler)
 
-    # Start utility container in background on app startup
+    # Test puppeting API (only in test mode)
+    if test_mode:
+        app.router.add_post("/api/test/session/create", test_session_create)
+        app.router.add_post("/api/test/session/{id}/send", test_session_send)
+        app.router.add_get("/api/test/session/{id}/read", test_session_read)
+        app.router.add_get("/api/test/session/{id}/status", test_session_status)
+        app.router.add_delete("/api/test/session/{id}", test_session_delete)
+        app.router.add_get("/api/test/sessions", test_sessions_list)
+
+    # Legacy hub WebSocket (catch-all, must be last)
+    app.router.add_get("/ws/{hub}", websocket_handler)
+
+    # Lifecycle hooks
+    config = read_config()
+    session_config = config.get("sessions", {})
+
     async def on_startup(app: web.Application) -> None:
+        mgr = SessionManager(
+            orphan_timeout=session_config.get("orphan_timeout", 300),
+            scrollback_size=session_config.get("scrollback_size", 65536),
+        )
+        app["session_manager"] = mgr
+        mgr.start_orphan_reaper()
         try:
             await ensure_util_container()
         except Exception:
             logger.warning("Failed to start utility container (non-fatal)")
 
+    async def on_shutdown(app: web.Application) -> None:
+        if "session_manager" in app:
+            app["session_manager"].stop_all()
+
     app.on_startup.append(on_startup)
-    app.router.add_get("/ws/{hub}", websocket_handler)
+    app.on_shutdown.append(on_shutdown)
     logger.info("Application routes registered")
     return app

--- a/claude_rts/sessions.py
+++ b/claude_rts/sessions.py
@@ -1,0 +1,241 @@
+"""Session persistence: PTY sessions that survive WebSocket disconnects.
+
+Each Session owns a PTY process and a scrollback ring buffer. The PTY read
+loop runs continuously, feeding the scrollback regardless of whether any
+WebSocket client is attached. On reconnect, the client receives the
+scrollback contents before live data.
+"""
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Optional
+
+from aiohttp import web
+from loguru import logger
+from winpty import PtyProcess
+
+
+class ScrollbackBuffer:
+    """Fixed-size ring buffer for raw PTY output bytes."""
+
+    def __init__(self, capacity: int = 65536):
+        self._buf = bytearray(capacity)
+        self._capacity = capacity
+        self._write_pos = 0
+        self._total_written = 0
+
+    @property
+    def total_written(self) -> int:
+        return self._total_written
+
+    @property
+    def size(self) -> int:
+        return min(self._total_written, self._capacity)
+
+    def append(self, data: bytes) -> None:
+        """Append data to the ring buffer."""
+        n = len(data)
+        if n == 0:
+            return
+        if n >= self._capacity:
+            # Data larger than buffer — keep only the tail
+            data = data[-self._capacity:]
+            n = self._capacity
+            self._buf[:] = data
+            self._write_pos = 0
+            self._total_written += len(data)
+            return
+
+        end = self._write_pos + n
+        if end <= self._capacity:
+            self._buf[self._write_pos:end] = data
+        else:
+            first = self._capacity - self._write_pos
+            self._buf[self._write_pos:] = data[:first]
+            self._buf[:n - first] = data[first:]
+        self._write_pos = end % self._capacity
+        self._total_written += n
+
+    def get_all(self) -> bytes:
+        """Return all buffered data in order."""
+        if self._total_written == 0:
+            return b""
+        if self._total_written < self._capacity:
+            return bytes(self._buf[:self._write_pos])
+        # Buffer is full or has wrapped
+        if self._write_pos == 0:
+            return bytes(self._buf[:self._capacity])
+        return bytes(self._buf[self._write_pos:] + self._buf[:self._write_pos])
+
+
+@dataclass
+class Session:
+    """A persistent PTY session."""
+    session_id: str
+    cmd: str
+    hub: Optional[str]
+    pty: PtyProcess
+    scrollback: ScrollbackBuffer
+    created_at: float = field(default_factory=time.monotonic)
+    last_client_time: float = field(default_factory=time.monotonic)
+    clients: set = field(default_factory=set)
+    read_task: Optional[asyncio.Task] = None
+    alive: bool = True
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+class SessionManager:
+    """Registry of persistent PTY sessions."""
+
+    def __init__(self, orphan_timeout: float = 300, scrollback_size: int = 65536):
+        self._sessions: dict[str, Session] = {}
+        self.orphan_timeout = orphan_timeout
+        self.scrollback_size = scrollback_size
+        self._reaper_task: Optional[asyncio.Task] = None
+
+    def create_session(
+        self,
+        cmd: str,
+        hub: str | None = None,
+        dimensions: tuple[int, int] = (24, 80),
+    ) -> Session:
+        """Spawn a PTY and register a new session."""
+        session_id = uuid.uuid4().hex[:16]
+        logger.info("Creating session {} for cmd={!r} hub={}", session_id, cmd, hub)
+
+        pty = PtyProcess.spawn(cmd, dimensions=dimensions)
+
+        session = Session(
+            session_id=session_id,
+            cmd=cmd,
+            hub=hub,
+            pty=pty,
+            scrollback=ScrollbackBuffer(self.scrollback_size),
+        )
+        session.read_task = asyncio.create_task(self._pty_read_loop(session))
+        self._sessions[session_id] = session
+
+        logger.info("Session {} created (PTY spawned)", session_id)
+        return session
+
+    def get_session(self, session_id: str) -> Session | None:
+        return self._sessions.get(session_id)
+
+    async def attach(self, session_id: str, ws: web.WebSocketResponse) -> bytes | None:
+        """Attach a WebSocket client to a session. Returns scrollback for replay."""
+        session = self._sessions.get(session_id)
+        if not session or not session.alive:
+            return None
+
+        async with session._lock:
+            scrollback = session.scrollback.get_all()
+            session.clients.add(ws)
+            session.last_client_time = time.monotonic()
+
+        logger.info("Session {}: client attached ({} total), scrollback={} bytes",
+                     session_id, len(session.clients), len(scrollback))
+        return scrollback
+
+    def detach(self, session_id: str, ws: web.WebSocketResponse) -> None:
+        """Detach a WebSocket client from a session."""
+        session = self._sessions.get(session_id)
+        if not session:
+            return
+        session.clients.discard(ws)
+        session.last_client_time = time.monotonic()
+        logger.info("Session {}: client detached ({} remaining)",
+                     session_id, len(session.clients))
+
+    def destroy_session(self, session_id: str) -> None:
+        """Kill a session's PTY and remove it from the registry."""
+        session = self._sessions.pop(session_id, None)
+        if not session:
+            return
+        session.alive = False
+        if session.read_task:
+            session.read_task.cancel()
+        try:
+            session.pty.terminate(force=True)
+        except Exception:
+            pass
+        logger.info("Session {} destroyed", session_id)
+
+    def list_sessions(self) -> list[dict]:
+        """Return metadata for all active sessions."""
+        now = time.monotonic()
+        return [
+            {
+                "session_id": s.session_id,
+                "cmd": s.cmd,
+                "hub": s.hub,
+                "alive": s.alive,
+                "client_count": len(s.clients),
+                "scrollback_size": s.scrollback.size,
+                "age_seconds": int(now - s.created_at),
+                "idle_seconds": int(now - s.last_client_time),
+            }
+            for s in self._sessions.values()
+        ]
+
+    async def _pty_read_loop(self, session: Session) -> None:
+        """Continuously read PTY output into scrollback and fan out to clients."""
+        loop = asyncio.get_event_loop()
+        logger.debug("Session {}: read loop started", session.session_id)
+        try:
+            while session.pty.isalive() and session.alive:
+                try:
+                    data = await loop.run_in_executor(None, session.pty.read)
+                    if not data:
+                        continue
+                    raw = data.encode("utf-8", errors="replace")
+
+                    async with session._lock:
+                        session.scrollback.append(raw)
+                        dead = []
+                        for ws in session.clients:
+                            try:
+                                await ws.send_bytes(raw)
+                            except Exception:
+                                dead.append(ws)
+                        for ws in dead:
+                            session.clients.discard(ws)
+                except EOFError:
+                    logger.info("Session {}: PTY EOF", session.session_id)
+                    break
+                except asyncio.CancelledError:
+                    break
+                except Exception:
+                    logger.exception("Session {}: read error", session.session_id)
+                    break
+        finally:
+            session.alive = False
+            logger.info("Session {}: read loop ended", session.session_id)
+
+    def start_orphan_reaper(self) -> None:
+        """Start background task to clean up orphaned sessions."""
+        self._reaper_task = asyncio.create_task(self._orphan_reaper())
+
+    async def _orphan_reaper(self) -> None:
+        """Periodically kill sessions with no clients past the timeout."""
+        while True:
+            await asyncio.sleep(30)
+            now = time.monotonic()
+            to_kill = [
+                sid for sid, s in self._sessions.items()
+                if len(s.clients) == 0
+                and (now - s.last_client_time) > self.orphan_timeout
+            ]
+            for sid in to_kill:
+                logger.info("Orphan reaper: killing session {} (no clients for {}s)",
+                            sid, int(now - self._sessions[sid].last_client_time))
+                self.destroy_session(sid)
+
+    def stop_all(self) -> None:
+        """Destroy all sessions and stop the reaper."""
+        if self._reaper_task:
+            self._reaper_task.cancel()
+        for sid in list(self._sessions.keys()):
+            self.destroy_session(sid)
+        logger.info("SessionManager: all sessions stopped")

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -1079,6 +1079,7 @@ class Card {
   serialize() {
     const data = { hub: this.hub, x: this.x, y: this.y, w: this.w, h: this.h, type: this.type, controlGroups: this.controlGroupNums.length > 0 ? [...this.controlGroupNums] : undefined };
     if (this.execCmd) data.exec = this.execCmd;
+    if (this.sessionId) data.session_id = this.sessionId;
     return data;
   }
 
@@ -1098,7 +1099,8 @@ class Card {
 class TerminalCard extends Card {
   constructor(opts) {
     super({ ...opts, type: 'terminal' });
-    this.execCmd = opts.exec || null; // custom exec command (for /ws/exec)
+    this.execCmd = opts.exec || null;
+    this.sessionId = opts.sessionId || null; // persistent session ID
     this.term = null;
     this.fitAddon = null;
     this.ws = null;
@@ -1148,19 +1150,39 @@ class TerminalCard extends Card {
 
   connectWs() {
     const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = this.execCmd
-      ? `${wsProto}//${location.host}/ws/exec?cmd=${encodeURIComponent(this.execCmd)}`
-      : `${wsProto}//${location.host}/ws/${this.hub}`;
+    let wsUrl;
+    if (this.sessionId) {
+      // Reconnect to existing persistent session
+      wsUrl = `${wsProto}//${location.host}/ws/session/${this.sessionId}`;
+    } else {
+      // Create new persistent session
+      const cmd = this.execCmd || `docker.exe exec -it -u vscode ${this.container} bash -l`;
+      wsUrl = `${wsProto}//${location.host}/ws/session/new?cmd=${encodeURIComponent(cmd)}&hub=${encodeURIComponent(this.hub)}`;
+    }
     this.ws = new WebSocket(wsUrl);
     this.ws.binaryType = 'arraybuffer';
 
     this.ws.addEventListener('open', () => {
-      this._reconnectDelay = 1000; // reset backoff
+      this._reconnectDelay = 1000;
       this.updateState('idle');
       this.ws.send(JSON.stringify({ type: 'resize', cols: this.term.cols, rows: this.term.rows }));
     });
     this.ws.addEventListener('message', (ev) => {
-      if (ev.data instanceof ArrayBuffer) {
+      if (typeof ev.data === 'string') {
+        // Control message from server (session_id, errors, etc.)
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.session_id) {
+            this.sessionId = msg.session_id;
+            saveLayout();
+          }
+          if (msg.error === 'session_not_found') {
+            this.sessionId = null;
+            this.connectWs(); // create new session
+            return;
+          }
+        } catch {}
+      } else if (ev.data instanceof ArrayBuffer) {
         this.term.write(new Uint8Array(ev.data));
         this.updateState('working');
       }
@@ -1481,9 +1503,9 @@ setInterval(() => {
 // ════════════════════════════════════════════
 // Spawn a terminal card
 // ════════════════════════════════════════════
-function spawnCard(hub, x, y, w, h, savedControlGroups, execCmd) {
+function spawnCard(hub, x, y, w, h, savedControlGroups, execCmd, sessionId) {
   const symbol = hubSymbolMap[hub.hub] || '?';
-  const card = new TerminalCard({ hub: hub.hub, container: hub.container, x, y, w, h, symbol, exec: execCmd || hub.exec || null });
+  const card = new TerminalCard({ hub: hub.hub, container: hub.container, x, y, w, h, symbol, exec: execCmd || hub.exec || null, sessionId: sessionId || null });
   if (savedControlGroups && Array.isArray(savedControlGroups)) {
     card.controlGroupNums = [...savedControlGroups];
   }
@@ -2107,7 +2129,7 @@ async function switchCanvas(name) {
         spawnWidget(s.widgetType, s.x, s.y, s.w, s.h);
       } else {
         const hub = hubs.find(h => h.hub === s.hub);
-        if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec);
+        if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec, s.session_id);
       }
     }
     rebuildControlGroupsFromCards();
@@ -2213,7 +2235,7 @@ async function switchCanvas(name) {
         spawnWidget(s.widgetType, s.x, s.y, s.w, s.h);
       } else {
         const hub = hubs.find(h => h.hub === s.hub);
-        if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec);
+        if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec, s.session_id);
       }
     }
     // Spawn any new hubs not in saved layout

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,249 @@
+"""Tests for session persistence: ScrollbackBuffer, SessionManager, and session APIs."""
+
+import asyncio
+import json
+import time
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+from aiohttp import web
+
+from claude_rts.sessions import ScrollbackBuffer, SessionManager, Session
+from claude_rts.server import create_app
+
+
+# ── ScrollbackBuffer unit tests ─────────────────────────────────────────────
+
+
+def test_scrollback_empty():
+    buf = ScrollbackBuffer(1024)
+    assert buf.get_all() == b""
+    assert buf.size == 0
+    assert buf.total_written == 0
+
+
+def test_scrollback_basic_write():
+    buf = ScrollbackBuffer(1024)
+    buf.append(b"hello")
+    assert buf.get_all() == b"hello"
+    assert buf.size == 5
+    assert buf.total_written == 5
+
+
+def test_scrollback_multiple_writes():
+    buf = ScrollbackBuffer(1024)
+    buf.append(b"hello ")
+    buf.append(b"world")
+    assert buf.get_all() == b"hello world"
+    assert buf.total_written == 11
+
+
+def test_scrollback_wraparound():
+    buf = ScrollbackBuffer(10)
+    buf.append(b"12345")
+    buf.append(b"67890")
+    assert buf.get_all() == b"1234567890"
+    # Now overflow
+    buf.append(b"ABC")
+    result = buf.get_all()
+    assert len(result) == 10
+    assert result == b"4567890ABC"
+
+
+def test_scrollback_large_write_exceeds_capacity():
+    buf = ScrollbackBuffer(8)
+    buf.append(b"0123456789ABCDEF")
+    # Only last 8 bytes kept
+    assert buf.get_all() == b"89ABCDEF"
+    assert buf.size == 8
+
+
+def test_scrollback_empty_append():
+    buf = ScrollbackBuffer(1024)
+    buf.append(b"data")
+    buf.append(b"")
+    assert buf.get_all() == b"data"
+
+
+# ── SessionManager unit tests (mocked PTY) ──────────────────────────────────
+
+
+class MockPty:
+    """Mock PtyProcess for testing."""
+    def __init__(self):
+        self._alive = True
+        self._output_queue = []
+        self._written = []
+
+    def isalive(self):
+        return self._alive
+
+    def read(self):
+        if self._output_queue:
+            return self._output_queue.pop(0)
+        # Simulate blocking read that returns when killed
+        time.sleep(0.1)
+        if not self._alive:
+            raise EOFError()
+        return ""
+
+    def write(self, text):
+        self._written.append(text)
+
+    def setwinsize(self, rows, cols):
+        pass
+
+    def terminate(self, force=False):
+        self._alive = False
+
+    @classmethod
+    def spawn(cls, cmd, dimensions=(24, 80)):
+        return cls()
+
+
+async def test_session_manager_create(monkeypatch):
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+    session = mgr.create_session("echo hello")
+    assert session.session_id
+    assert session.cmd == "echo hello"
+    assert session.alive
+    assert mgr.get_session(session.session_id) is session
+    mgr.stop_all()
+
+
+async def test_session_manager_destroy(monkeypatch):
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+    session = mgr.create_session("test")
+    sid = session.session_id
+    mgr.destroy_session(sid)
+    assert mgr.get_session(sid) is None
+    assert not session.alive
+    mgr.stop_all()
+
+
+async def test_session_manager_list(monkeypatch):
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+    mgr.create_session("cmd1", hub="hub1")
+    mgr.create_session("cmd2", hub="hub2")
+    sessions = mgr.list_sessions()
+    assert len(sessions) == 2
+    hubs = {s["hub"] for s in sessions}
+    assert hubs == {"hub1", "hub2"}
+    mgr.stop_all()
+
+
+async def test_session_manager_stop_all(monkeypatch):
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+    s1 = mgr.create_session("cmd1")
+    s2 = mgr.create_session("cmd2")
+    mgr.stop_all()
+    assert mgr.get_session(s1.session_id) is None
+    assert mgr.get_session(s2.session_id) is None
+
+
+# ── Test puppeting API tests ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    return create_app(test_mode=True)
+
+
+@pytest.fixture
+async def client(aiohttp_client, app):
+    return await aiohttp_client(app)
+
+
+async def test_test_session_create(client):
+    resp = await client.post("/api/test/session/create?cmd=echo+hello")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "session_id" in data
+
+
+async def test_test_session_status(client):
+    resp = await client.post("/api/test/session/create?cmd=echo+hello")
+    data = await resp.json()
+    sid = data["session_id"]
+
+    resp = await client.get(f"/api/test/session/{sid}/status")
+    assert resp.status == 200
+    status = await resp.json()
+    assert status["session_id"] == sid
+    assert status["alive"] is True
+    assert status["client_count"] == 0
+
+
+async def test_test_session_send_and_read(client):
+    resp = await client.post("/api/test/session/create?cmd=echo+hello")
+    data = await resp.json()
+    sid = data["session_id"]
+
+    # Send text to PTY
+    resp = await client.post(f"/api/test/session/{sid}/send", data="test input")
+    assert resp.status == 200
+
+    # Read scrollback (may be empty since MockPty doesn't echo)
+    resp = await client.get(f"/api/test/session/{sid}/read")
+    assert resp.status == 200
+    read_data = await resp.json()
+    assert "output" in read_data
+    assert "size" in read_data
+
+
+async def test_test_session_delete(client):
+    resp = await client.post("/api/test/session/create?cmd=echo+hello")
+    data = await resp.json()
+    sid = data["session_id"]
+
+    resp = await client.delete(f"/api/test/session/{sid}")
+    assert resp.status == 200
+
+    resp = await client.get(f"/api/test/session/{sid}/status")
+    assert resp.status == 404
+
+
+async def test_test_session_not_found(client):
+    resp = await client.get("/api/test/session/nonexistent/status")
+    assert resp.status == 404
+
+
+async def test_test_sessions_list(client):
+    await client.post("/api/test/session/create?cmd=cmd1")
+    await client.post("/api/test/session/create?cmd=cmd2")
+    resp = await client.get("/api/test/sessions")
+    assert resp.status == 200
+    data = await resp.json()
+    assert len(data) >= 2
+
+
+async def test_sessions_list_api(client):
+    """The non-test sessions list endpoint should also work."""
+    resp = await client.get("/api/sessions")
+    assert resp.status == 200
+    data = await resp.json()
+    assert isinstance(data, list)
+
+
+async def test_test_mode_disabled():
+    """Test API should NOT be available when test_mode=False."""
+    with patch("claude_rts.sessions.PtyProcess", MockPty):
+        app = create_app(test_mode=False)
+    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
+    assert "/api/test/sessions" not in routes
+    assert "/api/test/session/{id}/read" not in routes
+
+
+async def test_app_has_session_routes():
+    """Verify session WebSocket routes are registered."""
+    with patch("claude_rts.sessions.PtyProcess", MockPty):
+        app = create_app(test_mode=False)
+    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
+    assert "/ws/session/new" in routes
+    assert "/ws/session/{session_id}" in routes
+    assert "/api/sessions" in routes


### PR DESCRIPTION
## Summary

Major architectural change: PTY sessions now survive browser refresh and reconnect with scrollback history replay. Sessions are decoupled from WebSocket connections — the PTY keeps running when the browser disconnects, and reconnecting replays the scrollback buffer.

### New: `sessions.py`
- `SessionManager` — singleton registry of persistent PTY sessions
- `ScrollbackBuffer` — 64KB ring buffer storing raw PTY output
- Continuous PTY read loop feeds scrollback regardless of client state
- Fan-out: multiple WebSocket clients can attach to the same session
- Orphan reaper cleans up sessions with no client after 5 minutes

### New WebSocket protocol
- `GET /ws/session/new?cmd=...` — create session, returns `session_id` via text message
- `GET /ws/session/{session_id}` — reconnect, replays scrollback before live data
- `GET /api/sessions` — list all active sessions

### Test puppeting API (--test-mode only)
- `POST /api/test/session/create?cmd=...`
- `POST /api/test/session/{id}/send`
- `GET /api/test/session/{id}/read`
- `GET /api/test/session/{id}/status`
- `DELETE /api/test/session/{id}`

### Frontend
- `TerminalCard` stores `sessionId`, persisted in canvas layout
- Reconnect uses `/ws/session/{id}` to reattach with scrollback
- Falls back to new session if old one expired

Closes #33

## Test plan
- [x] All 72 tests pass (19 new session tests)
- [x] ScrollbackBuffer: wraparound, capacity overflow, empty
- [x] SessionManager: create, destroy, list, stop_all
- [x] Test API: create/send/read/status/delete sessions
- [x] Route registration verified
- [x] Test mode gating verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)