### PR TITLE
fix(#105): Canvas Claude tmux persistence + stale card recovery

### DIFF
--- a/claude_rts/cards/canvas_claude_card.py
+++ b/claude_rts/cards/canvas_claude_card.py
@@ -12,6 +12,10 @@ from .terminal_card import TerminalCard
 # Only alphanumeric, hyphens, and underscores are safe for shell interpolation.
 _SAFE_NAME = _re.compile(r"^[a-zA-Z0-9_-]+$")
 
+# Stable tmux session name used for canvas claude persistence.
+# Only one canvas claude per container is supported, so a fixed name is fine.
+TMUX_SESSION_NAME = "canvas-claude"
+
 
 def _validate_name(value: str, label: str) -> None:
     """Raise ValueError if value contains characters unsafe for shell interpolation."""
@@ -26,12 +30,21 @@ class CanvasClaudeCard(TerminalCard):
     /home/util/mcp_server.py and speaks the MCP stdio protocol over the
     subprocess's stdin/stdout, giving claude access to canvas control tools.
 
+    Persistence strategy:
+    The claude process runs inside a tmux session named ``canvas-claude``
+    within the container.  When the Windows-side PTY (ConPTY) is closed,
+    tmux keeps the process alive.  On reconnect, the PTY command is
+    ``tmux attach-session -t canvas-claude`` which rebinds to the live
+    session instead of spawning a fresh claude.
+
     Start sequence:
     1. write_mcp_config() — writes /tmp/mcp.json into the container via `docker exec`
        (non-interactive subprocess, no PTY, avoids shell-quoting issues on Windows).
-    2. The PTY is then started with:
-       `docker exec -it <container> env CLAUDE_CONFIG_DIR=/profiles/<profile> claude --mcp-config /tmp/mcp.json`
-       This mirrors the working pattern used by ClaudeUsageCard (no bash -c wrapper).
+    2. _ensure_tmux_session() — checks if a tmux session already exists:
+       a. If yes: the PTY command is set to ``docker exec -it <container> tmux
+          attach-session -t canvas-claude`` so claude resumes where it left off.
+       b. If no: the PTY command creates a new tmux session running claude:
+          ``docker exec -it <container> tmux new-session -s canvas-claude <claude_cmd>``
     """
 
     card_type: str = "canvas_claude"
@@ -67,26 +80,23 @@ class CanvasClaudeCard(TerminalCard):
         mcp_json = _json.dumps(mcp_config)
         self._mcp_b64 = _b64.b64encode(mcp_json.encode()).decode()
 
-        # Build the PTY command — no bash -c wrapper.
-        # Using `docker exec -it container env VAR=value claude ...` is identical to
-        # the pattern used by ClaudeUsageCard probe sessions, which work reliably
-        # through pywinpty/ConPTY on Windows.  The bash -c "..." wrapper interferes
-        # with PTY allocation and causes claude to exit immediately.
+        # Build the inner claude command (without docker/tmux wrapping).
+        # The actual PTY command is determined at start() time by
+        # _ensure_tmux_session(), which decides between attach vs new-session.
         docker_bin = "docker.exe"  # Windows host
         if profile:
-            cmd = (
-                f"{docker_bin} exec -it {effective_container} "
+            claude_cmd = (
                 f"env CLAUDE_CONFIG_DIR=/profiles/{profile} "
                 f"claude --dangerously-skip-permissions --mcp-config /tmp/mcp.json"
             )
         else:
-            cmd = (
-                f"{docker_bin} exec -it {effective_container} "
-                f"claude --dangerously-skip-permissions --mcp-config /tmp/mcp.json"
-            )
+            claude_cmd = "claude --dangerously-skip-permissions --mcp-config /tmp/mcp.json"
 
-        # Pass container=None so SessionManager doesn't override cmd with tmux.
-        # The docker exec is already baked into cmd; tmux would replace it with bash.
+        # Default cmd is the new-session variant; start() may override with attach.
+        cmd = f"{docker_bin} exec -it {effective_container} tmux new-session -s {TMUX_SESSION_NAME} {claude_cmd}"
+
+        # Pass container=None so SessionManager doesn't override cmd with its
+        # own tmux logic. We handle tmux ourselves with a stable session name.
         super().__init__(
             session_manager,
             cmd=cmd,
@@ -97,6 +107,7 @@ class CanvasClaudeCard(TerminalCard):
         )
 
         self._effective_container = effective_container
+        self._claude_cmd = claude_cmd
         self.api_base_url = api_base_url
         self.profile = profile
         self.canvas_name = canvas_name
@@ -133,41 +144,88 @@ class CanvasClaudeCard(TerminalCard):
             raise RuntimeError(f"Failed to write MCP config: {result.stderr.decode(errors='replace')}")
         logger.debug("CanvasClaudeCard: wrote /tmp/mcp.json to {}", self._effective_container)
 
-    def _kill_orphan_claudes(self) -> None:
-        """Kill lingering claude processes in the util container.
-
-        When the Windows-side ConPTY dies, docker exec exits but the container-side
-        claude process continues running (Docker-on-Windows doesn't reliably send SIGHUP
-        to the container process when the exec connection drops). This cleans up before
-        starting a fresh session so orphans don't accumulate.
-
-        NOTE: `pkill -x claude` kills ALL processes named 'claude' in the container.
-        Only one CanvasClaudeCard per container is supported. Running a second card
-        against the same container will kill the first card's claude process when the
-        second card starts a new session.
-        """
+    def _has_tmux_session(self) -> bool:
+        """Check if the stable tmux session already exists in the container."""
         try:
-            _subprocess.run(
-                ["docker.exe", "exec", self._effective_container, "pkill", "-x", "claude"],
+            result = _subprocess.run(
+                [
+                    "docker.exe",
+                    "exec",
+                    self._effective_container,
+                    "tmux",
+                    "has-session",
+                    "-t",
+                    TMUX_SESSION_NAME,
+                ],
                 timeout=5,
                 capture_output=True,
             )
-            logger.debug("CanvasClaudeCard: killed orphan claude processes in {}", self._effective_container)
+            return result.returncode == 0
         except Exception as exc:
-            logger.debug("CanvasClaudeCard: pkill claude (benign): {}", exc)
+            logger.debug("CanvasClaudeCard: tmux has-session check (benign): {}", exc)
+            return False
+
+    def _kill_tmux_session(self) -> None:
+        """Kill the stable tmux session in the container.
+
+        Used by new_session() to force a clean restart.  Unlike the old
+        pkill approach, this cleanly terminates the tmux session (and with
+        it the claude process running inside).
+        """
+        try:
+            _subprocess.run(
+                [
+                    "docker.exe",
+                    "exec",
+                    self._effective_container,
+                    "tmux",
+                    "kill-session",
+                    "-t",
+                    TMUX_SESSION_NAME,
+                ],
+                timeout=5,
+                capture_output=True,
+            )
+            logger.debug("CanvasClaudeCard: killed tmux session {} in {}", TMUX_SESSION_NAME, self._effective_container)
+        except Exception as exc:
+            logger.debug("CanvasClaudeCard: tmux kill-session (benign): {}", exc)
+
+    def _ensure_tmux_session(self) -> None:
+        """Set self.cmd to attach or new-session depending on tmux state.
+
+        If a tmux session named ``canvas-claude`` already exists, the PTY
+        command attaches to it (resume).  Otherwise, it creates a new tmux
+        session running the claude command.
+        """
+        docker_bin = "docker.exe"
+        if self._has_tmux_session():
+            self.cmd = f"{docker_bin} exec -it {self._effective_container} tmux attach-session -t {TMUX_SESSION_NAME}"
+            logger.info("CanvasClaudeCard: attaching to existing tmux session {}", TMUX_SESSION_NAME)
+        else:
+            self.cmd = (
+                f"{docker_bin} exec -it {self._effective_container} "
+                f"tmux new-session -s {TMUX_SESSION_NAME} {self._claude_cmd}"
+            )
+            logger.info("CanvasClaudeCard: creating new tmux session {}", TMUX_SESSION_NAME)
 
     async def start(self) -> None:
-        """Write MCP config and kill orphans, then start the PTY."""
+        """Write MCP config, resolve tmux state, then start the PTY."""
         loop = _asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._kill_orphan_claudes)
         await loop.run_in_executor(None, self._write_mcp_config)
+        await loop.run_in_executor(None, self._ensure_tmux_session)
         await super().start()
 
     # ── Session helpers ────────────────────────────────────────────────
 
     async def new_session(self) -> None:
-        """Destroy current PTY and start a fresh claude process."""
+        """Destroy current PTY and start a fresh claude process.
+
+        Kills the tmux session first so _ensure_tmux_session() creates a
+        new one rather than reattaching to the old conversation.
+        """
         await self.stop()
+        loop = _asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._kill_tmux_session)
         await self.start()
 
     async def clear_session(self) -> None:

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -1475,6 +1475,7 @@ class CanvasClaudeCard extends TerminalCard {
     // If session_not_found is received, we go through the server-side
     // create API to get a properly initialised session.
     if (!this.sessionId) return; // should not happen — spawnCanvasClaudeCard always sets sessionId
+    if (this._reconnectTimer) { clearTimeout(this._reconnectTimer); this._reconnectTimer = null; }
     this._intentionalClose = false;
     const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = `${wsProto}//${location.host}/ws/session/${this.sessionId}`;

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -1469,6 +1469,81 @@ class CanvasClaudeCard extends TerminalCard {
     titlebar.insertBefore(clearBtn, closeBtn);
   }
 
+  connectWs() {
+    // Canvas Claude cards always connect via /ws/session/{id} (never the
+    // /ws/session/new path, which would bypass MCP config + tmux setup).
+    // If session_not_found is received, we go through the server-side
+    // create API to get a properly initialised session.
+    if (!this.sessionId) return; // should not happen — spawnCanvasClaudeCard always sets sessionId
+    this._intentionalClose = false;
+    const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${wsProto}//${location.host}/ws/session/${this.sessionId}`;
+    this.ws = new WebSocket(wsUrl);
+    this.ws.binaryType = 'arraybuffer';
+
+    this.ws.addEventListener('open', () => {
+      this._reconnectDelay = 1000;
+      this.updateState('idle');
+      this.ws.send(JSON.stringify({ type: 'resize', cols: this.term.cols, rows: this.term.rows }));
+    });
+    this.ws.addEventListener('message', (ev) => {
+      if (typeof ev.data === 'string') {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.session_id) {
+            this.sessionId = msg.session_id;
+            saveLayout();
+          }
+          if (msg.error === 'session_not_found') {
+            // Session died — recreate via the server API (writes MCP config + tmux).
+            this._intentionalClose = true;
+            this._recreateSession();
+            return;
+          }
+        } catch {}
+      } else if (ev.data instanceof ArrayBuffer) {
+        this.term.write(new Uint8Array(ev.data));
+        this.updateState('working');
+      }
+    });
+    this.ws.addEventListener('close', () => {
+      this.updateState('dead');
+      if (!this._intentionalClose) {
+        this.term.write('\r\n\x1b[33m[reconnecting...]\x1b[0m\r\n');
+        this._reconnectTimer = setTimeout(() => {
+          this._reconnectDelay = Math.min(this._reconnectDelay * 2, 30000);
+          this.connectWs();
+        }, this._reconnectDelay);
+      } else {
+        this.term.write('\r\n\x1b[31m[disconnected]\x1b[0m\r\n');
+      }
+    });
+    this.ws.addEventListener('error', () => { this.updateState('dead'); });
+  }
+
+  async _recreateSession() {
+    // Ask the server to create a fresh canvas claude session (MCP config + tmux).
+    try {
+      this.term.write('\r\n\x1b[33m[session expired — restarting...]\x1b[0m\r\n');
+      const params = new URLSearchParams({ x: this.x, y: this.y, w: this.w, h: this.h });
+      if (this.profile) params.set('profile', this.profile);
+      if (this.canvasName) params.set('canvas_name', this.canvasName);
+      const resp = await fetch(`/api/canvas-claude/create?${params}`, { method: 'POST' });
+      if (!resp.ok) {
+        this.term.write('\r\n\x1b[31m[failed to restart session]\x1b[0m\r\n');
+        return;
+      }
+      const desc = await resp.json();
+      this.sessionId = desc.session_id;
+      saveLayout();
+      this._intentionalClose = false;
+      this.connectWs();
+    } catch (err) {
+      console.error('Canvas Claude recreate failed:', err);
+      this.term.write('\r\n\x1b[31m[failed to restart session]\x1b[0m\r\n');
+    }
+  }
+
   serialize() {
     const data = super.serialize();
     data.type = 'canvas_claude';
@@ -1769,6 +1844,24 @@ function spawnWidget(widgetType, x, y, w, h) {
 }
 
 async function spawnCanvasClaudeCard(x, y, w, h, sessionId, profile, canvasName) {
+  // If we have a saved sessionId (canvas reload / server restart), check if it is
+  // still alive.  If the session is dead (server restarted, orphan reaped), drop the
+  // stale ID so we fall through to the create-new path below.  This prevents zombie
+  // canvas claude cards that appear connected but have no live PTY.
+  if (sessionId) {
+    try {
+      const sessions = await (await fetch('/api/sessions')).json();
+      const alive = sessions.some(s => s.session_id === sessionId && s.alive);
+      if (!alive) {
+        console.log(`[canvas-claude] stale session ${sessionId} — will create fresh`);
+        sessionId = null;
+      }
+    } catch (_) {
+      // If the session list fetch fails, assume stale and recreate.
+      sessionId = null;
+    }
+  }
+
   // If no existing session, ask the server to create one
   if (!sessionId) {
     // Auto-resolve priority profile if none was explicitly set

--- a/tests/test_canvas_claude_card.py
+++ b/tests/test_canvas_claude_card.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from claude_rts.cards.canvas_claude_card import CanvasClaudeCard
+from claude_rts.cards.canvas_claude_card import CanvasClaudeCard, TMUX_SESSION_NAME
 from claude_rts.sessions import SessionManager
 
 
@@ -43,6 +43,11 @@ class MockPty:
 
 def _mock_subprocess_run(*a, **kw):
     return type("R", (), {"returncode": 0, "stderr": b""})()
+
+
+def _mock_subprocess_run_no_tmux(*a, **kw):
+    """Mock that returns failure for tmux has-session (no existing session)."""
+    return type("R", (), {"returncode": 1, "stderr": b"no session"})()
 
 
 async def test_canvas_claude_card_type():
@@ -121,11 +126,13 @@ async def test_canvas_claude_card_clear_session(monkeypatch):
     mgr.stop_all()
 
 
-async def test_canvas_claude_card_cmd_includes_mcp(monkeypatch):
-    """The computed cmd includes MCP config and docker exec."""
+async def test_canvas_claude_card_cmd_includes_tmux(monkeypatch):
+    """The computed cmd includes tmux new-session and the claude command."""
     monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
     mgr = SessionManager()
     card = CanvasClaudeCard(session_manager=mgr, container="my-container")
+    assert "tmux new-session" in card.cmd
+    assert TMUX_SESSION_NAME in card.cmd
     assert "mcp.json" in card.cmd
     assert "my-container" in card.cmd
 
@@ -151,12 +158,10 @@ async def test_canvas_claude_card_no_profile(monkeypatch):
 
 
 async def test_canvas_claude_card_no_bash_wrapper(monkeypatch):
-    """The PTY cmd does NOT use a bash -c wrapper (direct docker exec env pattern)."""
+    """The PTY cmd does NOT use a bash -c wrapper (direct docker exec pattern)."""
     monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
     mgr = SessionManager()
     card = CanvasClaudeCard(session_manager=mgr, container="my-container")
-    # cmd should be: docker.exe exec -it my-container [env ...] claude --mcp-config /tmp/mcp.json
-    # No bash -c wrapper — that pattern causes PTY allocation failures on Windows/ConPTY.
     assert "bash -c" not in card.cmd
 
 
@@ -189,4 +194,51 @@ async def test_canvas_claude_card_invalid_profile_rejected():
     mgr = SessionManager()
     with pytest.raises(ValueError):
         CanvasClaudeCard(session_manager=mgr, container="my-container", profile="x; evil")
+    mgr.stop_all()
+
+
+async def test_canvas_claude_card_ensure_tmux_attach(monkeypatch):
+    """_ensure_tmux_session sets cmd to attach when tmux session exists."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", _mock_subprocess_run)
+    mgr = SessionManager()
+    card = CanvasClaudeCard(session_manager=mgr, container="my-container")
+    # _mock_subprocess_run returns rc=0 → tmux session exists
+    card._ensure_tmux_session()
+    assert "tmux attach-session" in card.cmd
+    assert TMUX_SESSION_NAME in card.cmd
+    assert "--mcp-config" not in card.cmd  # attach doesn't include the full claude cmd
+
+
+async def test_canvas_claude_card_ensure_tmux_new(monkeypatch):
+    """_ensure_tmux_session sets cmd to new-session when no tmux session exists."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", _mock_subprocess_run_no_tmux)
+    mgr = SessionManager()
+    card = CanvasClaudeCard(session_manager=mgr, container="my-container")
+    card._ensure_tmux_session()
+    assert "tmux new-session" in card.cmd
+    assert TMUX_SESSION_NAME in card.cmd
+    assert "claude" in card.cmd
+
+
+async def test_canvas_claude_card_new_session_kills_tmux(monkeypatch):
+    """new_session() kills the tmux session before restarting."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    calls = []
+
+    def track_subprocess_run(cmd_list, **kw):
+        calls.append(cmd_list)
+        return type("R", (), {"returncode": 0, "stderr": b""})()
+
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", track_subprocess_run)
+    mgr = SessionManager()
+    card = CanvasClaudeCard(session_manager=mgr, container="test-container")
+    await card.start()
+    calls.clear()
+    await card.new_session()
+    # Should have called kill-session at some point
+    kill_calls = [c for c in calls if "kill-session" in c]
+    assert len(kill_calls) >= 1
+    await card.stop()
     mgr.stop_all()


### PR DESCRIPTION
Closes #105

## What changed

Canvas Claude Code cards were not resumable — closing and reopening a card spawned a fresh `claude` process, losing conversation history and tool context. Additionally, when the canvas was saved and reloaded (or the server restarted), stale Canvas Claude cards appeared as zombies with no live PTY backing them.

The root cause was that `CanvasClaudeCard` passed `container=None` to `SessionManager` to prevent SessionManager from replacing the bespoke `docker exec ... claude` command with its own generic tmux wrapper. This effectively disabled all tmux persistence. The fix gives CanvasClaudeCard its own tmux strategy: it wraps the claude command inside a tmux session with a stable name (`canvas-claude`) directly in the PTY command, bypassing SessionManager's tmux logic entirely.

## Implementation walkthrough

### New / modified functions

- **`_has_tmux_session()` in `claude_rts/cards/canvas_claude_card.py`** — Synchronously checks whether a tmux session named `canvas-claude` already exists inside the container by running `docker exec <container> tmux has-session -t canvas-claude`. Returns `True` if the session is alive, `False` otherwise (including on errors). This is the key probe that determines whether to attach or create.

- **`_kill_tmux_session()` in `claude_rts/cards/canvas_claude_card.py`** — Synchronously kills the `canvas-claude` tmux session inside the container. Called by `new_session()` before restarting, ensuring a clean slate. Replaces the old `_kill_orphan_claudes()` which used `pkill -x claude` — the tmux approach is cleaner because it terminates the entire session (including any child processes) rather than blindly killing processes by name.

- **`_ensure_tmux_session()` in `claude_rts/cards/canvas_claude_card.py`** — The decision point for attach vs create. If `_has_tmux_session()` returns True, sets `self.cmd` to `docker exec -it <container> tmux attach-session -t canvas-claude`. Otherwise, sets it to `docker exec -it <container> tmux new-session -s canvas-claude <claude_cmd>`. Called at `start()` time, just before `super().start()` spawns the PTY.

- **`__init__()` (modified)** — Now stores the inner claude command (`self._claude_cmd`) separately from the docker/tmux wrapping. The default `self.cmd` is set to the new-session variant, but `_ensure_tmux_session()` overrides it at start time based on actual container state.

- **`start()` (modified)** — No longer calls `_kill_orphan_claudes()`. Instead: (1) writes MCP config, (2) calls `_ensure_tmux_session()` to probe and set the right command, (3) delegates to `super().start()` for PTY spawning.

- **`new_session()` (modified)** — Now explicitly kills the tmux session between stop and start, so `_ensure_tmux_session()` sees no existing session and creates a fresh one.

### Frontend changes

- **`spawnCanvasClaudeCard()` in `index.html`** — When restoring from a saved layout (sessionId present), now checks `/api/sessions` to verify the session is still alive before attempting to reconnect. If the session is dead, drops the stale ID and falls through to the create-new path, preventing zombie cards.

- **`CanvasClaudeCard.connectWs()` in `index.html`** — New override that only connects via `/ws/session/{id}` (never the raw `/ws/session/new` path). On `session_not_found`, calls `_recreateSession()` instead of the parent's fallback, which would bypass MCP config and tmux setup.

- **`CanvasClaudeCard._recreateSession()` in `index.html`** — Shows a "[session expired — restarting...]" message, then calls `/api/canvas-claude/create` to get a properly initialized session (MCP config written, tmux session created), updates the sessionId, and reconnects.

### Default execution path

**Before**: `start()` → `_kill_orphan_claudes()` (pkill) → `_write_mcp_config()` → `super().start()` (spawns `docker exec -it container claude ...` without tmux) → PTY dies when card closes → next open spawns fresh claude, losing all state.

**After**: `start()` → `_write_mcp_config()` → `_ensure_tmux_session()` (probes container for existing tmux session) → `super().start()` (spawns either `tmux attach-session` or `tmux new-session ... claude`). When the card closes, the Windows-side PTY dies but tmux keeps claude alive in the container. Next open detects the existing session and attaches, resuming the conversation.

**Canvas reload path (before)**: Saved layout has stale `session_id` → `spawnCanvasClaudeCard()` passes it to `CanvasClaudeCard` → `connectWs()` tries `/ws/session/{staleId}` → server returns `session_not_found` → parent's handler clears sessionId and calls `connectWs()` again via `/ws/session/new` → raw session without MCP config = zombie card.

**Canvas reload path (after)**: Saved layout has `session_id` → `spawnCanvasClaudeCard()` checks `/api/sessions` → session dead → drops ID → calls `/api/canvas-claude/create` (writes MCP, sets up tmux) → gets fresh sessionId → card connects normally.

### Edge cases and error handling

- If `tmux has-session` fails (tmux not installed, container not running, timeout), `_has_tmux_session()` returns False and falls through to creating a new session — graceful degradation.
- If the `/api/sessions` check fails on canvas reload, sessionId is dropped and a fresh session is created — avoids getting stuck on a zombie.
- The `connectWs` override in `CanvasClaudeCard` shows "[session expired — restarting...]" feedback so the user sees what is happening rather than a silent failure.

### What was intentionally not changed

- `container=None` is still passed to SessionManager — this prevents SessionManager's own tmux wrapping from interfering. The card manages tmux itself with the stable `canvas-claude` session name.
- `recover_tmux_sessions()` was not modified to look for `canvas-claude` sessions. Instead, the frontend handles recovery: on reload, stale sessions are detected and recreated via the API. This is simpler and avoids coupling the generic session recovery to canvas-claude-specific logic.

## Tier / approach

Tier 1 — Planner -> Coder -> Reviewer

## Acceptance criteria

- [x] Close a Canvas Claude card, reopen it -> claude resumes at the same point in the conversation
- [x] Restart the server / reload the canvas -> no zombie canvas claude cards; stale sessions auto-restart
- [x] Existing PTY-alive reconnect path is preserved (if server did not restart, card reconnects correctly)

## Outstanding items

None

Generated with [Claude Code](https://claude.com/claude-code)