### PR TITLE
feat(#73): Start Claude button on terminal card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ To add a new preset: create a directory under `dev_presets/` with a `config.json
 |--------|---------|
 | `default` | Bare util-terminal + empty probe-qa canvas |
 | `profiles` | Profile Manager widget pre-placed on canvas |
+| `start-claude` | Start Claude button QA — priority_profile pre-set, Profile Manager widget on canvas |
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ netstat -ano | grep "LISTENING" | grep -E ":300[0-9] " | awk '{print $NF}' | sor
 
 Verify the port is free before starting. Running multiple instances causes port conflicts, confusing log output, and stale probe sessions.
 
+**Use `--electron` for manual/QA testing.** Launch via `python -m claude_rts --electron` to run in the Electron shell instead of a browser tab.
+
 ## Key Design Decisions
 
 - **pywinpty for ConPTY**: `asyncio.create_subprocess_exec` only gives pipes (no PTY), so `docker.exe exec -it` fails or has no echo. pywinpty provides a real Windows ConPTY.
@@ -61,6 +63,8 @@ CLAUDE_RTS_TEST_MODE=1 python -m claude_rts   # enables puppeting API at /api/te
 ```
 
 **Always run `ruff format` before committing.** CI enforces formatting via `ruff format --check`.
+
+**Wait for CI to pass before merging PRs.** All GitHub Actions checks (lint, format, tests) must be green.
 
 | File | Tests | What it covers |
 |------|-------|----------------|

--- a/claude_rts/dev_presets/start-claude/canvases/start-claude-qa.json
+++ b/claude_rts/dev_presets/start-claude/canvases/start-claude-qa.json
@@ -1,0 +1,8 @@
+{
+  "name": "start-claude-qa",
+  "canvas_size": [3840, 2160],
+  "cards": [
+    {"type": "widget", "widgetType": "profiles", "x": 100, "y": 100, "w": 600, "h": 400},
+    {"type": "terminal", "hub": "supreme-claudemander-util", "x": 750, "y": 100, "w": 900, "h": 600}
+  ]
+}

--- a/claude_rts/dev_presets/start-claude/config.json
+++ b/claude_rts/dev_presets/start-claude/config.json
@@ -1,0 +1,20 @@
+{
+  "startup_script": "util-terminal",
+  "default_canvas": "start-claude-qa",
+  "probe_profiles": ["test-profile"],
+  "priority_profile": "test-profile",
+  "sessions": {
+    "orphan_timeout": 60,
+    "scrollback_size": 65536,
+    "tmux_persistence": true
+  },
+  "util_container": {
+    "name": "supreme-claudemander-util",
+    "image": "supreme-claudemander-util:latest",
+    "auto_start": true,
+    "auto_stop": false,
+    "mounts": {
+      "~/.claude-profiles": "/profiles"
+    }
+  }
+}

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -104,8 +104,9 @@
   .terminal-titlebar .close-btn:hover { background: #f38ba8; color: #1e1e2e; }
   .terminal-titlebar .claude-btn {
     width: 20px; height: 20px; border: none; background: transparent;
-    color: #585b70; font-size: 14px; cursor: pointer; border-radius: 4px;
+    color: #cba6f7; font-size: 12px; cursor: pointer; border-radius: 4px;
     display: flex; align-items: center; justify-content: center;
+    margin-right: 4px;
   }
   .terminal-titlebar .claude-btn:hover { background: #cba6f7; color: #1e1e2e; }
   .terminal-titlebar .claude-btn:disabled { opacity: 0.3; pointer-events: none; }
@@ -1370,7 +1371,7 @@ class TerminalCard extends Card {
     const btn = document.createElement('button');
     btn.className = 'claude-btn';
     btn.title = 'Start Claude';
-    btn.textContent = '✦';
+    btn.innerHTML = '&#9654;';
 
     btn.addEventListener('click', async (e) => {
       e.stopPropagation();

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -102,6 +102,13 @@
     display: flex; align-items: center; justify-content: center;
   }
   .terminal-titlebar .close-btn:hover { background: #f38ba8; color: #1e1e2e; }
+  .terminal-titlebar .claude-btn {
+    width: 20px; height: 20px; border: none; background: transparent;
+    color: #585b70; font-size: 14px; cursor: pointer; border-radius: 4px;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .terminal-titlebar .claude-btn:hover { background: #cba6f7; color: #1e1e2e; }
+  .terminal-titlebar .claude-btn:disabled { opacity: 0.3; pointer-events: none; }
 
   .terminal-body {
     flex: 1;
@@ -1039,6 +1046,7 @@ class Card {
     // Double-click anywhere on card to zoom-to-fill
     el.addEventListener('dblclick', (e) => {
       if (e.target.closest('.close-btn')) return;
+      if (e.target.closest('.claude-btn')) return;
       zoomToCard(this);
     });
 
@@ -1192,6 +1200,7 @@ class TerminalCard extends Card {
     this.connectWs();
     this.setupInput();
     this.setupResizeObserver();
+    this.setupClaudeBtn();
   }
 
   onDestroy() {
@@ -1352,6 +1361,42 @@ class TerminalCard extends Card {
       }
     });
     this.ro.observe(body);
+  }
+
+  setupClaudeBtn() {
+    const titlebar = this.el.querySelector(`[data-drag="${this.id}"]`);
+    const closeBtn = titlebar.querySelector('.close-btn');
+
+    const btn = document.createElement('button');
+    btn.className = 'claude-btn';
+    btn.title = 'Start Claude';
+    btn.textContent = '✦';
+
+    btn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      btn.disabled = true;
+      try {
+        const resp = await fetch('/api/profiles/priority');
+        const data = await resp.json();
+        const name = data.priority_profile;
+        if (!name) {
+          this.term.write('\r\n\x1b[33m[No priority profile set — configure one in the Profile Manager]\x1b[0m\r\n');
+          return;
+        }
+        const command = `env CLAUDE_CONFIG_DIR=/profiles/${name} claude\n`;
+        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+          this.ws.send(new TextEncoder().encode(command));
+        } else {
+          this.term.write('\r\n\x1b[31m[Not connected — cannot send command]\x1b[0m\r\n');
+        }
+      } catch (err) {
+        this.term.write(`\r\n\x1b[31m[Error fetching priority profile: ${err.message}]\x1b[0m\r\n`);
+      } finally {
+        btn.disabled = false;
+      }
+    });
+
+    titlebar.insertBefore(btn, closeBtn);
   }
 }
 

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -1378,10 +1378,18 @@ class TerminalCard extends Card {
       btn.disabled = true;
       try {
         const resp = await fetch('/api/profiles/priority');
+        if (!resp.ok) {
+          this.term.write(`\r\n\x1b[31m[Failed to fetch priority profile: HTTP ${resp.status}]\x1b[0m\r\n`);
+          return;
+        }
         const data = await resp.json();
         const name = data.priority_profile;
         if (!name) {
           this.term.write('\r\n\x1b[33m[No priority profile set — configure one in the Profile Manager]\x1b[0m\r\n');
+          return;
+        }
+        if (!/^[a-zA-Z0-9._-]+$/.test(name)) {
+          this.term.write('\r\n\x1b[31m[Invalid profile name — contains unsafe characters]\x1b[0m\r\n');
           return;
         }
         const command = `env CLAUDE_CONFIG_DIR=/profiles/${name} claude\n`;


### PR DESCRIPTION
Closes #73

## What changed

The terminal card titlebar now has a "Start Claude" button (✦) that sends an interactive `claude` launch command into the card's existing PTY session. When clicked, the button fetches the priority profile name from the server, constructs the command `env CLAUDE_CONFIG_DIR=/profiles/{name} claude`, and delivers it as binary keystrokes over the card's live WebSocket — exactly as if the user had typed it. No new sessions, no server-side injection, no environment mutation: the command lands in the shell that is already running inside the container.

No backend changes were required. The `/api/profiles/priority` endpoint introduced in #72 already provides everything the button needs. The entire change is front-end only, contained in `index.html`, with a new `start-claude` dev config preset added for isolated QA.

## Implementation walkthrough

### `TerminalCard.setupClaudeBtn()` (new method, `index.html`)

`setupClaudeBtn()` is called at the end of `TerminalCard.onInit()`, after the xterm instance and WebSocket are wired up but before the card is visible. It queries the card's titlebar element by the `data-drag` attribute (the same handle used for drag events), creates a `<button class="claude-btn">` containing the ✦ glyph, and splices it into the titlebar immediately before the existing close button. This keeps the base `Card` class untouched — `TerminalCard` owns its own DOM extension, which is consistent with the class hierarchy's design intent.

The click handler is `async`. It disables the button immediately (preventing double-clicks during the fetch), then calls `GET /api/profiles/priority`. If the response contains a non-null `priority_profile`, it encodes `env CLAUDE_CONFIG_DIR=/profiles/{name} claude\n` as UTF-8 and sends it over `this.ws` as a binary frame — the same channel that carries every other keystroke typed into the terminal. The trailing `\n` triggers shell execution. If the WebSocket is not in `OPEN` state, the handler writes a red error line directly to the xterm instance via `this.term.write()`. The button is re-enabled in the `finally` block regardless of outcome.

The double-click-to-zoom guard in the base `Card` class was updated to ignore clicks that originate on `.claude-btn` elements, preventing the button click from triggering a zoom.

### CSS additions (`.claude-btn`)

A new `.terminal-titlebar .claude-btn` rule mirrors the visual contract of `.close-btn`: 20×20px, transparent background, border-radius 4px, `display: flex` for icon centering. On hover the background is `#cba6f7` (the purple accent already used for focused card borders), making the button feel native to the Catppuccin palette. A `disabled` state drops opacity to 0.3 and sets `pointer-events: none`, providing clear visual feedback during the async fetch.

### `start-claude` dev config preset (new files)

`claude_rts/dev_presets/start-claude/config.json` configures a self-contained QA environment: the `util-terminal` startup script launches a terminal card automatically, `priority_profile` is pre-set to `test-profile` so the button works on first click without any manual configuration, and `~/.claude-profiles` is bind-mounted into the container at `/profiles` (the path the command references). The companion canvas `start-claude-qa.json` places a Profile Manager widget alongside the terminal so a tester can inspect and change the priority profile mid-session to exercise the no-profile warning path.

## How components interact

<!-- MERMAID: Sequence diagram — User clicks Start Claude button → button's async handler fires → fetch /api/profiles/priority → server reads config.json → returns { priority_profile: "name" } → handler encodes launch command as UTF-8 binary → sends over TerminalCard.ws (WebSocket) → server PTY receives bytes → shell executes `env CLAUDE_CONFIG_DIR=... claude` → Claude starts interactively in existing terminal -->

The button is fully decoupled from the PTY lifecycle. `TerminalCard.ws` is the same WebSocket reference used by `TerminalCard.setupInput()` for all user keystrokes. Sending through that reference means the PTY cannot distinguish a button-triggered command from a manually typed one — no special PTY API, no out-of-band channel, no server-side state change.

## Default execution path

**Before (PR #97 baseline):** Terminal card titlebar contains only a title label and a close button. There is no way to start Claude from the UI; the user must manually type the `env CLAUDE_CONFIG_DIR=...` command.

**After — happy path (priority profile set, WebSocket open):**

1. User clicks ✦ on the terminal card titlebar.
2. Button is disabled synchronously; click propagation is stopped.
3. `fetch('/api/profiles/priority')` returns `{"priority_profile": "test-profile"}`.
4. Handler builds `env CLAUDE_CONFIG_DIR=/profiles/test-profile claude\n`.
5. `this.ws.send(new TextEncoder().encode(command))` delivers the bytes to the server PTY.
6. The shell running in the container receives the bytes, echoes the command, and executes it.
7. Claude's interactive TUI appears in the existing terminal.
8. Button is re-enabled.

**After — no priority profile:**

Steps 1–3 execute. `data.priority_profile` is null or absent. Handler calls `this.term.write('\r\n\x1b[33m[No priority profile set — configure one in the Profile Manager]\x1b[0m\r\n')`, printing a yellow message in-terminal. Returns early; button re-enabled.

**After — WebSocket not open:**

Steps 1–3 execute and a valid profile is found, but `this.ws.readyState !== WebSocket.OPEN`. Handler writes a red `[Not connected — cannot send command]` message via `this.term.write()`. Returns; button re-enabled.

## Edge cases and error handling

- **No priority profile configured** — yellow in-terminal warning, no command sent, no server request beyond the priority fetch.
- **WebSocket disconnected** — red in-terminal error, graceful fallback without throwing.
- **Network/fetch failure** — `catch (err)` writes `[Error fetching priority profile: {message}]` in red to the terminal.
- **Double-click protection** — button is disabled for the duration of the async handler; the zoom-on-dblclick guard is updated to ignore `.claude-btn` targets.
- **Credential secrecy** — only the profile *name* (e.g., `test-profile`) is sent over the wire and rendered in the terminal, never the API key. The key lives in the container's `/profiles/{name}` directory and is not touched or logged by any code in this PR.
- **Other terminal sessions** — the command is sent only to the WebSocket of the card whose button was clicked; other `TerminalCard` instances and their sessions are completely unaffected.

## Tier / approach
Tier 1 — Planner → Coder → Reviewer

## Acceptance criteria
- [x] Terminal card titlebar has a "Start Claude" button
- [x] Clicking sends `env CLAUDE_CONFIG_DIR=/profiles/{priority_profile} claude` into the existing PTY
- [x] Button checks for priority profile; shows feedback if none is set
- [x] Does not spawn a new card or session — reuses the existing terminal
- [x] Key value is never logged or exposed in API responses
- [x] New `start-claude` dev config preset for QA testing

## Outstanding items
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)