### PR TITLE
ci(#70): add GitHub Actions for ruff + unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check .
+      - run: ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[test]"
+      - run: python -m pytest tests/ -v

--- a/claude_rts/__main__.py
+++ b/claude_rts/__main__.py
@@ -35,16 +35,19 @@ def main():
     logger.info("supreme-claudemander starting on http://localhost:{}", args.port)
 
     import os
+
     test_mode = args.test_mode or os.environ.get("CLAUDE_RTS_TEST_MODE", "").lower() in ("1", "true")
     app = create_app(test_mode=test_mode)
     if test_mode:
         logger.info("Test mode enabled — puppeting API available")
 
     if not args.no_browser:
+
         async def open_browser(app):
             url = f"http://localhost:{args.port}"
             logger.info("Opening browser: {}", url)
             webbrowser.open(url)
+
         app.on_startup.append(open_browser)
 
     logger.info("Press Ctrl+C to stop")

--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -106,9 +106,7 @@ def write_config(data: dict) -> dict:
 def list_canvases() -> list[str]:
     """Return sorted list of saved canvas names (without .json extension)."""
     ensure_dirs()
-    names = sorted(
-        p.stem for p in CANVASES_DIR.glob("*.json") if p.is_file()
-    )
+    names = sorted(p.stem for p in CANVASES_DIR.glob("*.json") if p.is_file())
     logger.debug("Listed {} canvas(es)", len(names))
     return names
 

--- a/claude_rts/discovery.py
+++ b/claude_rts/discovery.py
@@ -1,7 +1,6 @@
 """Discover running devcontainer hubs via docker ps."""
 
 import asyncio
-import json
 import re
 import sys
 
@@ -15,9 +14,12 @@ async def discover_hubs() -> list[dict]:
     Sorted by hub name.
     """
     proc = await asyncio.create_subprocess_exec(
-        _DOCKER, "ps",
-        "--filter", "label=devcontainer.local_folder",
-        "--format", '{{.Names}}|{{.Label "devcontainer.local_folder"}}',
+        _DOCKER,
+        "ps",
+        "--filter",
+        "label=devcontainer.local_folder",
+        "--format",
+        '{{.Names}}|{{.Label "devcontainer.local_folder"}}',
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import pathlib
 import platform
-import re
 import sys
 import time
 
@@ -14,11 +13,11 @@ from .pty_compat import PtyProcess
 
 _start_time = time.monotonic()
 
-from .config import read_config, write_config, list_canvases, read_canvas, write_canvas, delete_canvas
-from .discovery import discover_hubs
-from .startup import run_startup
-from .util_container import ensure_util_container
-from .sessions import SessionManager
+from .config import read_config, write_config, list_canvases, read_canvas, write_canvas, delete_canvas  # noqa: E402
+from .discovery import discover_hubs  # noqa: E402
+from .startup import run_startup  # noqa: E402
+from .util_container import ensure_util_container  # noqa: E402
+from .sessions import SessionManager  # noqa: E402
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
@@ -123,7 +122,7 @@ async def websocket_handler(request: web.Request) -> web.WebSocketResponse:
 
     # Spawn docker exec via ConPTY for full terminal support
     _docker = "docker.exe" if sys.platform == "win32" else "docker"
-    cmd = f'{_docker} exec -it -u vscode -w /workspaces/{hub_name} {hub["container"]} bash -l'
+    cmd = f"{_docker} exec -it -u vscode -w /workspaces/{hub_name} {hub['container']} bash -l"
     logger.info("Spawning PTY process: {}", cmd)
 
     try:
@@ -406,11 +405,13 @@ async def test_session_read(request: web.Request) -> web.Response:
     if not session:
         raise web.HTTPNotFound(text="Session not found")
     data = session.scrollback.get_all()
-    return web.json_response({
-        "output": data.decode("utf-8", errors="replace"),
-        "size": len(data),
-        "total_written": session.scrollback.total_written,
-    })
+    return web.json_response(
+        {
+            "output": data.decode("utf-8", errors="replace"),
+            "size": len(data),
+            "total_written": session.scrollback.total_written,
+        }
+    )
 
 
 async def test_session_status(request: web.Request) -> web.Response:
@@ -420,14 +421,16 @@ async def test_session_status(request: web.Request) -> web.Response:
     if not session:
         raise web.HTTPNotFound(text="Session not found")
     now = time.monotonic()
-    return web.json_response({
-        "session_id": session.session_id,
-        "alive": session.alive,
-        "client_count": len(session.clients),
-        "scrollback_size": session.scrollback.size,
-        "age_seconds": int(now - session.created_at),
-        "idle_seconds": int(now - session.last_client_time),
-    })
+    return web.json_response(
+        {
+            "session_id": session.session_id,
+            "alive": session.alive,
+            "client_count": len(session.clients),
+            "scrollback_size": session.scrollback.size,
+            "age_seconds": int(now - session.created_at),
+            "idle_seconds": int(now - session.last_client_time),
+        }
+    )
 
 
 async def test_session_delete(request: web.Request) -> web.Response:

--- a/claude_rts/sessions.py
+++ b/claude_rts/sessions.py
@@ -46,7 +46,7 @@ class ScrollbackBuffer:
             return
         if n >= self._capacity:
             # Data larger than buffer — keep only the tail
-            data = data[-self._capacity:]
+            data = data[-self._capacity :]
             n = self._capacity
             self._buf[:] = data
             self._write_pos = 0
@@ -55,11 +55,11 @@ class ScrollbackBuffer:
 
         end = self._write_pos + n
         if end <= self._capacity:
-            self._buf[self._write_pos:end] = data
+            self._buf[self._write_pos : end] = data
         else:
             first = self._capacity - self._write_pos
-            self._buf[self._write_pos:] = data[:first]
-            self._buf[:n - first] = data[first:]
+            self._buf[self._write_pos :] = data[:first]
+            self._buf[: n - first] = data[first:]
         self._write_pos = end % self._capacity
         self._total_written += n
 
@@ -68,16 +68,17 @@ class ScrollbackBuffer:
         if self._total_written == 0:
             return b""
         if self._total_written < self._capacity:
-            return bytes(self._buf[:self._write_pos])
+            return bytes(self._buf[: self._write_pos])
         # Buffer is full or has wrapped
         if self._write_pos == 0:
-            return bytes(self._buf[:self._capacity])
-        return bytes(self._buf[self._write_pos:] + self._buf[:self._write_pos])
+            return bytes(self._buf[: self._capacity])
+        return bytes(self._buf[self._write_pos :] + self._buf[: self._write_pos])
 
 
 @dataclass
 class Session:
     """A persistent PTY session."""
+
     session_id: str
     cmd: str
     hub: Optional[str]
@@ -105,8 +106,7 @@ def _valid_container_name(name: str) -> bool:
 class SessionManager:
     """Registry of persistent PTY sessions."""
 
-    def __init__(self, orphan_timeout: float = 300, scrollback_size: int = 65536,
-                 tmux_enabled: bool = True):
+    def __init__(self, orphan_timeout: float = 300, scrollback_size: int = 65536, tmux_enabled: bool = True):
         self._sessions: dict[str, Session] = {}
         self.orphan_timeout = orphan_timeout
         self.scrollback_size = scrollback_size
@@ -131,7 +131,7 @@ class SessionManager:
 
         use_tmux = bool(container and self.tmux_enabled and self._tmux_cache.get(container))
         if use_tmux:
-            spawn_cmd = f'{_DOCKER} exec -it {container} tmux new-session -As {session_id}'
+            spawn_cmd = f"{_DOCKER} exec -it {container} tmux new-session -As {session_id}"
             logger.info("Using tmux persistence: {}", spawn_cmd)
         else:
             spawn_cmd = cmd
@@ -167,8 +167,12 @@ class SessionManager:
             session.clients.add(ws)
             session.last_client_time = time.monotonic()
 
-        logger.info("Session {}: client attached ({} total), scrollback={} bytes",
-                     session_id, len(session.clients), len(scrollback))
+        logger.info(
+            "Session {}: client attached ({} total), scrollback={} bytes",
+            session_id,
+            len(session.clients),
+            len(scrollback),
+        )
         return scrollback
 
     def detach(self, session_id: str, ws: web.WebSocketResponse) -> None:
@@ -178,8 +182,7 @@ class SessionManager:
             return
         session.clients.discard(ws)
         session.last_client_time = time.monotonic()
-        logger.info("Session {}: client detached ({} remaining)",
-                     session_id, len(session.clients))
+        logger.info("Session {}: client detached ({} remaining)", session_id, len(session.clients))
 
     def destroy_session(self, session_id: str, kill_tmux: bool = False) -> None:
         """Kill a session's PTY and remove it from the registry.
@@ -208,9 +211,15 @@ class SessionManager:
             return
         try:
             proc = await asyncio.create_subprocess_exec(
-                _DOCKER, "exec", session.container,
-                "tmux", "kill-session", "-t", session.session_id,
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                _DOCKER,
+                "exec",
+                session.container,
+                "tmux",
+                "kill-session",
+                "-t",
+                session.session_id,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
             await proc.communicate()
             logger.info("Killed tmux session {} in container {}", session.session_id, session.container)
@@ -279,13 +288,16 @@ class SessionManager:
             await asyncio.sleep(30)
             now = time.monotonic()
             to_kill = [
-                sid for sid, s in self._sessions.items()
-                if len(s.clients) == 0
-                and (now - s.last_client_time) > self.orphan_timeout
+                sid
+                for sid, s in self._sessions.items()
+                if len(s.clients) == 0 and (now - s.last_client_time) > self.orphan_timeout
             ]
             for sid in to_kill:
-                logger.info("Orphan reaper: detaching session {} (no clients for {}s)",
-                            sid, int(now - self._sessions[sid].last_client_time))
+                logger.info(
+                    "Orphan reaper: detaching session {} (no clients for {}s)",
+                    sid,
+                    int(now - self._sessions[sid].last_client_time),
+                )
                 self.destroy_session(sid, kill_tmux=False)
 
     def stop_all(self) -> None:
@@ -306,8 +318,13 @@ class SessionManager:
             return self._tmux_cache[container]
         try:
             proc = await asyncio.create_subprocess_exec(
-                _DOCKER, "exec", container, "tmux", "-V",
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                _DOCKER,
+                "exec",
+                container,
+                "tmux",
+                "-V",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
             await proc.communicate()
             available = proc.returncode == 0
@@ -327,9 +344,15 @@ class SessionManager:
             container = hub["container"]
             hub_name = hub["hub"]
             proc = await asyncio.create_subprocess_exec(
-                _DOCKER, "exec", container,
-                "tmux", "list-sessions", "-F", "#{session_name}",
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                _DOCKER,
+                "exec",
+                container,
+                "tmux",
+                "list-sessions",
+                "-F",
+                "#{session_name}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
             stdout, _ = await proc.communicate()
             if proc.returncode != 0:
@@ -344,7 +367,7 @@ class SessionManager:
                 if session_name in self._sessions:
                     continue
 
-                tmux_cmd = f'{_DOCKER} exec -it {container} tmux attach-session -t {session_name}'
+                tmux_cmd = f"{_DOCKER} exec -it {container} tmux attach-session -t {session_name}"
                 try:
                     pty = PtyProcess.spawn(tmux_cmd, dimensions=(24, 80))
                 except Exception:
@@ -364,9 +387,18 @@ class SessionManager:
                 # Seed scrollback from tmux history
                 try:
                     cap_proc = await asyncio.create_subprocess_exec(
-                        _DOCKER, "exec", container,
-                        "tmux", "capture-pane", "-t", session_name, "-p", "-S", "-500",
-                        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                        _DOCKER,
+                        "exec",
+                        container,
+                        "tmux",
+                        "capture-pane",
+                        "-t",
+                        session_name,
+                        "-p",
+                        "-S",
+                        "-500",
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
                     )
                     cap_stdout, _ = await cap_proc.communicate()
                     if cap_proc.returncode == 0 and cap_stdout:

--- a/claude_rts/startup.py
+++ b/claude_rts/startup.py
@@ -9,7 +9,6 @@ Custom scripts: executable files in ~/.supreme-claudemander/startup/ that output
 
 import asyncio
 import json
-import pathlib
 
 from loguru import logger
 
@@ -49,12 +48,14 @@ async def _builtin_discover_devcontainers() -> list[dict]:
     hubs = await discover_hubs()
     result = []
     for h in hubs:
-        result.append({
-            "type": "terminal",
-            "name": h["hub"],
-            "container": h["container"],
-            "exec": f'docker.exe exec -it -u vscode -w /workspaces/{h["hub"]} {h["container"]} bash -l',
-        })
+        result.append(
+            {
+                "type": "terminal",
+                "name": h["hub"],
+                "container": h["container"],
+                "exec": f"docker.exe exec -it -u vscode -w /workspaces/{h['hub']} {h['container']} bash -l",
+            }
+        )
     logger.info("discover-devcontainers: found {} hub(s)", len(result))
     return result
 
@@ -71,7 +72,8 @@ async def _run_custom_script(script_name: str) -> list[dict]:
 
     # Security: only allow alphanumeric, hyphens, underscores in script names
     import re
-    if not re.match(r'^[a-zA-Z0-9_-]+$', script_name):
+
+    if not re.match(r"^[a-zA-Z0-9_-]+$", script_name):
         logger.error("Invalid startup script name: {!r}", script_name)
         raise ValueError(f"Invalid startup script name: {script_name!r}")
 

--- a/claude_rts/util_container.py
+++ b/claude_rts/util_container.py
@@ -13,9 +13,9 @@ import time
 
 _DOCKER = "docker.exe" if sys.platform == "win32" else "docker"
 
-from loguru import logger
+from loguru import logger  # noqa: E402
 
-from .config import read_config
+from .config import read_config  # noqa: E402
 
 DOCKERFILE = pathlib.Path(__file__).parent / "Dockerfile.util"
 DEFAULT_CONTAINER_NAME = "supreme-claudemander-util"
@@ -53,9 +53,7 @@ async def _run(cmd: str, timeout: float = 30) -> tuple[int, str, str]:
 async def is_util_running() -> bool:
     """Check if the utility container is running."""
     cfg = _get_config()
-    rc, stdout, _ = await _run(
-        f'{_DOCKER} ps --filter "name=^/{cfg["name"]}$" --format "{{{{.Status}}}}"'
-    )
+    rc, stdout, _ = await _run(f'{_DOCKER} ps --filter "name=^/{cfg["name"]}$" --format "{{{{.Status}}}}"')
     return rc == 0 and "Up" in stdout
 
 
@@ -63,7 +61,7 @@ async def build_image() -> bool:
     """Build the utility container image if not already built."""
     cfg = _get_config()
     # Check if image exists
-    rc, stdout, _ = await _run(f'{_DOCKER} images -q {cfg["image"]}')
+    rc, stdout, _ = await _run(f"{_DOCKER} images -q {cfg['image']}")
     if rc == 0 and stdout.strip():
         logger.debug("Utility image {} already exists", cfg["image"])
         return True
@@ -104,10 +102,10 @@ async def start_container() -> bool:
             logger.warning("Mount source does not exist, skipping: {}", expanded)
 
     # Remove old stopped container if exists
-    await _run(f'{_DOCKER} rm -f {cfg["name"]}')
+    await _run(f"{_DOCKER} rm -f {cfg['name']}")
 
     # Start container
-    cmd = f'{_DOCKER} run -d --name {cfg["name"]}{mount_args} {cfg["image"]}'
+    cmd = f"{_DOCKER} run -d --name {cfg['name']}{mount_args} {cfg['image']}"
     logger.info("Starting utility container: {}", cmd)
     rc, stdout, stderr = await _run(cmd, timeout=60)
     if rc != 0:
@@ -121,11 +119,11 @@ async def start_container() -> bool:
 async def stop_container() -> bool:
     """Stop the utility container."""
     cfg = _get_config()
-    rc, _, stderr = await _run(f'{_DOCKER} stop {cfg["name"]}')
+    rc, _, stderr = await _run(f"{_DOCKER} stop {cfg['name']}")
     if rc != 0:
         logger.warning("Failed to stop utility container: {}", stderr)
         return False
-    await _run(f'{_DOCKER} rm {cfg["name"]}')
+    await _run(f"{_DOCKER} rm {cfg['name']}")
     logger.info("Utility container '{}' stopped", cfg["name"])
     return True
 
@@ -140,7 +138,7 @@ async def exec_in_util(cmd: str, timeout: float = 60) -> tuple[int, str]:
     if not await is_util_running():
         raise RuntimeError(f"Utility container '{cfg['name']}' is not running")
 
-    full_cmd = f'{_DOCKER} exec {cfg["name"]} {cmd}'
+    full_cmd = f"{_DOCKER} exec {cfg['name']} {cmd}"
     logger.debug("exec_in_util: {}", cmd)
     rc, stdout, stderr = await _run(full_cmd, timeout=timeout)
     if rc != 0:
@@ -161,7 +159,7 @@ async def exec_in_util_pty(cmd: str, timeout: float = 60) -> tuple[int, str]:
     if not await is_util_running():
         raise RuntimeError(f"Utility container '{cfg['name']}' is not running")
 
-    full_cmd = f'{_DOCKER} exec -it {cfg["name"]} {cmd}'
+    full_cmd = f"{_DOCKER} exec -it {cfg['name']} {cmd}"
     logger.debug("exec_in_util_pty: {}", cmd)
 
     loop = asyncio.get_event_loop()
@@ -183,7 +181,7 @@ async def exec_in_util_pty(cmd: str, timeout: float = 60) -> tuple[int, str]:
                         output.append(data.decode("utf-8", errors="replace"))
                         # Early exit: if we see a complete JSON object, we're done
                         combined = "".join(output)
-                        if '{\n' in combined and combined.rstrip().endswith('}'):
+                        if "{\n" in combined and combined.rstrip().endswith("}"):
                             logger.debug("exec_in_util_pty: detected complete JSON, exiting early")
                             break
                 except EOFError:
@@ -218,4 +216,3 @@ async def ensure_util_container() -> bool:
         logger.info("Utility container auto_start disabled, skipping")
         return False
     return await start_container()
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,18 @@ test = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-aiohttp>=1.0",
+    "ruff>=0.4",
 ]
 
 [project.scripts]
 supreme-claudemander = "claude_rts.__main__:main"
 
+[tool.setuptools.packages.find]
+include = ["claude_rts*"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 """Tests for config module and API endpoints."""
 
-import json
 from unittest.mock import patch
 
 import pytest
@@ -28,10 +27,12 @@ def config_dir(tmp_path):
     cfg_file = cfg_dir / "config.json"
     canvases_dir = cfg_dir / "canvases"
     legacy_dir = tmp_path / ".claude-rts-nonexistent"
-    with patch("claude_rts.config.CONFIG_DIR", cfg_dir), \
-         patch("claude_rts.config.CONFIG_FILE", cfg_file), \
-         patch("claude_rts.config.CANVASES_DIR", canvases_dir), \
-         patch("claude_rts.config._LEGACY_CONFIG_DIR", legacy_dir):
+    with (
+        patch("claude_rts.config.CONFIG_DIR", cfg_dir),
+        patch("claude_rts.config.CONFIG_FILE", cfg_file),
+        patch("claude_rts.config.CANVASES_DIR", canvases_dir),
+        patch("claude_rts.config._LEGACY_CONFIG_DIR", legacy_dir),
+    ):
         yield cfg_dir, cfg_file, canvases_dir
 
 
@@ -166,7 +167,7 @@ async def test_put_config_invalid_json(client, config_dir):
     assert resp.status == 400
 
 
-async def test_list_canvases_empty(client, config_dir):
+async def test_list_canvases_empty_api(client, config_dir):
     resp = await client.get("/api/canvases")
     assert resp.status == 200
     data = await resp.json()
@@ -252,7 +253,7 @@ async def test_delete_main_canvas_forbidden(client, config_dir):
 
 
 async def test_app_has_config_and_canvas_routes(app):
-    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
+    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, "resource")]
     assert "/api/config" in routes
     assert "/api/canvases" in routes
     assert "/api/canvases/{name}" in routes

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,7 +1,6 @@
 """Tests for hub discovery."""
 
-import asyncio
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -23,8 +22,7 @@ async def test_discover_hubs_parses_docker_output():
         b"cool_ramanujan|d:\\containers\\hub_3\n"
         b"suspicious_lichterman|d:\\containers\\hub_2\n"
     )
-    with patch("claude_rts.discovery.asyncio.create_subprocess_exec",
-               return_value=_mock_process(stdout)):
+    with patch("claude_rts.discovery.asyncio.create_subprocess_exec", return_value=_mock_process(stdout)):
         hubs = await discover_hubs()
 
     assert len(hubs) == 3
@@ -37,8 +35,7 @@ async def test_discover_hubs_parses_docker_output():
 @pytest.mark.asyncio
 async def test_discover_hubs_handles_forward_slashes():
     stdout = b"my_container|/mnt/d/containers/hub_5\n"
-    with patch("claude_rts.discovery.asyncio.create_subprocess_exec",
-               return_value=_mock_process(stdout)):
+    with patch("claude_rts.discovery.asyncio.create_subprocess_exec", return_value=_mock_process(stdout)):
         hubs = await discover_hubs()
 
     assert len(hubs) == 1
@@ -47,8 +44,7 @@ async def test_discover_hubs_handles_forward_slashes():
 
 @pytest.mark.asyncio
 async def test_discover_hubs_returns_empty_on_docker_failure():
-    with patch("claude_rts.discovery.asyncio.create_subprocess_exec",
-               return_value=_mock_process(b"", returncode=1)):
+    with patch("claude_rts.discovery.asyncio.create_subprocess_exec", return_value=_mock_process(b"", returncode=1)):
         hubs = await discover_hubs()
 
     assert hubs == []
@@ -56,8 +52,7 @@ async def test_discover_hubs_returns_empty_on_docker_failure():
 
 @pytest.mark.asyncio
 async def test_discover_hubs_returns_empty_on_no_containers():
-    with patch("claude_rts.discovery.asyncio.create_subprocess_exec",
-               return_value=_mock_process(b"")):
+    with patch("claude_rts.discovery.asyncio.create_subprocess_exec", return_value=_mock_process(b"")):
         hubs = await discover_hubs()
 
     assert hubs == []
@@ -65,14 +60,8 @@ async def test_discover_hubs_returns_empty_on_no_containers():
 
 @pytest.mark.asyncio
 async def test_discover_hubs_skips_malformed_lines():
-    stdout = (
-        b"good_container|d:\\containers\\hub_1\n"
-        b"bad_line_no_pipe\n"
-        b"|also_bad\n"
-        b"another_good|d:\\containers\\hub_2\n"
-    )
-    with patch("claude_rts.discovery.asyncio.create_subprocess_exec",
-               return_value=_mock_process(stdout)):
+    stdout = b"good_container|d:\\containers\\hub_1\nbad_line_no_pipe\n|also_bad\nanother_good|d:\\containers\\hub_2\n"
+    with patch("claude_rts.discovery.asyncio.create_subprocess_exec", return_value=_mock_process(stdout)):
         hubs = await discover_hubs()
 
     assert len(hubs) == 2
@@ -83,8 +72,7 @@ async def test_discover_hubs_skips_malformed_lines():
 @pytest.mark.asyncio
 async def test_discover_hubs_strips_whitespace():
     stdout = b"  spaced_container  |d:\\containers\\hub_1  \n"
-    with patch("claude_rts.discovery.asyncio.create_subprocess_exec",
-               return_value=_mock_process(stdout)):
+    with patch("claude_rts.discovery.asyncio.create_subprocess_exec", return_value=_mock_process(stdout)):
         hubs = await discover_hubs()
 
     assert len(hubs) == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,5 @@
 """Tests for CLI entry point."""
 
-import sys
 from unittest.mock import patch, MagicMock
 
 from claude_rts.__main__ import main
@@ -8,9 +7,11 @@ from claude_rts.__main__ import main
 
 def test_default_port():
     """Verify default port is 3000 when no args given."""
-    with patch("sys.argv", ["supreme-claudemander"]), \
-         patch("claude_rts.__main__.web") as mock_web, \
-         patch("claude_rts.__main__.create_app") as mock_create:
+    with (
+        patch("sys.argv", ["supreme-claudemander"]),
+        patch("claude_rts.__main__.web") as mock_web,
+        patch("claude_rts.__main__.create_app") as mock_create,
+    ):
         mock_create.return_value = MagicMock()
         try:
             main()
@@ -24,9 +25,11 @@ def test_default_port():
 
 def test_custom_port():
     """Verify --port flag is respected."""
-    with patch("sys.argv", ["supreme-claudemander", "--port", "4000"]), \
-         patch("claude_rts.__main__.web") as mock_web, \
-         patch("claude_rts.__main__.create_app") as mock_create:
+    with (
+        patch("sys.argv", ["supreme-claudemander", "--port", "4000"]),
+        patch("claude_rts.__main__.web") as mock_web,
+        patch("claude_rts.__main__.create_app") as mock_create,
+    ):
         mock_create.return_value = MagicMock()
         try:
             main()
@@ -38,9 +41,11 @@ def test_custom_port():
 
 def test_no_browser_flag():
     """Verify --no-browser skips browser open."""
-    with patch("sys.argv", ["supreme-claudemander", "--no-browser"]), \
-         patch("claude_rts.__main__.web") as mock_web, \
-         patch("claude_rts.__main__.create_app") as mock_create:
+    with (
+        patch("sys.argv", ["supreme-claudemander", "--no-browser"]),
+        patch("claude_rts.__main__.web") as _mock_web,
+        patch("claude_rts.__main__.create_app") as mock_create,
+    ):
         mock_app = MagicMock()
         mock_app.on_startup = []
         mock_create.return_value = mock_app
@@ -54,9 +59,11 @@ def test_no_browser_flag():
 
 def test_browser_opens_by_default():
     """Verify browser open callback is added by default."""
-    with patch("sys.argv", ["supreme-claudemander"]), \
-         patch("claude_rts.__main__.web") as mock_web, \
-         patch("claude_rts.__main__.create_app") as mock_create:
+    with (
+        patch("sys.argv", ["supreme-claudemander"]),
+        patch("claude_rts.__main__.web") as _mock_web,
+        patch("claude_rts.__main__.create_app") as mock_create,
+    ):
         mock_app = MagicMock()
         mock_app.on_startup = []
         mock_create.return_value = mock_app

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,11 +1,8 @@
 """Tests for the aiohttp server routes."""
 
-import json
 from unittest.mock import patch, AsyncMock
 
 import pytest
-from aiohttp import web
-from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 
 from claude_rts.server import create_app
 
@@ -35,8 +32,7 @@ async def test_index_returns_html(client):
 
 
 async def test_hubs_endpoint_returns_json(client):
-    with patch("claude_rts.server.discover_hubs", new_callable=AsyncMock,
-               return_value=MOCK_HUBS):
+    with patch("claude_rts.server.discover_hubs", new_callable=AsyncMock, return_value=MOCK_HUBS):
         resp = await client.get("/api/hubs")
 
     assert resp.status == 200
@@ -47,8 +43,7 @@ async def test_hubs_endpoint_returns_json(client):
 
 
 async def test_hubs_endpoint_empty(client):
-    with patch("claude_rts.server.discover_hubs", new_callable=AsyncMock,
-               return_value=[]):
+    with patch("claude_rts.server.discover_hubs", new_callable=AsyncMock, return_value=[]):
         resp = await client.get("/api/hubs")
 
     assert resp.status == 200
@@ -57,8 +52,7 @@ async def test_hubs_endpoint_empty(client):
 
 
 async def test_websocket_404_for_unknown_hub(client):
-    with patch("claude_rts.server.discover_hubs", new_callable=AsyncMock,
-               return_value=MOCK_HUBS):
+    with patch("claude_rts.server.discover_hubs", new_callable=AsyncMock, return_value=MOCK_HUBS):
         resp = await client.get("/ws/nonexistent_hub")
     assert resp.status == 404
 
@@ -87,7 +81,7 @@ async def test_widget_system_info_uptime_format(client):
 
 
 async def test_app_has_all_routes(app):
-    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
+    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, "resource")]
     assert "/" in routes
     assert "/api/hubs" in routes
     assert "/api/config" in routes

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,14 +1,11 @@
 """Tests for session persistence: ScrollbackBuffer, SessionManager, and session APIs."""
 
-import asyncio
-import json
 import time
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import patch, AsyncMock
 
 import pytest
-from aiohttp import web
 
-from claude_rts.sessions import ScrollbackBuffer, SessionManager, Session, _valid_container_name
+from claude_rts.sessions import ScrollbackBuffer, SessionManager, _valid_container_name
 from claude_rts.server import create_app
 
 
@@ -70,6 +67,7 @@ def test_scrollback_empty_append():
 
 class MockPty:
     """Mock PtyProcess for testing."""
+
     def __init__(self):
         self._alive = True
         self._output_queue = []
@@ -313,7 +311,7 @@ async def test_test_mode_disabled():
     """Test API should NOT be available when test_mode=False."""
     with patch("claude_rts.sessions.PtyProcess", MockPty):
         app = create_app(test_mode=False)
-    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
+    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, "resource")]
     assert "/api/test/sessions" not in routes
     assert "/api/test/session/{id}/read" not in routes
 
@@ -322,7 +320,7 @@ async def test_app_has_session_routes():
     """Verify session WebSocket routes are registered."""
     with patch("claude_rts.sessions.PtyProcess", MockPty):
         app = create_app(test_mode=False)
-    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, 'resource')]
+    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, "resource")]
     assert "/ws/session/new" in routes
     assert "/ws/session/{session_id}" in routes
     assert "/api/sessions" in routes
@@ -443,7 +441,7 @@ async def test_tmux_disabled_via_config(monkeypatch):
     try:
         mgr = SessionManager(tmux_enabled=False)
         mgr._tmux_cache["my-container"] = True
-        session = mgr.create_session("bash -l", container="my-container")
+        mgr.create_session("bash -l", container="my-container")
         # Should use original command, not tmux
         assert spawned_cmds[-1] == "bash -l"
         mgr.stop_all()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,6 +1,5 @@
 """Tests for the startup module and API endpoint."""
 
-import json
 from unittest.mock import patch, AsyncMock
 
 import pytest
@@ -46,6 +45,7 @@ async def test_custom_script_not_found(tmp_path):
 @pytest.fixture
 def app():
     from claude_rts.server import create_app
+
     return create_app()
 
 
@@ -56,8 +56,10 @@ async def client(aiohttp_client, app):
 
 async def test_startup_api_success(client):
     mock_hubs = [{"hub": "hub_1", "container": "c1"}]
-    with patch("claude_rts.startup.discover_hubs", new_callable=AsyncMock, return_value=mock_hubs), \
-         patch("claude_rts.server.read_config", return_value={"startup_script": "discover-devcontainers"}):
+    with (
+        patch("claude_rts.startup.discover_hubs", new_callable=AsyncMock, return_value=mock_hubs),
+        patch("claude_rts.server.read_config", return_value={"startup_script": "discover-devcontainers"}),
+    ):
         resp = await client.get("/api/startup")
 
     assert resp.status == 200
@@ -79,8 +81,10 @@ async def test_startup_api_from_layout(client):
 
 
 async def test_startup_api_error_returns_500(client):
-    with patch("claude_rts.server.read_config", return_value={"startup_script": "nonexistent"}), \
-         patch("claude_rts.startup.STARTUP_DIR", __import__("pathlib").Path("/tmp/empty_startup_dir_1234")):
+    with (
+        patch("claude_rts.server.read_config", return_value={"startup_script": "nonexistent"}),
+        patch("claude_rts.startup.STARTUP_DIR", __import__("pathlib").Path("/tmp/empty_startup_dir_1234")),
+    ):
         resp = await client.get("/api/startup")
 
     assert resp.status == 500


### PR DESCRIPTION
Closes #70

## What changed

The repository had no CI whatsoever. This PR adds a GitHub Actions workflow that runs on every push and PR to `main`, enforcing ruff linting/formatting and the full pytest suite. It also fixes all pre-existing ruff violations in the codebase so CI passes immediately on merge.

## Implementation walkthrough

### `.github/workflows/ci.yml`

Two parallel jobs:

- **`lint`** — installs only `ruff`, runs `ruff check .` then `ruff format --check .`. Fast (~10s). Catches unused imports, style violations, and formatting drift.
- **`test`** — installs the package with `pip install -e ".[test]"`, runs `python -m pytest tests/ -v`. All 78 tests use `MockPty` and do not require Docker.

Both jobs run on `ubuntu-latest` with Python 3.12.

### `pyproject.toml` changes

- Added `ruff>=0.4` to the `test` optional-dependencies group (CI uses `.[test]` for the test job; lint job installs ruff directly for speed).
- Added `[tool.ruff]` section: `target-version = "py310"`, `line-length = 120`.
- Added `[tool.setuptools.packages.find]` with `include = ["claude_rts*"]` to prevent setuptools from picking up the untracked `qa/` directory in local dev environments.

### Pre-existing ruff violations fixed

To make CI green on first run, all existing violations were cleaned up:
- **F401** — removed unused imports across all source and test files (auto-fixed)
- **E402** — added `# noqa: E402` to `server.py` and `util_container.py` where module-level code (e.g. `_start_time = time.monotonic()`) legitimately precedes imports
- **F811** — renamed `test_list_canvases_empty` → `test_list_canvases_empty_api` in `test_config.py` (was a duplicate sync/async pair)
- **F841** — replaced `mock_web` with `_mock_web` in test_main.py; removed unused `session` assignment in test_sessions.py
- **Formatting** — ran `ruff format` across all 13 files that needed reformatting

### Branch protection (post-merge, manual step)

After this PR merges and the CI workflow has run at least once, enable branch protection on `main` via GitHub settings or:

```bash
gh api repos/hyang0129/supreme-claudemander/branches/main/protection \
  --method PUT \
  --field 'required_status_checks={"strict":true,"contexts":["lint","test"]}' \
  --field enforce_admins=true \
  --field 'required_pull_request_reviews={"required_approving_review_count":1}' \
  --field restrictions=null
```

`enforce_admins=true` ensures administrators cannot bypass protections.

## Tier / approach

Tier 1 — Planner → Coder → Reviewer

## Acceptance criteria

- [x] `.github/workflows/ci.yml` exists with lint + test jobs
- [x] Workflow triggers on push to main and PRs targeting main
- [x] `ruff` is in `pyproject.toml` optional dependencies
- [x] All 78 tests pass locally with the new config
- [ ] Branch protection configured (post-merge manual step — see above)

## Outstanding items

- Ruff version in lint job is unpinned (`pip install ruff`); pyproject.toml constrains `>=0.4`. Could pin to a specific version if stricter reproducibility is needed.
- CI only tests Python 3.12; could add a matrix for 3.10 (minimum supported) later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)