### PR TITLE
feat(#72): credential manager with burn rate, priority, and probe subscription

### DIFF
--- a/claude_rts/cred_store.py
+++ b/claude_rts/cred_store.py
@@ -1,0 +1,231 @@
+"""File-based persistence for Claude API credentials (module: cred_store).
+
+Credentials file: ~/.supreme-claudemander/credentials.json
+"""
+
+import json
+import threading
+import uuid
+
+from loguru import logger
+
+from claude_rts.config import CONFIG_DIR, ensure_dirs
+
+CREDENTIALS_FILE = CONFIG_DIR / "credentials.json"
+DEFAULT_CREDENTIALS: dict = {"priority": None, "credentials": []}
+
+# Protects all read-modify-write sequences on the credentials file.
+_lock = threading.Lock()
+
+_USAGE_FIELDS = (
+    "five_hour_pct",
+    "burn_rate",
+    "five_hour_resets",
+    "seven_day_pct",
+    "usage_7d",
+    "quota",
+    "refresh_at",
+)
+
+
+# ── Persistence ─────────────────────────────────────────
+
+
+def read_credentials() -> dict:
+    """Read credentials from disk, returning defaults if missing or corrupt."""
+    if CREDENTIALS_FILE.exists():
+        try:
+            data = json.loads(CREDENTIALS_FILE.read_text(encoding="utf-8"))
+            logger.debug("Loaded credentials from {}", CREDENTIALS_FILE)
+            return data
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to read credentials, using defaults: {}", exc)
+    return {**DEFAULT_CREDENTIALS, "credentials": []}
+
+
+def write_credentials(data: dict) -> dict:
+    """Write credentials to disk. Returns the written data."""
+    ensure_dirs()
+    CREDENTIALS_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    logger.info("Wrote credentials to {}", CREDENTIALS_FILE)
+    return data
+
+
+# ── Key masking ─────────────────────────────────────────
+
+
+def mask_key(key: str) -> str:
+    """Return a masked representation of an API key.
+
+    - None or empty  → ""
+    - len <= 11      → "sk-ant-...xxxx"  (fully masked)
+    - else           → first 7 chars + "..." + last 4 chars
+    """
+    if not key:
+        return ""
+    if len(key) <= 11:
+        return "sk-ant-...xxxx"
+    return key[:7] + "..." + key[-4:]
+
+
+# ── Internal helpers ─────────────────────────────────────
+
+
+def _mask_credential(cred: dict) -> dict:
+    """Return a copy of cred with the raw 'key' field removed."""
+    return {k: v for k, v in cred.items() if k != "key"}
+
+
+# ── CRUD ────────────────────────────────────────────────
+
+
+def add_credential(label: str, key: str, profile: str | None = None) -> dict:
+    """Add a new credential record.
+
+    Validates label and key are non-empty, generates a unique id, appends to
+    the credentials list, persists to disk, and returns the record WITHOUT the
+    raw key field.
+    """
+    if not label or not isinstance(label, str):
+        raise ValueError("label must be a non-empty string")
+    if not key or not isinstance(key, str):
+        raise ValueError("key must be a non-empty string")
+
+    cred_id = f"cred-{uuid.uuid4().hex[:8]}"
+    record: dict = {
+        "id": cred_id,
+        "label": label,
+        "profile": profile,
+        "key": key,
+        "key_hint": mask_key(key),
+        "usage_7d": 0,
+        "quota": None,
+        "refresh_at": None,
+        "five_hour_pct": None,
+        "burn_rate": None,
+        "five_hour_resets": None,
+        "seven_day_pct": None,
+    }
+
+    with _lock:
+        data = read_credentials()
+        data["credentials"].append(record)
+        write_credentials(data)
+    logger.info("Added credential '{}' (id={})", label, cred_id)
+
+    return _mask_credential(record)
+
+
+def delete_credential(cred_id: str) -> bool:
+    """Delete a credential by id. Clears priority if it matched.
+
+    Returns True if found and deleted, False otherwise.
+    """
+    with _lock:
+        data = read_credentials()
+        original_len = len(data["credentials"])
+        data["credentials"] = [c for c in data["credentials"] if c["id"] != cred_id]
+
+        if len(data["credentials"]) == original_len:
+            logger.debug("delete_credential: id={} not found", cred_id)
+            return False
+
+        if data.get("priority") == cred_id:
+            data["priority"] = None
+            logger.debug("Cleared priority because credential {} was deleted", cred_id)
+
+        write_credentials(data)
+
+    logger.info("Deleted credential id={}", cred_id)
+    return True
+
+
+def set_priority(cred_id: str) -> bool:
+    """Set the priority credential by id.
+
+    Returns True if the id exists and priority was set, False otherwise.
+    """
+    with _lock:
+        data = read_credentials()
+        ids = {c["id"] for c in data["credentials"]}
+        if cred_id not in ids:
+            logger.debug("set_priority: id={} not found", cred_id)
+            return False
+
+        data["priority"] = cred_id
+        write_credentials(data)
+
+    logger.info("Set priority credential to id={}", cred_id)
+    return True
+
+
+def get_priority() -> dict | None:
+    """Return the priority credential (masked, no raw key), or None."""
+    data = read_credentials()
+    priority_id = data.get("priority")
+    if not priority_id:
+        return None
+
+    for cred in data["credentials"]:
+        if cred["id"] == priority_id:
+            return _mask_credential(cred)
+
+    logger.debug("get_priority: priority id={} not found in credentials list", priority_id)
+    return None
+
+
+def update_credential_usage(cred_id: str, usage_data: dict) -> bool:
+    """Merge usage fields from usage_data into the credential record.
+
+    Accepted fields: five_hour_pct, burn_rate, five_hour_resets, seven_day_pct,
+    usage_7d, quota, refresh_at.
+
+    Returns True if found and updated, False otherwise.
+    """
+    with _lock:
+        data = read_credentials()
+        for cred in data["credentials"]:
+            if cred["id"] == cred_id:
+                for field in _USAGE_FIELDS:
+                    if field in usage_data:
+                        cred[field] = usage_data[field]
+                write_credentials(data)
+                logger.debug("Updated usage for credential id={}", cred_id)
+                return True
+
+    logger.debug("update_credential_usage: id={} not found", cred_id)
+    return False
+
+
+def _rank_from_data(data: dict) -> list[dict]:
+    """Build ranked credential list from an already-loaded data dict (no file I/O)."""
+    priority_id = data.get("priority")
+
+    def _sort_key(cred: dict):
+        br = cred.get("burn_rate")
+        return (1, 0) if br is None else (0, br)
+
+    ranked = sorted(data["credentials"], key=_sort_key)
+    result = []
+    for cred in ranked:
+        masked = _mask_credential(cred)
+        masked["is_priority"] = cred["id"] == priority_id
+        result.append(masked)
+    return result
+
+
+def list_credentials_ranked() -> list[dict]:
+    """Return all credentials sorted by ascending burn_rate (None values last).
+
+    Each record has the raw key removed and an 'is_priority' boolean added.
+    """
+    return _rank_from_data(read_credentials())
+
+
+def get_credentials_response() -> dict:
+    """Return priority id + ranked list in a single file read.
+
+    Used by the list API handler to avoid two separate reads that could diverge.
+    """
+    data = read_credentials()
+    return {"priority": data.get("priority"), "credentials": _rank_from_data(data)}

--- a/claude_rts/cred_store.py
+++ b/claude_rts/cred_store.py
@@ -15,7 +15,7 @@ CREDENTIALS_FILE = CONFIG_DIR / "credentials.json"
 DEFAULT_CREDENTIALS: dict = {"priority": None, "credentials": []}
 
 # Protects all read-modify-write sequences on the credentials file.
-_lock = threading.Lock()
+_lock = threading.RLock()
 
 _USAGE_FIELDS = (
     "five_hour_pct",
@@ -33,14 +33,15 @@ _USAGE_FIELDS = (
 
 def read_credentials() -> dict:
     """Read credentials from disk, returning defaults if missing or corrupt."""
-    if CREDENTIALS_FILE.exists():
-        try:
-            data = json.loads(CREDENTIALS_FILE.read_text(encoding="utf-8"))
-            logger.debug("Loaded credentials from {}", CREDENTIALS_FILE)
-            return data
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("Failed to read credentials, using defaults: {}", exc)
-    return {**DEFAULT_CREDENTIALS, "credentials": []}
+    with _lock:
+        if CREDENTIALS_FILE.exists():
+            try:
+                data = json.loads(CREDENTIALS_FILE.read_text(encoding="utf-8"))
+                logger.debug("Loaded credentials from {}", CREDENTIALS_FILE)
+                return data
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Failed to read credentials, using defaults: {}", exc)
+        return {**DEFAULT_CREDENTIALS, "credentials": []}
 
 
 def write_credentials(data: dict) -> dict:
@@ -194,6 +195,32 @@ def update_credential_usage(cred_id: str, usage_data: dict) -> bool:
                 return True
 
     logger.debug("update_credential_usage: id={} not found", cred_id)
+    return False
+
+
+def update_usage_by_profile(profile_name: str, usage_data: dict) -> bool:
+    """Atomically look up a credential by profile name and update its usage stats.
+
+    Combines the profile→id lookup and the usage update under a single lock
+    acquisition to avoid TOCTOU races.
+
+    Returns True if a matching credential was found and updated, False otherwise.
+    """
+    with _lock:
+        data = read_credentials()
+        for cred in data.get("credentials", []):
+            if cred.get("profile") == profile_name:
+                for field in _USAGE_FIELDS:
+                    if field in usage_data:
+                        cred[field] = usage_data[field]
+                write_credentials(data)
+                logger.debug(
+                    "Updated usage for credential with profile={}", profile_name
+                )
+                return True
+    logger.debug(
+        "update_usage_by_profile: no credential with profile={}", profile_name
+    )
     return False
 
 

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -19,6 +19,7 @@ from .startup import run_startup  # noqa: E402
 from .util_container import ensure_util_container  # noqa: E402
 from .sessions import SessionManager  # noqa: E402
 from .cards import ServiceCardRegistry, ClaudeUsageCard  # noqa: E402
+from claude_rts import cred_store  # noqa: E402
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
@@ -448,6 +449,81 @@ async def test_sessions_list(request: web.Request) -> web.Response:
     return web.json_response(mgr.list_sessions())
 
 
+async def credentials_list_handler(request: web.Request) -> web.Response:
+    """GET /api/credentials — list credentials ranked by burn rate."""
+    return web.json_response(cred_store.get_credentials_response())
+
+
+async def credentials_add_handler(request: web.Request) -> web.Response:
+    """POST /api/credentials — add a new credential."""
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    label = body.get("label", "").strip()
+    key = body.get("key", "").strip()
+    profile = body.get("profile") or None
+
+    if not label or not key:
+        return web.json_response({"error": "label and key are required"}, status=400)
+
+    try:
+        cred = cred_store.add_credential(label, key, profile)
+    except ValueError as e:
+        return web.json_response({"error": str(e)}, status=400)
+
+    return web.json_response(cred, status=201)
+
+
+async def credentials_delete_handler(request: web.Request) -> web.Response:
+    """DELETE /api/credentials/{id} — remove a credential."""
+    cred_id = request.match_info["id"]
+    found = cred_store.delete_credential(cred_id)
+    if not found:
+        return web.json_response({"error": "not found"}, status=404)
+    return web.json_response({"deleted": cred_id})
+
+
+async def credentials_priority_get_handler(request: web.Request) -> web.Response:
+    """GET /api/credentials/priority — return the priority credential."""
+    cred = cred_store.get_priority()
+    if cred is None:
+        return web.json_response({"error": "no priority credential set"}, status=404)
+    return web.json_response(cred)
+
+
+async def credentials_priority_set_handler(request: web.Request) -> web.Response:
+    """PUT /api/credentials/priority — set the priority credential."""
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    cred_id = body.get("id", "").strip()
+    if not cred_id:
+        return web.json_response({"error": "id is required"}, status=400)
+
+    found = cred_store.set_priority(cred_id)
+    if not found:
+        return web.json_response({"error": "credential not found"}, status=404)
+    return web.json_response({"priority": cred_id})
+
+
+async def credentials_usage_update_handler(request: web.Request) -> web.Response:
+    """PUT /api/credentials/{id}/usage — update usage stats for a credential."""
+    cred_id = request.match_info["id"]
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    found = cred_store.update_credential_usage(cred_id, body)
+    if not found:
+        return web.json_response({"error": "credential not found"}, status=404)
+    return web.json_response({"updated": cred_id})
+
+
 def create_app(test_mode: bool = False) -> web.Application:
     app = web.Application()
     app["test_mode"] = test_mode
@@ -463,6 +539,14 @@ def create_app(test_mode: bool = False) -> web.Application:
     app.router.add_put("/api/canvases/{name}", canvas_put_handler)
     app.router.add_delete("/api/canvases/{name}", canvas_delete_handler)
     app.router.add_get("/api/widgets/system-info", widget_system_info_handler)
+
+    # Credential routes (priority routes must be before {id} wildcard routes)
+    app.router.add_get("/api/credentials", credentials_list_handler)
+    app.router.add_post("/api/credentials", credentials_add_handler)
+    app.router.add_get("/api/credentials/priority", credentials_priority_get_handler)
+    app.router.add_put("/api/credentials/priority", credentials_priority_set_handler)
+    app.router.add_delete("/api/credentials/{id}", credentials_delete_handler)
+    app.router.add_put("/api/credentials/{id}/usage", credentials_usage_update_handler)
 
     # Session routes (must be before /ws/{hub} catch-all)
     app.router.add_get("/api/sessions", sessions_list_handler)
@@ -519,6 +603,15 @@ def create_app(test_mode: bool = False) -> web.Application:
         util_cfg = config.get("util_container", {})
         util_name = util_cfg.get("name", "supreme-claudemander-util")
         probe_interval = config.get("probe_interval", 1800)
+
+        def _update_cred_usage(profile_name: str, result: dict) -> None:
+            """Update credential usage stats from a service card probe result."""
+            data = cred_store.read_credentials()
+            for cred in data.get("credentials", []):
+                if cred.get("profile") == profile_name:
+                    cred_store.update_credential_usage(cred["id"], result)
+                    break
+
         for profile in config.get("probe_profiles", []):
 
             def _log_usage(result, _p=profile):
@@ -530,11 +623,18 @@ def create_app(test_mode: bool = False) -> web.Application:
                     result.get("five_hour_resets"),
                 )
 
+            def _usage_callback(result, _p=profile):
+                _update_cred_usage(_p, result)
+
+            def _combined_callback(result, _log=_log_usage, _usage=_usage_callback):
+                _log(result)
+                _usage(result)
+
             try:
                 await registry.subscribe(
                     "claude-usage",
                     profile,
-                    _log_usage,
+                    _combined_callback,
                     container=util_name,
                     interval_seconds=probe_interval,
                 )

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -449,6 +449,9 @@ async def test_sessions_list(request: web.Request) -> web.Response:
     return web.json_response(mgr.list_sessions())
 
 
+# Note: credential handlers return JSON error bodies {"error": "..."} rather than
+# raising HTTPBadRequest with plain text (the pattern used by config/canvas handlers).
+# This is intentional — clients parsing credential errors expect JSON.
 async def credentials_list_handler(request: web.Request) -> web.Response:
     """GET /api/credentials — list credentials ranked by burn rate."""
     return web.json_response(cred_store.get_credentials_response())
@@ -606,11 +609,7 @@ def create_app(test_mode: bool = False) -> web.Application:
 
         def _update_cred_usage(profile_name: str, result: dict) -> None:
             """Update credential usage stats from a service card probe result."""
-            data = cred_store.read_credentials()
-            for cred in data.get("credentials", []):
-                if cred.get("profile") == profile_name:
-                    cred_store.update_credential_usage(cred["id"], result)
-                    break
+            cred_store.update_usage_by_profile(profile_name, result)
 
         for profile in config.get("probe_profiles", []):
 

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -419,6 +419,126 @@
   .usage-status { color: #585b70; font-size: 11px; text-align: center; padding: 8px 0; }
 
 
+  /* ── Credential Manager widget ── */
+  .cred-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 10px;
+  }
+  .cred-empty {
+    color: #585b70;
+    font-size: 12px;
+    padding: 8px 0;
+    text-align: center;
+  }
+  .cred-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 6px;
+    border-radius: 4px;
+    background: #181825;
+    border: 1px solid #313244;
+    font-size: 12px;
+  }
+  .cred-row.cred-priority {
+    border-color: #f9e2af;
+    background: rgba(249, 226, 175, 0.06);
+  }
+  .cred-label {
+    font-weight: 600;
+    color: #cdd6f4;
+    min-width: 70px;
+    flex-shrink: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .cred-hint {
+    color: #585b70;
+    font-family: monospace;
+    font-size: 11px;
+    min-width: 60px;
+    flex-shrink: 0;
+  }
+  .cred-burn-bar {
+    flex: 1;
+    height: 6px;
+    background: #313244;
+    border-radius: 3px;
+    overflow: hidden;
+    min-width: 40px;
+  }
+  .cred-burn-fill {
+    height: 100%;
+    background: #a6e3a1;
+    border-radius: 3px;
+    transition: width 0.3s ease;
+  }
+  .cred-burn-pct {
+    color: #a6adc8;
+    font-family: monospace;
+    font-size: 11px;
+    min-width: 32px;
+    text-align: right;
+    flex-shrink: 0;
+  }
+  .cred-reset {
+    color: #585b70;
+    font-size: 11px;
+    min-width: 48px;
+    flex-shrink: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .cred-btn-priority, .cred-btn-delete {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 13px;
+    padding: 0 2px;
+    border-radius: 3px;
+    flex-shrink: 0;
+    line-height: 1;
+  }
+  .cred-btn-priority { color: #a6adc8; }
+  .cred-btn-priority:hover { color: #f9e2af; }
+  .cred-row.cred-priority .cred-btn-priority { color: #f9e2af; }
+  .cred-btn-delete { color: #585b70; }
+  .cred-btn-delete:hover { color: #f38ba8; }
+  .cred-add-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding-top: 8px;
+    border-top: 1px solid #313244;
+    margin-top: 4px;
+  }
+  .cred-add-form input {
+    background: #181825;
+    border: 1px solid #45475a;
+    color: #cdd6f4;
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 12px;
+    flex: 1;
+    min-width: 80px;
+  }
+  .cred-add-form input:focus { outline: 1px solid #cba6f7; }
+  .cred-add-form button {
+    background: #313244;
+    border: 1px solid #45475a;
+    color: #cdd6f4;
+    border-radius: 4px;
+    padding: 4px 12px;
+    font-size: 12px;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .cred-add-form button:hover { background: #45475a; }
+
   /* ── Control group badge ── */
   .control-group-badge {
     font-size: 10px;
@@ -1385,6 +1505,13 @@ class LoaderCard {
 }
 
 // ════════════════════════════════════════════
+// Utility helpers
+// ════════════════════════════════════════════
+function escapeHtml(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// ════════════════════════════════════════════
 // Widget registry
 // ════════════════════════════════════════════
 const WIDGET_REGISTRY = {
@@ -1411,6 +1538,107 @@ const WIDGET_REGISTRY = {
         card.updateState('working');
       } catch (err) {
         body.innerHTML = `<div class="widget-row"><span class="widget-label" style="color:#f38ba8">Error: ${err.message}</span></div>`;
+        card.updateState('dead');
+      }
+    },
+  },
+  'credential-manager': {
+    label: 'Credential Manager',
+    defaultRefreshInterval: 15000,
+    async render(body, card) {
+      try {
+        const resp = await fetch('/api/credentials');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        const creds = data.credentials || [];
+        const priorityId = data.priority;
+
+        let html = '<div class="cred-list">';
+
+        if (creds.length === 0) {
+          html += '<div class="cred-empty">No credentials stored. Add one below.</div>';
+        }
+
+        for (const c of creds) {
+          const isPriority = c.id === priorityId;
+          const burnPct = c.five_hour_pct != null ? Math.min(100, Math.round(c.five_hour_pct)) : null;
+          const burnDisplay = burnPct != null ? `${burnPct}%` : '—';
+          const resetDisplay = c.five_hour_resets || '—';
+          const priorityClass = isPriority ? ' cred-priority' : '';
+
+          html += `
+            <div class="cred-row${priorityClass}" data-id="${escapeHtml(String(c.id))}">
+              <div class="cred-label">${escapeHtml(c.label)}</div>
+              <div class="cred-hint">${escapeHtml(c.key_hint || '')}</div>
+              <div class="cred-burn-bar"><div class="cred-burn-fill" style="width:${burnPct ?? 0}%"></div></div>
+              <div class="cred-burn-pct">${burnDisplay}</div>
+              <div class="cred-reset">${escapeHtml(resetDisplay)}</div>
+              <button class="cred-btn-priority" data-id="${escapeHtml(String(c.id))}">${isPriority ? '★' : '☆'}</button>
+              <button class="cred-btn-delete" data-id="${escapeHtml(String(c.id))}">✕</button>
+            </div>`;
+        }
+
+        html += `</div>
+          <form class="cred-add-form" id="cred-add-form-${card.id}">
+            <input type="text" name="label" placeholder="Label" required />
+            <input type="password" name="key" placeholder="API Key" required />
+            <input type="text" name="profile" placeholder="Profile (optional)" />
+            <button type="submit">Add</button>
+          </form>`;
+
+        body.innerHTML = html;
+
+        // Wire up delete buttons
+        body.querySelectorAll('.cred-btn-delete').forEach(btn => {
+          btn.addEventListener('click', async () => {
+            const id = btn.dataset.id;
+            await fetch(`/api/credentials/${encodeURIComponent(id)}`, { method: 'DELETE' });
+            card.render();
+          });
+        });
+
+        // Wire up priority buttons
+        body.querySelectorAll('.cred-btn-priority').forEach(btn => {
+          btn.addEventListener('click', async () => {
+            const id = btn.dataset.id;
+            await fetch('/api/credentials/priority', {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ id }),
+            });
+            card.render();
+          });
+        });
+
+        // Wire up add form
+        const form = body.querySelector(`#cred-add-form-${card.id}`);
+        if (form) {
+          form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const fd = new FormData(form);
+            const payload = {
+              label: fd.get('label'),
+              key: fd.get('key'),
+              profile: fd.get('profile') || null,
+            };
+            const r = await fetch('/api/credentials', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+            if (r.ok) {
+              form.reset();
+              card.render();
+            } else {
+              const err = await r.json();
+              alert(`Error: ${err.error || 'Failed to add credential'}`);
+            }
+          });
+        }
+
+        card.updateState('working');
+      } catch (err) {
+        body.innerHTML = `<div class="widget-error">Error: ${escapeHtml(err.message)}</div>`;
         card.updateState('dead');
       }
     },

--- a/tests/test_cred_store.py
+++ b/tests/test_cred_store.py
@@ -1,0 +1,225 @@
+"""Tests for the cred_store module."""
+
+import pytest
+from unittest.mock import patch
+
+from claude_rts.cred_store import (
+    read_credentials,
+    write_credentials,
+    mask_key,
+    add_credential,
+    delete_credential,
+    set_priority,
+    get_priority,
+    update_credential_usage,
+    list_credentials_ranked,
+)
+
+
+@pytest.fixture
+def creds_file(tmp_path):
+    cred_path = tmp_path / "credentials.json"
+    with patch("claude_rts.cred_store.CREDENTIALS_FILE", cred_path):
+        yield cred_path
+
+
+# ── read_credentials ────────────────────────────────────────────────────────
+
+
+def test_read_credentials_default_when_missing(creds_file):
+    """Returns default structure when file doesn't exist."""
+    data = read_credentials()
+    assert data == {"priority": None, "credentials": []}
+
+
+def test_write_and_read_round_trip(creds_file):
+    """Write then read back produces identical data."""
+    payload = {"priority": "cred-abc", "credentials": [{"id": "cred-abc", "label": "test"}]}
+    write_credentials(payload)
+    result = read_credentials()
+    assert result == payload
+
+
+# ── mask_key ────────────────────────────────────────────────────────────────
+
+
+def test_mask_key_long(creds_file):
+    """Long key returns first 7 chars + '...' + last 4 chars."""
+    key = "sk-ant-api03-ABCDEFGHIJK1234"
+    result = mask_key(key)
+    assert result == key[:7] + "..." + key[-4:]
+
+
+def test_mask_key_short(creds_file):
+    """Short key (<=11 chars) returns a masked string without original content."""
+    key = "shortkey"
+    result = mask_key(key)
+    assert key not in result
+    assert result != ""
+
+
+def test_mask_key_empty(creds_file):
+    """mask_key('') returns ''."""
+    assert mask_key("") == ""
+
+
+def test_mask_key_none(creds_file):
+    """mask_key(None) returns ''."""
+    assert mask_key(None) == ""
+
+
+# ── add_credential ──────────────────────────────────────────────────────────
+
+
+def test_add_credential_returns_no_raw_key(creds_file):
+    """add_credential return value does not expose the raw key field."""
+    result = add_credential("My Label", "sk-ant-api03-supersecretkeyvalue")
+    assert "key" not in result
+
+
+def test_add_credential_has_key_hint(creds_file):
+    """add_credential return value contains key_hint field."""
+    result = add_credential("My Label", "sk-ant-api03-supersecretkeyvalue")
+    assert "key_hint" in result
+    assert result["key_hint"] != ""
+
+
+def test_add_credential_raises_on_empty_label(creds_file):
+    """add_credential raises ValueError for empty label."""
+    with pytest.raises(ValueError, match="label"):
+        add_credential("", "sk-ant-api03-somevalidkey")
+
+
+def test_add_credential_raises_on_empty_key(creds_file):
+    """add_credential raises ValueError for empty key."""
+    with pytest.raises(ValueError, match="key"):
+        add_credential("Valid Label", "")
+
+
+# ── list_credentials_ranked ─────────────────────────────────────────────────
+
+
+def test_list_credentials_ranked_empty(creds_file):
+    """Returns [] when no credentials exist."""
+    result = list_credentials_ranked()
+    assert result == []
+
+
+def test_list_credentials_sorted_by_burn_rate(creds_file):
+    """Credentials are sorted ascending by burn_rate."""
+    c1 = add_credential("High Burn", "sk-ant-api03-highburnkeyvalue1234")
+    c2 = add_credential("Low Burn", "sk-ant-api03-lowburnkeyvalue12345")
+    c3 = add_credential("Mid Burn", "sk-ant-api03-midburnkeyvalue12345")
+
+    update_credential_usage(c1["id"], {"burn_rate": 80.0})
+    update_credential_usage(c2["id"], {"burn_rate": 10.0})
+    update_credential_usage(c3["id"], {"burn_rate": 45.0})
+
+    ranked = list_credentials_ranked()
+    burn_rates = [r["burn_rate"] for r in ranked]
+    assert burn_rates == sorted(burn_rates)
+
+
+def test_list_credentials_none_burn_rate_last(creds_file):
+    """Credentials with None burn_rate sort after those with a value."""
+    c_none = add_credential("No Burn", "sk-ant-api03-noburnkeyvalue123456")
+    c_val = add_credential("Has Burn", "sk-ant-api03-hasburnkeyvalue12345")
+
+    update_credential_usage(c_val["id"], {"burn_rate": 5.0})
+    # c_none retains burn_rate=None
+
+    ranked = list_credentials_ranked()
+    ids = [r["id"] for r in ranked]
+    assert ids.index(c_val["id"]) < ids.index(c_none["id"])
+
+
+def test_list_credentials_no_raw_key(creds_file):
+    """No returned record contains the raw 'key' field."""
+    add_credential("Cred A", "sk-ant-api03-credAkeyvalue123456")
+    add_credential("Cred B", "sk-ant-api03-credBkeyvalue123456")
+    for cred in list_credentials_ranked():
+        assert "key" not in cred
+
+
+def test_list_credentials_has_is_priority(creds_file):
+    """Each returned record has an 'is_priority' boolean field."""
+    add_credential("Cred X", "sk-ant-api03-credXkeyvalue123456")
+    for cred in list_credentials_ranked():
+        assert "is_priority" in cred
+        assert isinstance(cred["is_priority"], bool)
+
+
+# ── delete_credential ───────────────────────────────────────────────────────
+
+
+def test_delete_credential_existing(creds_file):
+    """delete_credential returns True when the id exists."""
+    cred = add_credential("Delete Me", "sk-ant-api03-deletemekeyvalue123")
+    assert delete_credential(cred["id"]) is True
+
+
+def test_delete_credential_nonexistent(creds_file):
+    """delete_credential returns False for an unknown id."""
+    assert delete_credential("cred-doesnotexist") is False
+
+
+def test_delete_credential_clears_priority(creds_file):
+    """Deleting the priority credential clears the priority field."""
+    cred = add_credential("Priority One", "sk-ant-api03-priorityonekeyval1")
+    set_priority(cred["id"])
+    assert get_priority() is not None
+
+    delete_credential(cred["id"])
+    assert get_priority() is None
+
+
+# ── set_priority / get_priority ─────────────────────────────────────────────
+
+
+def test_set_priority_existing(creds_file):
+    """set_priority returns True and get_priority returns that credential."""
+    cred = add_credential("Priority Cred", "sk-ant-api03-prioritycredkeyval")
+    result = set_priority(cred["id"])
+    assert result is True
+    priority = get_priority()
+    assert priority is not None
+    assert priority["id"] == cred["id"]
+
+
+def test_set_priority_nonexistent(creds_file):
+    """set_priority returns False for an unknown id."""
+    assert set_priority("cred-fakeid") is False
+
+
+def test_get_priority_none_initially(creds_file):
+    """get_priority returns None when no priority has been set."""
+    assert get_priority() is None
+
+
+def test_get_priority_no_raw_key(creds_file):
+    """Priority credential returned by get_priority has no raw 'key' field."""
+    cred = add_credential("Key Owner", "sk-ant-api03-keyownerkeyvalue123")
+    set_priority(cred["id"])
+    priority = get_priority()
+    assert priority is not None
+    assert "key" not in priority
+
+
+# ── update_credential_usage ─────────────────────────────────────────────────
+
+
+def test_update_credential_usage_existing(creds_file):
+    """update_credential_usage returns True and fields appear in list output."""
+    cred = add_credential("Usage Cred", "sk-ant-api03-usagecredkeyvalue1")
+    result = update_credential_usage(cred["id"], {"burn_rate": 42.5, "usage_7d": 100})
+    assert result is True
+
+    ranked = list_credentials_ranked()
+    match = next(r for r in ranked if r["id"] == cred["id"])
+    assert match["burn_rate"] == 42.5
+    assert match["usage_7d"] == 100
+
+
+def test_update_credential_usage_nonexistent(creds_file):
+    """update_credential_usage returns False for an unknown id."""
+    assert update_credential_usage("cred-ghost", {"burn_rate": 10.0}) is False

--- a/tests/test_cred_store.py
+++ b/tests/test_cred_store.py
@@ -1,5 +1,6 @@
 """Tests for the cred_store module."""
 
+import json
 import pytest
 from unittest.mock import patch
 
@@ -137,8 +138,13 @@ def test_list_credentials_no_raw_key(creds_file):
     """No returned record contains the raw 'key' field."""
     add_credential("Cred A", "sk-ant-api03-credAkeyvalue123456")
     add_credential("Cred B", "sk-ant-api03-credBkeyvalue123456")
-    for cred in list_credentials_ranked():
+    result = list_credentials_ranked()
+    for cred in result:
         assert "key" not in cred
+    # Also verify the raw key values themselves do not appear anywhere in serialized output
+    serialized = json.dumps(result)
+    assert "sk-ant-api03-credAkeyvalue123456" not in serialized, "Raw key value must not appear in list output"
+    assert "sk-ant-api03-credBkeyvalue123456" not in serialized, "Raw key value must not appear in list output"
 
 
 def test_list_credentials_has_is_priority(creds_file):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -91,3 +91,7 @@ async def test_app_has_all_routes(app):
     assert "/api/widgets/system-info" in routes
     assert "/ws/exec" in routes
     assert "/ws/{hub}" in routes
+    assert "/api/credentials" in routes
+    assert "/api/credentials/priority" in routes
+    assert "/api/credentials/{id}" in routes
+    assert "/api/credentials/{id}/usage" in routes

--- a/tests/test_server_cred_store.py
+++ b/tests/test_server_cred_store.py
@@ -1,0 +1,207 @@
+"""API-level tests for credential endpoints in server.py."""
+
+from unittest.mock import patch
+
+import pytest
+
+from claude_rts.server import create_app
+
+
+# ── Fixtures ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def cred_dir(tmp_path):
+    """Patch CREDENTIALS_FILE and CONFIG_DIR to use tmp_path."""
+    cfg_dir = tmp_path / ".supreme-claudemander"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    creds_file = cfg_dir / "credentials.json"
+    with (
+        patch("claude_rts.cred_store.CREDENTIALS_FILE", creds_file),
+        patch("claude_rts.config.CONFIG_DIR", cfg_dir),
+    ):
+        yield cfg_dir, creds_file
+
+
+@pytest.fixture
+def app(cred_dir):
+    return create_app(test_mode=True)
+
+
+@pytest.fixture
+async def client(aiohttp_client, app):
+    return await aiohttp_client(app)
+
+
+# ── Tests ──────────────────────────────────────────────────
+
+
+async def test_get_credentials_empty(client, cred_dir):
+    """GET /api/credentials returns empty list when no credentials stored."""
+    resp = await client.get("/api/credentials")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["priority"] is None
+    assert data["credentials"] == []
+
+
+async def test_post_credentials_adds_credential(client, cred_dir):
+    """POST /api/credentials with valid data returns 201 with masked credential."""
+    resp = await client.post(
+        "/api/credentials",
+        json={"label": "Test", "key": "sk-ant-api03-abcdefghijklmnop"},
+    )
+    assert resp.status == 201
+    data = await resp.json()
+    assert data["label"] == "Test"
+    assert "key_hint" in data
+    assert "key" not in data
+    assert "id" in data
+
+
+async def test_post_credentials_missing_fields(client, cred_dir):
+    """POST /api/credentials with missing 'key' field returns 400."""
+    resp = await client.post(
+        "/api/credentials",
+        json={"label": "No Key Here"},
+    )
+    assert resp.status == 400
+
+
+async def test_post_credentials_empty_label(client, cred_dir):
+    """POST /api/credentials with empty label returns 400."""
+    resp = await client.post(
+        "/api/credentials",
+        json={"label": "", "key": "sk-ant-api03-abcdefghijklmnop"},
+    )
+    assert resp.status == 400
+
+
+async def test_delete_credential_existing(client, cred_dir):
+    """Add then delete a credential — verify 200 with {'deleted': <id>}."""
+    add_resp = await client.post(
+        "/api/credentials",
+        json={"label": "ToDelete", "key": "sk-ant-api03-deleteme1234567"},
+    )
+    assert add_resp.status == 201
+    cred = await add_resp.json()
+    cred_id = cred["id"]
+
+    del_resp = await client.delete(f"/api/credentials/{cred_id}")
+    assert del_resp.status == 200
+    del_data = await del_resp.json()
+    assert del_data["deleted"] == cred_id
+
+
+async def test_delete_credential_nonexistent(client, cred_dir):
+    """DELETE /api/credentials/not-real-id returns 404."""
+    resp = await client.delete("/api/credentials/not-real-id")
+    assert resp.status == 404
+
+
+async def test_get_priority_no_priority_set(client, cred_dir):
+    """GET /api/credentials/priority returns 404 when no priority is set."""
+    resp = await client.get("/api/credentials/priority")
+    assert resp.status == 404
+
+
+async def test_put_and_get_priority(client, cred_dir):
+    """Add a credential, PUT priority with its id, then GET priority returns 200."""
+    add_resp = await client.post(
+        "/api/credentials",
+        json={"label": "PriorityOne", "key": "sk-ant-api03-prioritykey12345"},
+    )
+    assert add_resp.status == 201
+    cred = await add_resp.json()
+    cred_id = cred["id"]
+
+    put_resp = await client.put(
+        "/api/credentials/priority",
+        json={"id": cred_id},
+    )
+    assert put_resp.status == 200
+    put_data = await put_resp.json()
+    assert put_data["priority"] == cred_id
+
+    get_resp = await client.get("/api/credentials/priority")
+    assert get_resp.status == 200
+    get_data = await get_resp.json()
+    assert get_data["id"] == cred_id
+    assert get_data["label"] == "PriorityOne"
+
+
+async def test_put_priority_nonexistent_id(client, cred_dir):
+    """PUT /api/credentials/priority with fake id returns 404."""
+    resp = await client.put(
+        "/api/credentials/priority",
+        json={"id": "fake-id"},
+    )
+    assert resp.status == 404
+
+
+async def test_put_priority_missing_id_field(client, cred_dir):
+    """PUT /api/credentials/priority with empty body returns 400."""
+    resp = await client.put(
+        "/api/credentials/priority",
+        json={},
+    )
+    assert resp.status == 400
+
+
+async def test_credentials_never_expose_raw_key(client, cred_dir):
+    """POST a credential then GET /api/credentials — raw key must not appear."""
+    raw_key = "sk-ant-api03-supersecretkey99999"
+    add_resp = await client.post(
+        "/api/credentials",
+        json={"label": "SecretTest", "key": raw_key},
+    )
+    assert add_resp.status == 201
+
+    get_resp = await client.get("/api/credentials")
+    assert get_resp.status == 200
+    body_text = await get_resp.text()
+    assert raw_key not in body_text
+
+
+async def test_credentials_persist_across_requests(client, cred_dir):
+    """Add a credential via POST then GET /api/credentials — it appears in list."""
+    add_resp = await client.post(
+        "/api/credentials",
+        json={"label": "Persistent", "key": "sk-ant-api03-persistentkey12345"},
+    )
+    assert add_resp.status == 201
+    added = await add_resp.json()
+
+    get_resp = await client.get("/api/credentials")
+    assert get_resp.status == 200
+    data = await get_resp.json()
+    ids = [c["id"] for c in data["credentials"]]
+    assert added["id"] in ids
+
+
+async def test_update_usage_existing(client, cred_dir):
+    """Add credential, PUT /api/credentials/{id}/usage with burn_rate, verify 200."""
+    add_resp = await client.post(
+        "/api/credentials",
+        json={"label": "UsageTest", "key": "sk-ant-api03-usagetestkey12345"},
+    )
+    assert add_resp.status == 201
+    cred = await add_resp.json()
+    cred_id = cred["id"]
+
+    usage_resp = await client.put(
+        f"/api/credentials/{cred_id}/usage",
+        json={"burn_rate": 5.5},
+    )
+    assert usage_resp.status == 200
+    usage_data = await usage_resp.json()
+    assert usage_data["updated"] == cred_id
+
+
+async def test_update_usage_nonexistent(client, cred_dir):
+    """PUT /api/credentials/fake-id/usage with burn_rate returns 404."""
+    resp = await client.put(
+        "/api/credentials/fake-id/usage",
+        json={"burn_rate": 5.5},
+    )
+    assert resp.status == 404


### PR DESCRIPTION
Closes #72

## What changed

This PR delivers the Credential Manager feature: a new `cred_store` backend module, six new HTTP API handlers in `server.py`, and a `credential-manager` widget in the frontend WIDGET_REGISTRY. Users can now add, delete, and rank Claude API credentials by burn rate, designate a priority credential, and have service-card probe results automatically flow back to update per-credential usage stats - all without the raw key ever appearing in any API response or UI.

## Implementation walkthrough

### `claude_rts/cred_store.py` (new)

This module owns all file-based persistence for credentials. Credentials are stored in `~/.supreme-claudemander/credentials.json` as a JSON object with a top-level `priority` id field and a `credentials` array. Each record carries `id`, `label`, `profile`, `key` (raw, server-side only), `key_hint`, and seven usage fields (`five_hour_pct`, `burn_rate`, `five_hour_resets`, `seven_day_pct`, `usage_7d`, `quota`, `refresh_at`).

`mask_key(key)` produces a safe display string: keys longer than 11 characters become `first7...last4`; shorter keys become the constant `"sk-ant-...xxxx"`. `_mask_credential(cred)` strips the `"key"` field from a record dict before any record leaves the module boundary, ensuring the raw key is confined to the JSON file on disk.

A module-level `_lock = threading.Lock()` serialises all read-modify-write sequences. Because aiohttp runs handlers in the event loop thread and the probe subscriber callbacks fire from the same thread, a plain `threading.Lock` is sufficient; it also guards the rare case where a future executor thread writes usage data concurrently with a DELETE.

The public API:
- `add_credential(label, key, profile)` - validates inputs, generates a `cred-{8hex}` id, appends the record, and returns the masked copy.
- `delete_credential(cred_id)` - filters the record out; if it was the priority, clears `priority` to `None`. Returns True/False.
- `set_priority(cred_id)` - verifies the id exists, writes `"priority"`, returns True/False.
- `get_priority()` - returns the masked priority record, or `None` if unset or stale.
- `update_credential_usage(cred_id, usage_data)` - merges whitelisted fields from `_USAGE_FIELDS` into the matching record; returns True/False.
- `list_credentials_ranked()` - sorts by `burn_rate` ascending, `None` values last (sort key `(1,0)` vs `(0, burn_rate)`), injects `is_priority` boolean, strips raw key.
- `get_credentials_response()` - returns `{"priority": ..., "credentials": [...ranked...]}` in a single file read to avoid TOCTOU divergence between priority id and the list.

Corrupt or missing files fall back to `{"priority": None, "credentials": []}` via a `json.JSONDecodeError / OSError` catch in `read_credentials`.

### `claude_rts/server.py` (modified)

Six new handler functions were added above `create_app`:

| Handler | Method + Path | Notes |
|---|---|---|
| `credentials_list_handler` | `GET /api/credentials` | Returns `get_credentials_response()` directly |
| `credentials_add_handler` | `POST /api/credentials` | Strips whitespace, validates label+key, catches `ValueError` from `add_credential`, returns 201 |
| `credentials_delete_handler` | `DELETE /api/credentials/{id}` | 404 if not found |
| `credentials_priority_get_handler` | `GET /api/credentials/priority` | 404 when `get_priority()` returns `None` |
| `credentials_priority_set_handler` | `PUT /api/credentials/priority` | Body must contain `"id"`; 400 on missing field, 404 on unknown id |
| `credentials_usage_update_handler` | `PUT /api/credentials/{id}/usage` | Passes full body to `update_credential_usage`; 404 on unknown id |

Route registration order in `create_app` is critical: the two `/api/credentials/priority` literal routes are registered **before** the `{id}` wildcard routes so aiohttp matches `priority` as a literal path segment rather than a credential id.

In `on_startup`, after the util container is ready, a `_update_cred_usage` closure is defined that reads the credentials file, finds the first record whose `profile` field matches the probe profile name, and calls `update_credential_usage`. For each entry in `config["probe_profiles"]` the startup code builds three closures - `_log_usage`, `_usage_callback`, and `_combined_callback` - using default-argument capture (`_p=profile`) to freeze the loop variable, then calls `registry.subscribe("claude-usage", profile, _combined_callback, ...)`. This wires every `ClaudeUsageCard` probe result directly into the credential store.

### `claude_rts/static/index.html` (modified)

A `credential-manager` entry was added to `WIDGET_REGISTRY` with `defaultRefreshInterval: 15000` (15 s). The `render(body, card)` function:

1. Fetches `GET /api/credentials` and destructures `{credentials, priority}`.
2. Iterates the ranked list and for each record renders a `.cred-row` div containing: label, `key_hint`, a CSS burn-rate bar with `width: N%`, numeric burn display, reset-time display, a priority star button, and a delete button.
3. Appends a form with label, password (API key), and optional profile fields.
4. Wires `.cred-btn-delete` click handlers to `DELETE /api/credentials/{id}` then `card.render()`.
5. Wires `.cred-btn-priority` click handlers to `PUT /api/credentials/priority` then `card.render()`.
6. Wires the form submit handler to `POST /api/credentials`; on success resets the form and re-renders; on failure uses `alert()` with the server error message.

The `catch` block uses `escapeHtml(err.message)` when writing the error into `body.innerHTML`, preventing XSS from error strings that may contain angle brackets. Earlier widget catch blocks used raw string interpolation; this entry adopts the safer pattern.

The widget is automatically available in the right-click context menu under "Spawn widget" because `WIDGET_REGISTRY` keys are enumerated dynamically - no separate sidebar entry is required.

### How components interact

```mermaid
graph TD
    Browser[Browser Widget] -->|GET /api/credentials| ListH[credentials_list_handler]
    Browser -->|POST /api/credentials| AddH[credentials_add_handler]
    Browser -->|DELETE /api/credentials/id| DelH[credentials_delete_handler]
    Browser -->|PUT /api/credentials/priority| PrioH[credentials_priority_set_handler]
    ListH --> GetResp[cred_store.get_credentials_response]
    AddH --> AddCred[cred_store.add_credential]
    DelH --> DelCred[cred_store.delete_credential]
    PrioH --> SetPrio[cred_store.set_priority]
    GetResp --> File[credentials.json]
    AddCred --> File
    DelCred --> File
    SetPrio --> File
    Probe[ClaudeUsageCard probe] -->|result dict| CB[_combined_callback]
    CB --> UpdUsage[cred_store.update_credential_usage]
    UpdUsage --> File
```

### Default execution path

**Before:** no credential management existed. Service card probes logged usage to the console only; there was no way to store API keys or track burn rate.

**After:** a user opens the credential-manager widget, adds a credential with a label, key, and optional profile name. `GET /api/credentials` returns the ranked list; the widget renders the burn bar at 0% until a probe fires. When a `ClaudeUsageCard` probe completes for a matching profile, `_combined_callback` calls `_update_cred_usage`, which writes `five_hour_pct`, `burn_rate`, etc. into the matching credential record. On the next 15-second refresh the widget shows the updated bar. The priority credential is readable at `GET /api/credentials/priority` for future session injection.

### Edge cases and error handling

- `DELETE /api/credentials/{id}` and `PUT /api/credentials/priority` with an unknown id return 404.
- `POST /api/credentials` with a missing or empty `label` or `key` field returns 400; the `ValueError` from `add_credential` is caught and re-surfaced.
- All read-modify-write sequences hold `_lock`, preventing torn writes if two requests arrive concurrently.
- A corrupt `credentials.json` silently falls back to empty defaults, preventing server startup failure.
- `get_credentials_response()` performs a single file read, avoiding a race where a concurrent write between a priority read and a list read would return an inconsistent response.

### What was intentionally not changed

- **File permission hardening** (`chmod 0600` on the credentials file) was deferred to a follow-up issue; it is a Unix-only concern and adds platform-detection complexity.
- **Encryption at rest** was not added. The raw key is stored in plaintext in `credentials.json`, consistent with the existing `config.json` precedent. This is acceptable because the file lives in the user home directory and the key is needed in plaintext for future terminal session injection.

## Tier / approach

Tier 2 - Planner -> parallel Coder A (backend) + Coder B (frontend) + Tester -> Wave 2 server routes + API tests -> Reviewer -> fixes

## Acceptance criteria

- [x] Priority credential accessible via `GET /api/credentials/priority`
- [x] Credential list ranked by ascending burn rate (None last)
- [x] Each credential shows `five_hour_pct` and `five_hour_resets`
- [x] User can add, delete, and set priority credential via UI
- [x] Service card probe results update credential usage automatically
- [x] Credentials persisted in `~/.supreme-claudemander/credentials.json`
- [x] Raw key NEVER appears in any API response (only `key_hint`)
- [x] 24 unit tests + 14 API tests + route assertions added

## Outstanding items

- File permission hardening deferred (chmod 0600 on Unix)
- Raw key stored in plaintext - acceptable for future session injection, follows config.json precedent

---

Generated with [Claude Code](https://claude.com/claude-code)
