### PR TITLE
feat(#97): claude-api dev preset + integration test + CLAUDE.md docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ To add a new preset: create a directory under `dev_presets/` with a `config.json
 | `profiles` | Profile Manager widget pre-placed on canvas |
 | `start-claude` | Start Claude button QA — priority_profile pre-set, Profile Manager widget on canvas |
 | `stress-test` | Layout QA — 6 cards at edge positions, varying sizes, overlapping z-order |
+| `claude-api` | Claude terminal control API QA — empty canvas for programmatic terminal lifecycle |
 
 ## Testing
 
@@ -78,6 +79,7 @@ CLAUDE_RTS_TEST_MODE=1 python -m claude_rts   # enables puppeting API at /api/te
 | `test_dev_config.py` | 8 | Dev-config preset loading and setup |
 | `test_sessions.py` | 30 | ScrollbackBuffer, SessionManager, test puppeting API |
 | `test_terminal_card.py` | 11 | TerminalCard lifecycle, CardRegistry, server integration |
+| `test_claude_api.py` | 27 | Claude terminal control API (CRUD, send/read, strip_ansi, /ws/control, full lifecycle integration) |
 | `test_event_bus.py` | 14 | EventBus core (subscribe, emit, unsubscribe, wildcard, async, errors, clear) + integration (ServiceCard bus emit, CardRegistry events) |
 | `e2e/test_smoke.py` | 7 | Playwright Electron smoke tests — launch, spawn, drag, resize, widgets, pan/zoom, save/reload |
 
@@ -96,8 +98,15 @@ Tests use `MockPty` to avoid needing Docker. E2E tests require Playwright and El
 | GET | `/api/widgets/system-info` | System info widget data |
 | GET | `/api/profiles` | Probe profiles with usage data, sorted by burn rate |
 | GET/PUT | `/api/profiles/priority` | Read/set priority profile |
+| POST | `/api/claude/terminal/create` | Create a TerminalCard + PTY session (params: cmd, hub, container, cols, rows, x, y, w, h) |
+| POST | `/api/claude/terminal/{id}/send` | Write text to a terminal PTY |
+| GET | `/api/claude/terminal/{id}/read` | Read scrollback (optional: strip_ansi, last_n) |
+| GET | `/api/claude/terminal/{id}/status` | Session metadata (alive, age, idle, cmd) |
+| DELETE | `/api/claude/terminal/{id}` | Stop card, clean up session and card registry |
+| GET | `/api/claude/terminals` | List all terminal cards with metadata |
 | WS | `/ws/session/new?cmd=...` | Create persistent PTY session |
 | WS | `/ws/session/{session_id}` | Reconnect to existing session |
+| WS | `/ws/control` | Card lifecycle events (card_created, card_deleted) broadcast |
 
 ## WebSocket Protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ CLAUDE_RTS_TEST_MODE=1 python -m claude_rts   # enables puppeting API at /api/te
 | `test_dev_config.py` | 8 | Dev-config preset loading and setup |
 | `test_sessions.py` | 30 | ScrollbackBuffer, SessionManager, test puppeting API |
 | `test_terminal_card.py` | 11 | TerminalCard lifecycle, CardRegistry, server integration |
-| `test_claude_api.py` | 27 | Claude terminal control API (CRUD, send/read, strip_ansi, /ws/control, full lifecycle integration) |
+| `test_claude_api.py` | 30 | Claude terminal control API (CRUD, send/read, strip_ansi, /ws/control, full lifecycle integration) |
 | `test_event_bus.py` | 14 | EventBus core (subscribe, emit, unsubscribe, wildcard, async, errors, clear) + integration (ServiceCard bus emit, CardRegistry events) |
 | `e2e/test_smoke.py` | 7 | Playwright Electron smoke tests — launch, spawn, drag, resize, widgets, pan/zoom, save/reload |
 

--- a/claude_rts/dev_presets/claude-api/canvases/claude-api-qa.json
+++ b/claude_rts/dev_presets/claude-api/canvases/claude-api-qa.json
@@ -1,0 +1,5 @@
+{
+  "name": "claude-api-qa",
+  "canvas_size": [3840, 2160],
+  "cards": []
+}

--- a/claude_rts/dev_presets/claude-api/config.json
+++ b/claude_rts/dev_presets/claude-api/config.json
@@ -1,0 +1,19 @@
+{
+  "startup_script": "util-terminal",
+  "default_canvas": "claude-api-qa",
+  "probe_profiles": [],
+  "sessions": {
+    "orphan_timeout": 60,
+    "scrollback_size": 65536,
+    "tmux_persistence": true
+  },
+  "util_container": {
+    "name": "supreme-claudemander-util",
+    "image": "supreme-claudemander-util:latest",
+    "auto_start": true,
+    "auto_stop": false,
+    "mounts": {
+      "~/.claude-profiles": "/profiles"
+    }
+  }
+}

--- a/tests/test_claude_api.py
+++ b/tests/test_claude_api.py
@@ -419,3 +419,63 @@ async def test_ws_control_descriptor_has_layout(aiohttp_client, app_factory):
         assert desc["y"] == 200
         assert desc["w"] == 600
         assert desc["h"] == 400
+
+
+# ── Full round-trip integration test ─────────────────────────────────────
+
+
+async def test_full_lifecycle_create_send_read_delete(aiohttp_client, app_factory):
+    """Integration: create terminal → send command → read output → delete.
+
+    Exercises the complete Claude terminal control API lifecycle in sequence,
+    verifying each step returns the expected state.
+    """
+    client = await aiohttp_client(app_factory())
+
+    # 1. Create
+    resp = await client.post("/api/claude/terminal/create?cmd=bash")
+    assert resp.status == 200
+    create_data = await resp.json()
+    sid = create_data["session_id"]
+    assert sid
+    assert create_data["type"] == "terminal"
+
+    # Verify card is registered
+    card_reg = client.app["card_registry"]
+    card = card_reg.get_terminal(sid)
+    assert card is not None
+
+    # 2. Send
+    resp = await client.post(f"/api/claude/terminal/{sid}/send", data="echo hello\n")
+    assert resp.status == 200
+    send_data = await resp.json()
+    assert send_data["status"] == "ok"
+    assert send_data["sent"] == len("echo hello\n")
+
+    # 3. Read
+    resp = await client.get(f"/api/claude/terminal/{sid}/read")
+    assert resp.status == 200
+    read_data = await resp.json()
+    assert "output" in read_data
+    assert "size" in read_data
+    assert "total_written" in read_data
+
+    # Verify status is still alive
+    resp = await client.get(f"/api/claude/terminal/{sid}/status")
+    assert resp.status == 200
+    status_data = await resp.json()
+    assert status_data["session_id"] == sid
+    assert status_data["alive"] is True
+
+    # 4. Delete
+    resp = await client.delete(f"/api/claude/terminal/{sid}")
+    assert resp.status == 200
+
+    # Verify gone from both registries
+    assert card_reg.get(sid) is None
+    mgr = client.app["session_manager"]
+    assert mgr.get_session(sid) is None
+
+    # Verify status returns 404
+    resp = await client.get(f"/api/claude/terminal/{sid}/status")
+    assert resp.status == 404


### PR DESCRIPTION
Closes #97

## What changed

This is sub-issue 3 of 3 for the Claude Code canvas integration epic (#46). It adds the `claude-api` dev preset for QA-testing the programmatic terminal control API, a full round-trip integration test that exercises the complete terminal lifecycle, and CLAUDE.md documentation covering all new API endpoints introduced by #95 and #96.

## Implementation walkthrough

### New files

- **`claude_rts/dev_presets/claude-api/config.json`** — Dev preset configuration following the same structure as `default` and `stress-test` presets. Uses `util-terminal` startup script and points to the `claude-api-qa` canvas. Preset is auto-discovered by the existing preset loader without any registration code.

- **`claude_rts/dev_presets/claude-api/canvases/claude-api-qa.json`** — An intentionally empty canvas (no pre-placed cards). This is the correct design for API QA — the Claude terminal control API creates cards programmatically, so the canvas starts blank and cards are created via `POST /api/claude/terminal/create`.

### Modified files

- **`tests/test_claude_api.py`** — Added `test_full_lifecycle_create_send_read_delete`, an integration test that exercises the full Claude terminal control API lifecycle in sequence: create a terminal (verify session_id and card registration), send a command (verify byte count), read scrollback (verify output fields), check status (verify alive state), delete (verify removal from both CardRegistry and SessionManager), and confirm 404 on subsequent status check. This validates that the four API endpoints work correctly when composed end-to-end, not just in isolation.

- **`CLAUDE.md`** — Three documentation additions: (1) six new Claude terminal control API endpoints added to the API Endpoints table (`POST create`, `POST send`, `GET read`, `GET status`, `DELETE`, `GET list`), plus the `/ws/control` WebSocket endpoint; (2) `claude-api` preset added to the Dev Config Presets table; (3) `test_claude_api.py` (27 tests) added to the Testing table.

### Default execution path

**Before**: The Claude terminal control API endpoints (from #95) and the `/ws/control` WebSocket bridge (from #96) existed but had no dev preset for QA and no integration test covering the full lifecycle. Individual endpoint tests existed but did not verify the create-send-read-delete sequence as a composed workflow.

**After**: `python -m claude_rts --dev-config claude-api` starts a clean instance with an empty canvas, ready for programmatic terminal creation. The integration test validates the full lifecycle in one test function, catching regressions in cross-endpoint state (e.g., a create that registers in SessionManager but not CardRegistry, or a delete that removes from one but not the other).

## Tier / approach

Tier 1 — Planner -> Coder -> Reviewer (single-area change: preset + test + docs)

## Acceptance criteria

- [x] `--dev-config claude-api` starts with preset (verified via `test_dev_config.py` auto-discovery — 14 tests pass including `test_preset_loads_and_seeds[claude-api]`)
- [x] Integration test passes full lifecycle (create -> send -> read -> delete) — `test_full_lifecycle_create_send_read_delete` passes
- [x] CLAUDE.md documented with new endpoints and preset info
- [x] All tests green (215 passed), ruff format clean

## Outstanding items

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)