### PR TITLE
feat: reliable usage probe via SessionManager ConPTY (#53)

### DIFF
--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -16,7 +16,7 @@ _start_time = time.monotonic()
 from .config import read_config, write_config, list_canvases, read_canvas, write_canvas, delete_canvas
 from .discovery import discover_hubs
 from .startup import run_startup
-from .util_container import ensure_util_container, is_util_running, list_profiles, probe_usage
+from .util_container import ensure_util_container, is_util_running, list_profiles, probe_usage_via_session
 from .sessions import SessionManager
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
@@ -211,14 +211,40 @@ async def widget_system_info_handler(request: web.Request) -> web.Response:
 
 # Cache: {profile_name: {data: {...}, timestamp: float}}
 _usage_cache: dict[str, dict] = {}
-_USAGE_CACHE_TTL = 60  # seconds
+_USAGE_CACHE_TTL = 3600      # 1 hour — usage endpoint is rate-limited
+_USAGE_PROBE_INTERVAL = 1800  # background probe every 30 minutes
+
+
+async def _usage_probe_loop(app: web.Application) -> None:
+    """Background task: probe all profiles every 30 minutes."""
+    await asyncio.sleep(5)  # stagger so startup isn't blocked
+    while True:
+        try:
+            mgr: SessionManager = app["session_manager"]
+            if await is_util_running():
+                profiles = await list_profiles()
+                now = time.monotonic()
+                for profile in profiles:
+                    try:
+                        usage = await probe_usage_via_session(profile, mgr)
+                        if usage:
+                            _usage_cache[profile] = {"data": usage, "timestamp": now}
+                            logger.info("Background probe updated cache for profile '{}'", profile)
+                        else:
+                            logger.warning("Background probe returned no data for profile '{}'", profile)
+                    except Exception:
+                        logger.exception("Background probe failed for profile '{}'", profile)
+        except Exception:
+            logger.exception("Usage probe loop error")
+        await asyncio.sleep(_USAGE_PROBE_INTERVAL)
 
 
 async def widget_claude_usage_handler(request: web.Request) -> web.Response:
     """Return Claude usage data for all profiles.
 
-    Probes each profile via claude-usage-plz in the utility container.
-    Results cached for 60s since each probe takes 15-20s.
+    Cache is populated by a background probe loop every 30 minutes.
+    Cached data is served for up to 1 hour (rate-limited usage endpoint).
+    On cache miss or force refresh, probes on-demand via ConPTY session.
     """
     force = request.query.get("force", "").lower() in ("1", "true")
 
@@ -238,6 +264,7 @@ async def widget_claude_usage_handler(request: web.Request) -> web.Response:
         })
 
     now = time.monotonic()
+    mgr: SessionManager = request.app["session_manager"]
     results = []
 
     for profile in profiles:
@@ -246,11 +273,14 @@ async def widget_claude_usage_handler(request: web.Request) -> web.Response:
             results.append({"profile": profile, **cached["data"], "cached": True})
             continue
 
-        claude_dir = f"/profiles/{profile}"
-        usage = await probe_usage(claude_dir)
+        # Cache miss or force refresh — probe now (background loop normally handles this)
+        usage = await probe_usage_via_session(profile, mgr)
         if usage:
             _usage_cache[profile] = {"data": usage, "timestamp": now}
             results.append({"profile": profile, **usage, "cached": False})
+        elif cached:
+            # Return stale data rather than an error
+            results.append({"profile": profile, **cached["data"], "cached": True, "stale": True})
         else:
             results.append({"profile": profile, "error": "probe failed", "cached": False})
 
@@ -569,7 +599,15 @@ def create_app(test_mode: bool = False) -> web.Application:
         except Exception:
             logger.warning("Failed to start utility container (non-fatal)")
 
+        app["usage_probe_task"] = asyncio.create_task(_usage_probe_loop(app))
+
     async def on_shutdown(app: web.Application) -> None:
+        if "usage_probe_task" in app:
+            app["usage_probe_task"].cancel()
+            try:
+                await app["usage_probe_task"]
+            except asyncio.CancelledError:
+                pass
         if "session_manager" in app:
             app["session_manager"].stop_all()
 

--- a/claude_rts/util_container.py
+++ b/claude_rts/util_container.py
@@ -9,6 +9,7 @@ It stays alive via `sleep infinity` and commands are executed via `docker exec`.
 import asyncio
 import json
 import pathlib
+import re
 import shutil
 import time
 
@@ -276,3 +277,66 @@ async def probe_usage(claude_dir: str, timeout: float = 60) -> dict | None:
     except json.JSONDecodeError as exc:
         logger.warning("claude-usage returned invalid JSON for {}: {}", claude_dir, exc)
         return None
+
+
+_ANSI_ESCAPE = re.compile(r'\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+
+
+def parse_json_from_output(output: str) -> dict | None:
+    """Extract and parse a JSON object from raw PTY/ANSI output."""
+    clean = _ANSI_ESCAPE.sub('', output).replace('\r', '').strip()
+    json_start = clean.find('{')
+    json_end = clean.rfind('}')
+    if json_start < 0 or json_end <= json_start:
+        return None
+    try:
+        return json.loads(clean[json_start:json_end + 1])
+    except json.JSONDecodeError:
+        return None
+
+
+async def probe_usage_via_session(
+    name: str,
+    session_mgr,
+    container_name: str | None = None,
+    timeout: float = 90,
+) -> dict | None:
+    """Run claude-usage inside the utility container via a real ConPTY session.
+
+    Uses SessionManager.create_session() without a container= argument so that
+    tmux-wrapping is NOT triggered — the full docker exec command is passed
+    directly, giving pexpect the genuine Windows ConPTY it requires.
+
+    Each probe takes 30-60s; the background probe loop staggers calls.
+    """
+    if container_name is None:
+        cfg = _get_config()
+        container_name = cfg["name"]
+
+    cmd = f'docker.exe exec -it {container_name} claude-usage --claude-dir /profiles/{name} --json'
+    logger.info("probe_usage_via_session: name={} container={}", name, container_name)
+
+    try:
+        session = session_mgr.create_session(cmd)
+    except Exception as exc:
+        logger.error("probe_usage_via_session: failed to create session for {}: {}", name, exc)
+        return None
+
+    try:
+        deadline = time.monotonic() + timeout
+        while session.alive and time.monotonic() < deadline:
+            await asyncio.sleep(1)
+
+        if time.monotonic() >= deadline:
+            logger.warning("probe_usage_via_session: timed out after {}s for name={}", timeout, name)
+
+        output = session.scrollback.get_all().decode("utf-8", errors="replace")
+        result = parse_json_from_output(output)
+        if result is None:
+            logger.warning(
+                "probe_usage_via_session: no JSON found for name={}; raw={!r}",
+                name, output[:200],
+            )
+        return result
+    finally:
+        session_mgr.destroy_session(session.session_id)

--- a/tests/test_util_container.py
+++ b/tests/test_util_container.py
@@ -1,11 +1,12 @@
 """Tests for the utility container module and claude-usage widget API."""
 
 import json
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
 from claude_rts.server import create_app
+from claude_rts.util_container import parse_json_from_output
 
 
 @pytest.fixture
@@ -54,7 +55,7 @@ async def test_claude_usage_with_profiles(client):
     }
     with patch("claude_rts.server.is_util_running", new_callable=AsyncMock, return_value=True), \
          patch("claude_rts.server.list_profiles", new_callable=AsyncMock, return_value=["acct-alice"]), \
-         patch("claude_rts.server.probe_usage", new_callable=AsyncMock, return_value=mock_usage):
+         patch("claude_rts.server.probe_usage_via_session", new_callable=AsyncMock, return_value=mock_usage):
         resp = await client.get("/api/widgets/claude-usage")
     assert resp.status == 200
     data = await resp.json()
@@ -65,14 +66,39 @@ async def test_claude_usage_with_profiles(client):
 
 
 async def test_claude_usage_probe_failure(client):
-    """When a probe fails, return error for that profile."""
+    """When a probe fails with no stale data, return error for that profile."""
     with patch("claude_rts.server.is_util_running", new_callable=AsyncMock, return_value=True), \
          patch("claude_rts.server.list_profiles", new_callable=AsyncMock, return_value=["acct-bob"]), \
-         patch("claude_rts.server.probe_usage", new_callable=AsyncMock, return_value=None):
+         patch("claude_rts.server.probe_usage_via_session", new_callable=AsyncMock, return_value=None):
         resp = await client.get("/api/widgets/claude-usage")
     assert resp.status == 200
     data = await resp.json()
     assert data["profiles"][0]["error"] == "probe failed"
+
+
+# ── parse_json_from_output unit tests ──
+
+
+def test_parse_json_clean():
+    assert parse_json_from_output('{"five_hour_pct": 42.0}') == {"five_hour_pct": 42.0}
+
+
+def test_parse_json_with_ansi():
+    raw = '\x1b[32m{"five_hour_pct": 10.0}\x1b[0m'
+    assert parse_json_from_output(raw) == {"five_hour_pct": 10.0}
+
+
+def test_parse_json_with_surrounding_text():
+    raw = "some preamble\r\n{\"key\": \"val\"}\r\nextra output"
+    assert parse_json_from_output(raw) == {"key": "val"}
+
+
+def test_parse_json_no_json():
+    assert parse_json_from_output("WARNING: No usage data parsed") is None
+
+
+def test_parse_json_malformed():
+    assert parse_json_from_output("{not valid json}") is None
 
 
 async def test_claude_usage_status_endpoint(client):


### PR DESCRIPTION
## Summary

- Replaces the `script -qc` probe approach with `probe_usage_via_session()`, which calls `SessionManager.create_session(cmd)` **without** `container=` so tmux-wrapping is not triggered — the full `docker.exe exec -it` command runs directly under a genuine Windows ConPTY, giving pexpect what it needs
- Adds `parse_json_from_output()` to strip ANSI escapes and extract JSON from raw PTY scrollback
- Adds a background `_usage_probe_loop` that refreshes all profiles every 30 minutes, raises cache TTL to 1 hour, and returns stale data on probe failure rather than an error

Supersedes #54 (closed), which was branched before the tmux-backed session persistence landed.

Closes #53

## Test plan

- [ ] All 88 existing tests pass (`pytest --ignore=tests/test_e2e.py`)
- [ ] 5 new unit tests for `parse_json_from_output` (clean JSON, ANSI-wrapped, surrounding text, no JSON, malformed)
- [ ] Widget API tests updated to mock `probe_usage_via_session` instead of `probe_usage`
- [ ] Manual: verify `GET /api/widgets/claude-usage` returns data after the 5s background probe fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)