### PR TITLE
feat(#107): VM Manager card — list, start, and interact with VMs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ CLAUDE_RTS_TEST_MODE=1 python -m claude_rts   # enables puppeting API at /api/te
 | `test_terminal_card.py` | 11 | TerminalCard lifecycle, CardRegistry, server integration |
 | `test_claude_api.py` | 30 | Claude terminal control API (CRUD, send/read, strip_ansi, /ws/control, full lifecycle integration) |
 | `test_event_bus.py` | 14 | EventBus core (subscribe, emit, unsubscribe, wildcard, async, errors, clear) + integration (ServiceCard bus emit, CardRegistry events) |
+| `test_vm_manager.py` | 12 | VM Manager API (discover containers, favorites CRUD, start container, route registration) |
 | `e2e/test_smoke.py` | 7 | Playwright Electron smoke tests — launch, spawn, drag, resize, widgets, pan/zoom, save/reload |
 
 Tests use `MockPty` to avoid needing Docker. E2E tests require Playwright and Electron (`pip install -e ".[e2e]" && python -m playwright install chromium`).
@@ -98,6 +99,9 @@ Tests use `MockPty` to avoid needing Docker. E2E tests require Playwright and El
 | GET | `/api/widgets/system-info` | System info widget data |
 | GET | `/api/profiles` | Probe profiles with usage data, sorted by burn rate |
 | GET/PUT | `/api/profiles/priority` | Read/set priority profile |
+| GET | `/api/vms/discover` | Discover all Docker containers (running + stopped) with status |
+| GET/PUT | `/api/vms/favorites` | Read/write VM Manager favorites list |
+| POST | `/api/vms/{name}/start` | Start a stopped Docker container |
 | POST | `/api/claude/terminal/create` | Create a TerminalCard + PTY session (params: cmd, hub, container, cols, rows, x, y, w, h) |
 | POST | `/api/claude/terminal/{id}/send` | Write text to a terminal PTY |
 | GET | `/api/claude/terminal/{id}/read` | Read scrollback (optional: strip_ansi, last_n) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ To add a new preset: create a directory under `dev_presets/` with a `config.json
 
 ## Testing
 
+For E2E QA of new features, follow [`docs/e2e-qa-workflow.md`](docs/e2e-qa-workflow.md) — a 5-agent team workflow that designs, implements, and iterates on E2E tests using real dependencies (Docker containers, filesystem) by default.
+
 ```bash
 python -m pytest tests/ -v
 python -m ruff check . && python -m ruff format --check .   # lint + format check

--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -63,6 +63,9 @@ DEFAULT_CONFIG = {
         "scrollback_size": 65536,
         "tmux_persistence": True,
     },
+    "vm_manager": {
+        "favorites": [],
+    },
 }
 
 # Allowed canvas name pattern: alphanumeric, hyphens, underscores

--- a/claude_rts/dev_presets/vm-manager/canvases/vm-qa.json
+++ b/claude_rts/dev_presets/vm-manager/canvases/vm-qa.json
@@ -1,0 +1,14 @@
+{
+  "name": "vm-qa",
+  "canvas_size": [3840, 2160],
+  "cards": [
+    {
+      "type": "widget",
+      "widgetType": "vm-manager",
+      "x": 100,
+      "y": 100,
+      "w": 500,
+      "h": 450
+    }
+  ]
+}

--- a/claude_rts/dev_presets/vm-manager/config.json
+++ b/claude_rts/dev_presets/vm-manager/config.json
@@ -1,0 +1,45 @@
+{
+  "startup_script": "util-terminal",
+  "default_canvas": "vm-qa",
+  "priority_profile": "team-alpha",
+  "probe_profiles": [],
+  "sessions": {
+    "orphan_timeout": 60,
+    "scrollback_size": 65536,
+    "tmux_persistence": true
+  },
+  "util_container": {
+    "name": "supreme-claudemander-util",
+    "image": "supreme-claudemander-util:latest",
+    "auto_start": true,
+    "auto_stop": false,
+    "mounts": {
+      "~/.claude-profiles": "/profiles"
+    }
+  },
+  "vm_manager": {
+    "favorites": [
+      {
+        "name": "supreme-claudemander-util",
+        "type": "docker",
+        "actions": [
+          {"label": "Terminal", "type": "terminal"}
+        ]
+      },
+      {
+        "name": "e2e-qa-stopped",
+        "type": "docker",
+        "actions": [
+          {"label": "Terminal", "type": "terminal"}
+        ]
+      },
+      {
+        "name": "does-not-exist",
+        "type": "docker",
+        "actions": [
+          {"label": "Terminal", "type": "terminal"}
+        ]
+      }
+    ]
+  }
+}

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -218,6 +218,102 @@ async def widget_system_info_handler(request: web.Request) -> web.Response:
     return web.json_response(data)
 
 
+_DOCKER_CMD = "docker.exe" if sys.platform == "win32" else "docker"
+
+
+# ── VM Manager API ───────────────────────────────────────────────────────────
+
+
+async def vm_discover_handler(request: web.Request) -> web.Response:
+    """Discover all Docker containers (running + stopped) with status."""
+    proc = await asyncio.create_subprocess_exec(
+        _DOCKER_CMD,
+        "ps",
+        "-a",
+        "--format",
+        "{{.Names}}|{{.State}}|{{.Image}}|{{.Status}}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        err = stderr.decode().strip() if stderr else "docker ps failed"
+        logger.warning("vm_discover: docker ps failed: {}", err)
+        return web.json_response({"error": err}, status=500)
+
+    containers = []
+    for line in stdout.decode().strip().splitlines():
+        parts = line.split("|", 3)
+        if len(parts) < 2:
+            continue
+        name = parts[0].strip()
+        state = parts[1].strip().lower()
+        image = parts[2].strip() if len(parts) > 2 else ""
+        status_text = parts[3].strip() if len(parts) > 3 else ""
+        # Normalize state to online/offline/starting
+        if state == "running":
+            normalized = "online"
+        elif state in ("created", "restarting"):
+            normalized = "starting"
+        else:
+            normalized = "offline"
+        containers.append(
+            {
+                "name": name,
+                "state": normalized,
+                "image": image,
+                "status": status_text,
+            }
+        )
+
+    containers.sort(key=lambda c: c["name"])
+    return web.json_response(containers)
+
+
+async def vm_favorites_get_handler(request: web.Request) -> web.Response:
+    """Read the VM Manager favorites list from config."""
+    app_config: AppConfig = request.app["app_config"]
+    config = read_config(app_config)
+    vm_config = config.get("vm_manager", {})
+    favorites = vm_config.get("favorites", [])
+    return web.json_response(favorites)
+
+
+async def vm_favorites_put_handler(request: web.Request) -> web.Response:
+    """Write the VM Manager favorites list to config."""
+    app_config: AppConfig = request.app["app_config"]
+    body = await request.json()
+    favorites = body if isinstance(body, list) else body.get("favorites", [])
+    config = read_config(app_config)
+    if "vm_manager" not in config:
+        config["vm_manager"] = {}
+    config["vm_manager"]["favorites"] = favorites
+    write_config(app_config, config)
+    return web.json_response(favorites)
+
+
+async def vm_start_handler(request: web.Request) -> web.Response:
+    """Start a stopped Docker container by name."""
+    name = request.match_info["name"]
+    proc = await asyncio.create_subprocess_exec(
+        _DOCKER_CMD,
+        "start",
+        name,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        err = stderr.decode().strip() if stderr else "docker start failed"
+        logger.warning("vm_start: failed to start container '{}': {}", name, err)
+        return web.json_response({"error": err}, status=500)
+
+    logger.info("vm_start: started container '{}'", name)
+    return web.json_response({"name": name, "state": "online"})
+
+
 async def exec_websocket_handler(request: web.Request) -> web.WebSocketResponse:
     """WebSocket handler that spawns a PTY for an arbitrary command."""
     cmd = request.query.get("cmd", "").strip()
@@ -982,6 +1078,13 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
     app.router.add_put("/api/canvases/{name}", canvas_put_handler)
     app.router.add_delete("/api/canvases/{name}", canvas_delete_handler)
     app.router.add_get("/api/widgets/system-info", widget_system_info_handler)
+
+    # VM Manager API
+    app.router.add_get("/api/vms/discover", vm_discover_handler)
+    app.router.add_get("/api/vms/favorites", vm_favorites_get_handler)
+    app.router.add_put("/api/vms/favorites", vm_favorites_put_handler)
+    app.router.add_post("/api/vms/{name}/start", vm_start_handler)
+
     app.router.add_get("/api/profiles", profiles_list_handler)
     app.router.add_get("/api/profiles/discover", profiles_discover_handler)
     app.router.add_get("/api/profiles/priority", priority_get_handler)

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -226,6 +226,11 @@ _DOCKER_CMD = "docker.exe" if sys.platform == "win32" else "docker"
 
 async def vm_discover_handler(request: web.Request) -> web.Response:
     """Discover all Docker containers (running + stopped) with status."""
+    # In test mode, return injected mock data if available
+    test_containers = request.app.get("_test_vm_containers")
+    if test_containers is not None:
+        return web.json_response(sorted(test_containers, key=lambda c: c["name"]))
+
     proc = await asyncio.create_subprocess_exec(
         _DOCKER_CMD,
         "ps",
@@ -296,6 +301,17 @@ async def vm_favorites_put_handler(request: web.Request) -> web.Response:
 async def vm_start_handler(request: web.Request) -> web.Response:
     """Start a stopped Docker container by name."""
     name = request.match_info["name"]
+
+    # In test mode, flip mock container state instead of calling Docker
+    test_containers = request.app.get("_test_vm_containers")
+    if test_containers is not None:
+        for c in test_containers:
+            if c["name"] == name:
+                c["state"] = "online"
+                logger.info("vm_start (test): flipped '{}' to online", name)
+                return web.json_response({"name": name, "state": "online"})
+        return web.json_response({"error": f"No such container: {name}"}, status=500)
+
     proc = await asyncio.create_subprocess_exec(
         _DOCKER_CMD,
         "start",
@@ -576,6 +592,20 @@ async def test_session_delete(request: web.Request) -> web.Response:
 async def test_sessions_list(request: web.Request) -> web.Response:
     mgr: SessionManager = request.app["session_manager"]
     return web.json_response(mgr.list_sessions())
+
+
+async def test_vm_containers_put(request: web.Request) -> web.Response:
+    """PUT /api/test/vm-containers — inject fake container list for E2E tests."""
+    data = await request.json()
+    containers = data if isinstance(data, list) else data.get("containers", [])
+    request.app["_test_vm_containers"] = containers
+    return web.json_response(containers)
+
+
+async def test_vm_containers_get(request: web.Request) -> web.Response:
+    """GET /api/test/vm-containers — read back fake container list."""
+    containers = request.app.get("_test_vm_containers", [])
+    return web.json_response(containers)
 
 
 async def profiles_discover_handler(request: web.Request) -> web.Response:
@@ -1120,6 +1150,8 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
         app.router.add_get("/api/test/session/{id}/status", test_session_status)
         app.router.add_delete("/api/test/session/{id}", test_session_delete)
         app.router.add_get("/api/test/sessions", test_sessions_list)
+        app.router.add_put("/api/test/vm-containers", test_vm_containers_put)
+        app.router.add_get("/api/test/vm-containers", test_vm_containers_get)
 
     # Legacy hub WebSocket (catch-all, must be last)
     app.router.add_get("/ws/{hub}", websocket_handler)

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -1735,6 +1735,257 @@ const WIDGET_REGISTRY = {
       }
     },
   },
+  'vm-manager': {
+    label: 'VM Manager',
+    defaultRefreshInterval: 15000,
+    async render(body, card) {
+      try {
+        const esc = (s) => String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+
+        // Load favorites and discovered containers in parallel
+        const [favsResp, discoverResp, configResp] = await Promise.all([
+          fetch('/api/vms/favorites'),
+          fetch('/api/vms/discover'),
+          fetch('/api/config'),
+        ]);
+        if (!favsResp.ok) throw new Error(`Favorites: HTTP ${favsResp.status}`);
+        if (!discoverResp.ok) throw new Error(`Discover: HTTP ${discoverResp.status}`);
+
+        const favorites = await favsResp.json();
+        const allContainers = await discoverResp.json();
+        const config = configResp.ok ? await configResp.json() : {};
+        const priorityProfile = config.priority_profile || null;
+
+        // Build a lookup of discovered containers
+        const containerMap = {};
+        for (const c of allContainers) containerMap[c.name] = c;
+
+        // State indicator
+        const stateIcon = (state) => {
+          if (state === 'online') return '<span style="color:#a6e3a1" title="Online">●</span>';
+          if (state === 'starting') return '<span style="color:#f9e2af" title="Starting">●</span>';
+          return '<span style="color:#585b70" title="Offline">●</span>';
+        };
+
+        let html = '';
+
+        // ── Search / Add section ──
+        html += '<div style="padding:4px 6px;border-bottom:1px solid #313244">';
+        html += '<div style="display:flex;gap:4px;align-items:center">';
+        html += '<input type="text" data-vm-search placeholder="Search containers…" style="flex:1;background:#1e1e2e;border:1px solid #45475a;color:#cdd6f4;border-radius:4px;padding:3px 6px;font-size:11px;outline:none">';
+        html += '</div>';
+        html += '<div data-vm-search-results style="max-height:120px;overflow-y:auto;margin-top:4px;display:none"></div>';
+        html += '</div>';
+
+        // ── Favorites list ──
+        if (favorites.length === 0) {
+          html += '<div class="widget-row" style="padding:8px 6px"><span class="widget-label" style="color:#a6adc8">No favorites yet. Search above to add containers.</span></div>';
+        } else {
+          html += '<div style="overflow-y:auto;max-height:400px">';
+          for (const fav of favorites) {
+            const discovered = containerMap[fav.name];
+            const state = discovered ? discovered.state : 'offline';
+            const image = discovered ? discovered.image : '';
+            const actions = fav.actions || [{ label: 'Terminal', type: 'terminal' }];
+
+            html += '<div style="padding:6px;border-bottom:1px solid #181825">';
+            html += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:4px">';
+            html += stateIcon(state);
+            html += `<span style="font-weight:bold;font-size:12px;flex:1">${esc(fav.name)}</span>`;
+            if (state === 'offline') {
+              html += `<button data-vm-start="${esc(fav.name)}" style="background:#1e1e2e;border:1px solid #45475a;color:#a6e3a1;border-radius:4px;padding:2px 8px;cursor:pointer;font-size:10px" title="Start container">▶ Start</button>`;
+            }
+            html += `<button data-vm-remove="${esc(fav.name)}" style="background:none;border:1px solid #45475a;color:#f38ba8;border-radius:4px;padding:2px 6px;cursor:pointer;font-size:10px" title="Remove from favorites">✕</button>`;
+            html += '</div>';
+            if (image) {
+              html += `<div style="font-size:10px;color:#6c7086;margin-bottom:3px;padding-left:18px">${esc(image)}</div>`;
+            }
+            // Action buttons
+            html += '<div style="display:flex;gap:4px;flex-wrap:wrap;padding-left:18px">';
+            for (let i = 0; i < actions.length; i++) {
+              const act = actions[i];
+              const disabled = state !== 'online' ? 'opacity:0.4;pointer-events:none;' : '';
+              html += `<button data-vm-action="${esc(fav.name)}" data-action-idx="${i}" style="${disabled}background:#1e1e2e;border:1px solid #45475a;color:#89b4fa;border-radius:4px;padding:2px 8px;cursor:pointer;font-size:10px">${esc(act.label)}</button>`;
+            }
+            // Configure actions button
+            html += `<button data-vm-configure="${esc(fav.name)}" style="background:none;border:1px dashed #45475a;color:#6c7086;border-radius:4px;padding:2px 6px;cursor:pointer;font-size:10px" title="Configure actions">⚙</button>`;
+            html += '</div>';
+            html += '</div>';
+          }
+          html += '</div>';
+        }
+
+        body.innerHTML = html;
+
+        // ── Search functionality ──
+        const searchInput = body.querySelector('[data-vm-search]');
+        const searchResults = body.querySelector('[data-vm-search-results]');
+        if (searchInput && searchResults) {
+          searchInput.addEventListener('input', () => {
+            const q = searchInput.value.trim().toLowerCase();
+            if (!q) { searchResults.style.display = 'none'; return; }
+            const favNames = new Set(favorites.map(f => f.name));
+            const matches = allContainers.filter(c => c.name.toLowerCase().includes(q) && !favNames.has(c.name));
+            if (matches.length === 0) {
+              searchResults.innerHTML = '<div style="padding:4px 6px;color:#6c7086;font-size:11px">No matches</div>';
+            } else {
+              searchResults.innerHTML = matches.map(c =>
+                `<div style="display:flex;align-items:center;gap:6px;padding:3px 6px;cursor:pointer;font-size:11px" data-vm-add="${esc(c.name)}">
+                  ${stateIcon(c.state)} <span style="flex:1">${esc(c.name)}</span>
+                  <span style="color:#6c7086;font-size:10px">${esc(c.image)}</span>
+                  <span style="color:#a6e3a1;font-size:10px">+ Add</span>
+                </div>`
+              ).join('');
+            }
+            searchResults.style.display = 'block';
+          });
+
+          // Add to favorites
+          searchResults.addEventListener('click', async (e) => {
+            const addBtn = e.target.closest('[data-vm-add]');
+            if (!addBtn) return;
+            const name = addBtn.getAttribute('data-vm-add');
+            const newFavs = [...favorites, { name, type: 'docker', actions: [{ label: 'Terminal', type: 'terminal' }] }];
+            await fetch('/api/vms/favorites', {
+              method: 'PUT',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify(newFavs),
+            });
+            card.render();
+          });
+        }
+
+        // ── Remove from favorites ──
+        body.querySelectorAll('[data-vm-remove]').forEach(btn => {
+          btn.addEventListener('click', async () => {
+            const name = btn.getAttribute('data-vm-remove');
+            const newFavs = favorites.filter(f => f.name !== name);
+            await fetch('/api/vms/favorites', {
+              method: 'PUT',
+              headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify(newFavs),
+            });
+            card.render();
+          });
+        });
+
+        // ── Start container ──
+        body.querySelectorAll('[data-vm-start]').forEach(btn => {
+          btn.addEventListener('click', async () => {
+            const name = btn.getAttribute('data-vm-start');
+            btn.textContent = '⏳';
+            btn.disabled = true;
+            try {
+              const r = await fetch(`/api/vms/${encodeURIComponent(name)}/start`, { method: 'POST' });
+              if (!r.ok) {
+                const err = await r.json();
+                console.error('Failed to start:', err);
+              }
+            } catch (err) {
+              console.error('Start error:', err);
+            }
+            // Refresh after a short delay to let container come up
+            setTimeout(() => card.render(), 2000);
+          });
+        });
+
+        // ── Action buttons ──
+        body.querySelectorAll('[data-vm-action]').forEach(btn => {
+          btn.addEventListener('click', () => {
+            const name = btn.getAttribute('data-vm-action');
+            const idx = parseInt(btn.getAttribute('data-action-idx'), 10);
+            const fav = favorites.find(f => f.name === name);
+            if (!fav) return;
+            const act = (fav.actions || [])[idx];
+            if (!act) return;
+
+            const discovered = containerMap[name];
+            if (!discovered || discovered.state !== 'online') return;
+
+            const _docker = (navigator.platform.startsWith('Win') || navigator.userAgent.includes('Windows')) ? 'docker.exe' : 'docker';
+            let cmd;
+
+            if (act.shell_prefix) {
+              // Resolve import_keys
+              let prefix = act.shell_prefix;
+              if (act.import_keys && Array.isArray(act.import_keys)) {
+                for (const key of act.import_keys) {
+                  if (key === 'priority_credential' && priorityProfile) {
+                    prefix = prefix.replace('${priority_credential}', priorityProfile);
+                  }
+                }
+              }
+              cmd = `${_docker} exec -it ${name} bash -lc '${prefix.replace(/'/g, "'\\''")}'`;
+            } else {
+              // Default: attach terminal to container
+              cmd = `${_docker} exec -it ${name} bash -l`;
+            }
+
+            // Find or create a hub entry for spawnCard
+            const hub = { hub: name, container: name, exec: cmd };
+            if (typeof spawnCard === 'function') {
+              // Place near center of viewport
+              const vw = viewport.clientWidth;
+              const vh = viewport.clientHeight;
+              const cx = (-pan.x + vw / 2) / zoom;
+              const cy = (-pan.y + vh / 2) / zoom;
+              spawnCard(hub, cx - 480 + Math.random() * 60, cy - 320 + Math.random() * 60, 960, 640);
+            }
+          });
+        });
+
+        // ── Configure actions ──
+        body.querySelectorAll('[data-vm-configure]').forEach(btn => {
+          btn.addEventListener('click', () => {
+            const name = btn.getAttribute('data-vm-configure');
+            const fav = favorites.find(f => f.name === name);
+            if (!fav) return;
+
+            // Simple inline editor for actions
+            const dialog = document.createElement('div');
+            dialog.style.cssText = 'position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;z-index:100000';
+            const box = document.createElement('div');
+            box.style.cssText = 'background:#1e1e2e;border:1px solid #45475a;border-radius:8px;padding:16px;min-width:400px;max-width:600px;color:#cdd6f4;font-size:12px';
+            box.innerHTML = `
+              <div style="font-weight:bold;margin-bottom:8px">Configure actions for ${esc(name)}</div>
+              <div style="margin-bottom:8px;color:#6c7086;font-size:11px">Edit the JSON array of actions. Each action: { "label": "...", "type": "terminal", "shell_prefix": "...", "import_keys": [...] }</div>
+              <textarea data-actions-json style="width:100%;height:150px;background:#11111b;border:1px solid #45475a;color:#cdd6f4;border-radius:4px;padding:8px;font-family:monospace;font-size:11px;resize:vertical">${esc(JSON.stringify(fav.actions || [], null, 2))}</textarea>
+              <div style="display:flex;gap:8px;margin-top:8px;justify-content:flex-end">
+                <button data-cancel style="background:none;border:1px solid #45475a;color:#cdd6f4;border-radius:4px;padding:4px 12px;cursor:pointer">Cancel</button>
+                <button data-save style="background:#89b4fa;border:none;color:#1e1e2e;border-radius:4px;padding:4px 12px;cursor:pointer;font-weight:bold">Save</button>
+              </div>
+            `;
+            dialog.appendChild(box);
+            document.body.appendChild(dialog);
+
+            dialog.querySelector('[data-cancel]').addEventListener('click', () => dialog.remove());
+            dialog.addEventListener('click', (e) => { if (e.target === dialog) dialog.remove(); });
+
+            dialog.querySelector('[data-save]').addEventListener('click', async () => {
+              try {
+                const actions = JSON.parse(box.querySelector('[data-actions-json]').value);
+                const newFavs = favorites.map(f => f.name === name ? { ...f, actions } : f);
+                await fetch('/api/vms/favorites', {
+                  method: 'PUT',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify(newFavs),
+                });
+                dialog.remove();
+                card.render();
+              } catch (err) {
+                alert('Invalid JSON: ' + err.message);
+              }
+            });
+          });
+        });
+
+        card.updateState(favorites.length > 0 ? 'working' : 'idle');
+      } catch (err) {
+        body.innerHTML = `<div class="widget-row"><span class="widget-label" style="color:#f38ba8">Error: ${err.message}</span></div>`;
+        card.updateState('dead');
+      }
+    },
+  },
 };
 
 // ════════════════════════════════════════════

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -184,6 +184,8 @@
     padding: 4px 0;
     z-index: 2000;
     min-width: 200px;
+    max-height: calc(100vh - 20px);
+    overflow-y: auto;
     box-shadow: 0 8px 32px rgba(0,0,0,0.5);
   }
   #context-menu.visible { display: block; }
@@ -874,6 +876,15 @@ function showContextMenu(sx, sy) {
   ctxMenu.style.top = sy + 'px';
   ctxMenu.classList.add('visible');
 
+  // Clamp menu position so it doesn't overflow the viewport
+  const menuRect = ctxMenu.getBoundingClientRect();
+  if (menuRect.bottom > window.innerHeight) {
+    ctxMenu.style.top = Math.max(10, window.innerHeight - menuRect.height - 10) + 'px';
+  }
+  if (menuRect.right > window.innerWidth) {
+    ctxMenu.style.left = Math.max(10, window.innerWidth - menuRect.width - 10) + 'px';
+  }
+
   ctxMenu.querySelectorAll('.ctx-item[data-hub]').forEach(item => {
     item.addEventListener('click', (e) => {
       e.stopPropagation();
@@ -1266,8 +1277,10 @@ class TerminalCard extends Card {
     this.ws = new WebSocket(wsUrl);
     this.ws.binaryType = 'arraybuffer';
 
+    this._sessionCreatedAt = null;
     this.ws.addEventListener('open', () => {
       this._reconnectDelay = 1000;
+      this._sessionCreatedAt = Date.now();
       this.updateState('idle');
       this.ws.send(JSON.stringify({ type: 'resize', cols: this.term.cols, rows: this.term.rows }));
     });
@@ -1297,6 +1310,13 @@ class TerminalCard extends Card {
     });
     this.ws.addEventListener('close', () => {
       this.updateState('dead');
+      // If the session died within 3 seconds of creation, the command likely failed
+      // (e.g. bash not found in container). Stop reconnecting to avoid a runaway loop.
+      const sessionAge = this._sessionCreatedAt ? Date.now() - this._sessionCreatedAt : Infinity;
+      if (sessionAge < 3000) {
+        this.term.write('\r\n\x1b[31m[command failed — not reconnecting]\x1b[0m\r\n');
+        return;
+      }
       if (!this._intentionalClose) {
         this.term.write('\r\n\x1b[33m[reconnecting...]\x1b[0m\r\n');
         this._reconnectTimer = setTimeout(() => {
@@ -1875,17 +1895,26 @@ const WIDGET_REGISTRY = {
             const name = btn.getAttribute('data-vm-start');
             btn.textContent = '⏳';
             btn.disabled = true;
+            let failed = false;
             try {
               const r = await fetch(`/api/vms/${encodeURIComponent(name)}/start`, { method: 'POST' });
               if (!r.ok) {
-                const err = await r.json();
+                const err = await r.json().catch(() => ({ error: `HTTP ${r.status}` }));
                 console.error('Failed to start:', err);
+                btn.textContent = '✗';
+                btn.title = err.error || 'Start failed';
+                btn.style.color = '#f38ba8';
+                failed = true;
               }
             } catch (err) {
               console.error('Start error:', err);
+              btn.textContent = '✗';
+              btn.title = err.message || 'Start failed';
+              btn.style.color = '#f38ba8';
+              failed = true;
             }
             // Refresh after a short delay to let container come up
-            setTimeout(() => card.render(), 2000);
+            if (!failed) setTimeout(() => card.render(), 2000);
           });
         });
 
@@ -1915,10 +1944,10 @@ const WIDGET_REGISTRY = {
                   }
                 }
               }
-              cmd = `${_docker} exec -it ${name} bash -lc '${prefix.replace(/'/g, "'\\''")}'`;
+              cmd = `${_docker} exec -it ${name} sh -c '${prefix.replace(/'/g, "'\\''")}'`;
             } else {
-              // Default: attach terminal to container
-              cmd = `${_docker} exec -it ${name} bash -l`;
+              // Default: attach terminal to container (sh for compatibility — works on Alpine, busybox, etc.)
+              cmd = `${_docker} exec -it ${name} sh`;
             }
 
             // Find or create a hub entry for spawnCard

--- a/docs/e2e-qa-workflow.md
+++ b/docs/e2e-qa-workflow.md
@@ -1,0 +1,318 @@
+# E2E QA Workflow
+
+Automated end-to-end QA for new features using a team of agents. This workflow catches integration bugs that unit tests miss — frontend/backend wiring, DOM interactions, state across page reloads, and real external dependencies (Docker, filesystem, network).
+
+See [feature-testing-guide.md](feature-testing-guide.md) for the lower layers (unit tests, puppeting API, log inspection) that this workflow builds on top of.
+
+---
+
+## When to use
+
+- New user-facing feature with frontend + backend components
+- Feature adds new card types, widgets, or UI flows
+- Feature modifies existing E2E-covered behavior (regression risk)
+- Complex API + UI integration that unit tests cannot fully exercise
+
+**Skip when:** the change is backend-only with no UI, or is purely config/docs.
+
+---
+
+## Agent team
+
+Five agents run sequentially. Agents 4 and 5 loop until tests pass or the max iteration limit is hit.
+
+```
+Agent 1 (Analyst)
+  │
+  ▼
+Agent 2 (Designer)
+  │
+  ▼
+Agent 3 (Implementer)
+  │
+  ▼
+Agent 4 (Runner) ◄──┐
+  │                  │
+  ▼                  │
+Agent 5 (Fixer) ─────┘
+  │                 (max 3 rounds)
+  ▼
+Agent 4 (Runner) ← final pass
+  │
+  ▼
+Report
+```
+
+All agents run on Opus. Each agent is a separate subagent with a fresh context window — no accumulated context drift.
+
+---
+
+## Agent 1 — Analyst
+
+**Role:** Identify what needs to be tested and evaluated.
+
+**Input:** Issue number, PR diff, branch name.
+
+**Process:**
+1. Read the issue, PR description, and refined spec (if one exists in `.claude-work/`)
+2. Read the changed files to understand what was built
+3. Identify user-facing behaviors that need verification
+4. Identify external dependencies (Docker, filesystem, network, config persistence)
+5. Classify each dependency as **real** or **mock** (see [Real vs. mock](#real-vs-mock) below)
+
+**Output:** `.claude-work/E2E_<FEATURE>_ANALYSIS.md`
+
+```markdown
+# E2E Analysis: <feature>
+
+## Behaviors to verify
+- <behavior 1>
+- <behavior 2>
+
+## External dependencies
+| Dependency | Real or mock | Justification |
+|---|---|---|
+| Docker containers | Real | Feature starts/stops containers — must test real Docker responses |
+| Config file persistence | Real | Feature reads/writes config — must survive reload |
+| CDN (xterm.js) | Mock | Out of scope, not testing terminal rendering |
+
+## Risk areas
+- <integration point that is most likely to break>
+```
+
+---
+
+## Agent 2 — Designer
+
+**Role:** Design E2E test scenarios based on the analysis.
+
+**Input:** The analysis from Agent 1, plus access to existing E2E tests for pattern reference.
+
+**Process:**
+1. Read existing E2E tests (`tests/e2e/`) to understand patterns, fixtures, and infrastructure
+2. Read new unit tests to understand what is already covered — do not duplicate
+3. Design scenarios that exercise **frontend-backend integration**
+4. One scenario per distinct user flow, not per feature
+5. Prioritize: critical > high > medium > low
+
+**Output:** `.claude-work/E2E_<FEATURE>_PLAN.md`
+
+```markdown
+# E2E Test Plan: <feature>
+
+## Test Infrastructure Notes
+<fixtures, test containers, setup/teardown needed>
+
+## Scenarios
+
+### S1: <name>
+- **Setup**: <preconditions — containers to spin up, config to seed>
+- **Steps**: <numbered user actions>
+- **Expected**: <observable outcomes to assert>
+- **Priority**: critical / high / medium / low
+- **Real deps**: <which external systems are exercised for real>
+```
+
+---
+
+## Agent 3 — Implementer
+
+**Role:** Write the E2E test code and any supporting infrastructure.
+
+**Input:** The test plan from Agent 2.
+
+**Process:**
+1. Read existing E2E test files to match patterns exactly (fixtures, conftest, assertions)
+2. Implement all critical and high priority scenarios; include medium/low if straightforward
+3. Set up real dependencies (spin up test containers, seed config files)
+4. Add teardown logic to clean up real resources after tests
+5. Run linter/formatter — do NOT run the tests yet
+
+**Output:**
+- Test file(s) in `tests/e2e/`
+- Any test infrastructure (fixtures, helper functions, container setup scripts)
+- Dev preset if needed (under `claude_rts/dev_presets/`)
+
+**Constraints:**
+- Match existing test patterns exactly — do not invent new conventions
+- Real dependencies must have deterministic setup and teardown
+- Any test-only server endpoints must be gated behind test mode
+
+---
+
+## Agent 4 — Runner
+
+**Role:** Execute E2E tests, diagnose failures, produce a bug report.
+
+**Input:** Path to E2E test file(s), round number (R1, R2, R3).
+
+**Process:**
+1. Kill any running server instances (follow the server rule in CLAUDE.md)
+2. Run unit tests first to verify baseline is clean
+3. Run E2E tests
+4. For each failure:
+   - Read the error message and traceback
+   - Read the relevant source code to understand the root cause
+   - Classify as **app-bug** (source code wrong) or **test-bug** (test code wrong)
+5. On the final round, also run existing E2E smoke tests as a regression check
+
+**Output:** `.claude-work/E2E_BUG_REPORT_R<N>.md`
+
+```markdown
+# E2E Bug Report — Round <N>
+
+## Test Results Summary
+- Passed: N
+- Failed: N
+- Errors: N
+
+## Bugs Found
+
+### BUG-R<N>-1: <title>
+- **Test**: <test class/method>
+- **Type**: app-bug | test-bug
+- **Error**: <brief error message>
+- **Root cause**: <analysis after reading source>
+- **Fix**: <what needs to change and where>
+- **Severity**: critical | high | medium
+```
+
+**Key principles:**
+- Don't just report errors — **diagnose root causes** by reading source code
+- A single root cause can cascade across many tests (especially with module-scoped fixtures) — identify the root, don't list each test separately
+- Distinguish app bugs (ship-blocking) from test bugs (test code needs fixing)
+
+---
+
+## Agent 5 — Fixer
+
+**Role:** Apply fixes from the bug report.
+
+**Input:** Bug report from Agent 4.
+
+**Process:**
+1. Read the bug report
+2. Read the relevant source files before making changes
+3. Fix all bugs (both app-bugs and test-bugs)
+4. Run linter/formatter on modified files
+5. Run unit tests to verify nothing broke
+6. Do NOT run E2E tests — hand back to Agent 4
+
+**Constraints:**
+- Fix only what the bug report identifies — no unrelated refactoring
+- For app-bugs: minimal fix. If non-trivial, document the approach
+- For test-bugs: fix the test to correctly exercise the behavior, don't weaken assertions
+
+---
+
+## Loop protocol
+
+```
+Round 1: Agent 4 (Runner) → Agent 5 (Fixer)
+Round 2: Agent 4 (Runner) → Agent 5 (Fixer)
+Round 3: Agent 4 (Runner) — final, report only, no more fixes
+```
+
+**Rules:**
+- **Max 3 rounds.** If tests still fail after round 3, report outstanding issues and move on
+- After each Fixer pass, the next Runner starts with a fresh context
+- If a round finds 0 bugs, skip remaining rounds and report success
+- The final Runner round must also run existing E2E/smoke tests as a regression check
+
+---
+
+## Real vs. mock
+
+**Default to real.** If the feature interacts with an external system and that interaction is what we're testing, use the real thing.
+
+### Use real when
+
+- The feature starts/stops/queries Docker containers — spin up a test container
+- The feature reads/writes config files — use real filesystem with temp dirs
+- The feature makes HTTP calls to its own server — use the real running server
+- The feature exercises a subprocess (`docker.exe ps`, `docker.exe start`) — run the real command
+- The external system has multiple outcomes that matter (success, failure, timeout, partial response)
+
+**Example:** VM Manager calls `docker.exe start <name>`. The test should start a real stopped container and verify it transitions to running. It should also test starting a non-existent container and verify the error is surfaced to the user.
+
+### Use mock when
+
+- The dependency is out of scope for this feature (e.g. CDN assets, third-party APIs)
+- The real system is unavailable in CI and the interaction is not what we're testing
+- The dependency is already thoroughly covered by unit tests and adding real infra would be high cost for low signal
+
+**Example:** If testing a widget's drag/resize behavior, mock the data endpoint — the test is about the UI interaction, not the data.
+
+### Test container pattern
+
+For features that need Docker containers:
+
+```python
+@pytest.fixture(scope="module")
+def test_container():
+    """Spin up a lightweight container for E2E tests."""
+    name = "e2e-test-" + uuid.uuid4().hex[:8]
+    subprocess.run(
+        ["docker.exe", "run", "-d", "--name", name, "alpine:latest", "sleep", "3600"],
+        check=True, capture_output=True,
+    )
+    yield name
+    subprocess.run(
+        ["docker.exe", "rm", "-f", name],
+        capture_output=True,
+    )
+```
+
+Always clean up test containers in fixture teardown. Use `alpine:latest` or similar minimal images to keep spin-up fast.
+
+---
+
+## Final report
+
+After the last Runner round, the orchestrator presents:
+
+```markdown
+## E2E QA Report: <feature>
+
+### Results by round
+| Round | Passed | Failed | App bugs | Test bugs |
+|-------|--------|--------|----------|-----------|
+| R1    | N      | N      | N        | N         |
+| R2    | N      | N      | N        | N         |
+| R3    | N      | N      | N        | N         |
+
+### App bugs found and fixed
+- <title> — <one-line fix description>
+
+### Test bugs found and fixed
+- <title> — <one-line fix description>
+
+### Outstanding issues (not fixed after 3 rounds)
+- <title> — <severity, root cause, suggested fix>
+
+### Dependency coverage
+| Dependency | Real or mock | Notes |
+|---|---|---|
+| Docker containers | Real | Test container spun up/torn down per module |
+| Config persistence | Real | Temp dir via tmp_path fixture |
+| ... | ... | ... |
+
+### Regression check
+- Existing E2E smoke tests: N/N passed
+- Unit tests: N/N passed
+
+### Verdict: PASS | FAIL | PARTIAL (N outstanding issues)
+```
+
+---
+
+## Artifacts
+
+All intermediate artifacts are written to `.claude-work/` (git-excluded):
+
+| File | Agent | Contents |
+|------|-------|----------|
+| `E2E_<FEATURE>_ANALYSIS.md` | Analyst | Behaviors, dependencies, risk areas |
+| `E2E_<FEATURE>_PLAN.md` | Designer | Test scenarios with setup/steps/expected |
+| `E2E_BUG_REPORT_R<N>.md` | Runner | Per-round bug reports with root cause analysis |
+| `E2E_FINAL_REPORT.md` | Runner (final) | Consolidated results and verdict |

--- a/docs/feature-testing-guide.md
+++ b/docs/feature-testing-guide.md
@@ -191,6 +191,12 @@ credential-manager widget (frontend)
 
 This applies everywhere — QA scripts, agent automation, test fixtures. If you need probe data in a test context, render the credential-manager widget or call `POST /api/credentials/{name}/probe-result` directly with fixture data. Never call `probe_usage` or `probe_usage_via_session` — those functions have been removed.
 
+## Layer 5 — E2E QA workflow (agent team, real dependencies)
+
+For features with significant frontend + backend integration, run the full E2E QA workflow described in [e2e-qa-workflow.md](e2e-qa-workflow.md). This spawns a team of 5 agents (Analyst, Designer, Implementer, Runner, Fixer) that design, implement, and iterate on E2E tests using Playwright + Electron. Unlike the layers above, this workflow defaults to **real external dependencies** (real Docker containers, real filesystem) rather than mocks — see the guide for when to use each.
+
+---
+
 ## Coverage expectations per feature type
 
 | Feature type | Required coverage |
@@ -199,6 +205,7 @@ This applies everywhere — QA scripts, agent automation, test fixtures. If you 
 | API route (new endpoint) | aiohttp_client test for happy path + error cases |
 | Docker/subprocess integration | Mock `asyncio.create_subprocess_exec` at unit level; optionally smoke with real containers |
 | Startup script (new built-in) | Unit test for card list shape; WebFetch `/api/startup` smoke on running server |
+| Frontend + backend integration | E2E QA workflow ([e2e-qa-workflow.md](e2e-qa-workflow.md)) with Playwright + real dependencies |
 | Frontend-only behaviour | Log inspection (server side) + WebFetch API endpoints; browser visual confirmation deferred to human QA |
 | Config/canvas persistence | `test_config.py` pattern — use temp dirs via `tmp_path` fixture |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,3 +4,4 @@
 |------|----------|
 | [cards-and-canvas.md](cards-and-canvas.md) | Cards, canvases, startup scripts, config, file formats, and the probe-debug canvas |
 | [feature-testing-guide.md](feature-testing-guide.md) | Layered testing approach: unit tests, puppeting API, log inspection, REST smoke tests |
+| [e2e-qa-workflow.md](e2e-qa-workflow.md) | Agent team workflow for automated E2E QA: design, implement, run, fix, report |

--- a/tests/e2e/test_vm_manager_e2e.py
+++ b/tests/e2e/test_vm_manager_e2e.py
@@ -1,0 +1,1008 @@
+"""Playwright E2E tests for the VM Manager card.
+
+These tests launch the real backend with --dev-config vm-manager and
+verify VM Manager widget interactions via Playwright in a browser.
+
+Run:
+    pip install pytest-playwright playwright
+    python -m playwright install chromium
+    python -m pytest tests/e2e/test_vm_manager_e2e.py -v
+
+Headed mode (shows the browser window):
+    HEADED=1 python -m pytest tests/e2e/test_vm_manager_e2e.py -v
+"""
+
+import json
+
+import pytest
+
+# Skip module entirely if playwright is not installed
+pw = pytest.importorskip("playwright")
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def dev_config_preset():
+    """Use the vm-manager dev-config preset."""
+    return "vm-manager"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def seed_containers(page, backend_port, containers):
+    """PUT fake container data to the test puppeting API."""
+    page.evaluate(
+        """async ([port, containers]) => {
+        await fetch(`http://localhost:${port}/api/test/vm-containers`, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(containers),
+        });
+    }""",
+        [backend_port, containers],
+    )
+
+
+def set_favorites(page, backend_port, favorites):
+    """PUT favorites to the API."""
+    page.evaluate(
+        """async ([port, favorites]) => {
+        await fetch(`http://localhost:${port}/api/vms/favorites`, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(favorites),
+        });
+    }""",
+        [backend_port, favorites],
+    )
+
+
+def get_favorites(page, backend_port):
+    """GET favorites from the API."""
+    return page.evaluate(
+        """async (port) => {
+        const r = await fetch(`http://localhost:${port}/api/vms/favorites`);
+        return r.json();
+    }""",
+        backend_port,
+    )
+
+
+def get_test_vm_containers(page, backend_port):
+    """GET test VM containers from the puppeting API."""
+    return page.evaluate(
+        """async (port) => {
+        const r = await fetch(`http://localhost:${port}/api/test/vm-containers`);
+        return r.json();
+    }""",
+        backend_port,
+    )
+
+
+def refresh_vm_card(page):
+    """Force re-render of all VM Manager widget cards on the canvas."""
+    page.evaluate(
+        """() => {
+        if (typeof cards !== 'undefined') {
+            for (const card of cards) {
+                if (card.widgetType === 'vm-manager' && typeof card.render === 'function') {
+                    card.render();
+                }
+            }
+        }
+    }"""
+    )
+    page.wait_for_timeout(1500)
+
+
+def cleanup_non_vm_cards(page):
+    """Remove all cards except VM Manager widgets to prevent overlap issues.
+
+    Terminal cards spawned by earlier tests can intercept pointer events
+    on the VM Manager card.  This helper destroys them.
+    """
+    page.evaluate(
+        """() => {
+        if (typeof cards === 'undefined') return;
+        const toRemove = [];
+        for (let i = cards.length - 1; i >= 0; i--) {
+            if (cards[i].widgetType !== 'vm-manager') {
+                if (typeof cards[i].destroy === 'function') cards[i].destroy();
+                toRemove.push(i);
+            }
+        }
+        for (const idx of toRemove) cards.splice(idx, 1);
+    }"""
+    )
+    page.wait_for_timeout(300)
+
+
+def ensure_vm_card_exists(page):
+    """Ensure at least one VM Manager card exists; spawn one if needed."""
+    vm_cards = page.locator("[data-card-id]").filter(has=page.locator("[data-vm-search]"))
+    if vm_cards.count() > 0:
+        return
+    # Spawn from context menu
+    viewport = page.locator("#viewport")
+    viewport.click(button="right", position={"x": 500, "y": 100})
+    ctx_menu = page.locator("#context-menu")
+    ctx_menu.wait_for(state="visible", timeout=3000)
+    widget_item = ctx_menu.locator('[data-widget="vm-manager"]')
+    if widget_item.count() > 0:
+        widget_item.click()
+        page.wait_for_timeout(2000)
+    # Fallback: if context menu approach didn't spawn a card, use JS directly
+    vm_cards_after = page.locator("[data-card-id]").filter(has=page.locator("[data-vm-search]"))
+    if vm_cards_after.count() == 0:
+        page.evaluate("() => spawnWidget('vm-manager', 100, 100)")
+        page.wait_for_timeout(2000)
+
+
+# ── S1: VM Manager widget spawns from context menu ───────────────────────────
+
+
+class TestVmManagerSpawn:
+    """S1: VM Manager widget spawns from context menu."""
+
+    def test_vm_manager_spawns_from_context_menu(self, page, backend_port):
+        """Right-click canvas, click vm-manager widget, verify card appears."""
+        # Clear all cards first
+        page.evaluate(
+            """() => {
+            if (typeof cards !== 'undefined') {
+                for (const card of cards) {
+                    if (typeof card.destroy === 'function') card.destroy();
+                }
+                cards.length = 0;
+            }
+            const el = document.getElementById('canvas');
+            if (el) el.innerHTML = '';
+        }"""
+        )
+        page.wait_for_timeout(500)
+
+        # Right-click on viewport
+        viewport = page.locator("#viewport")
+        viewport.click(button="right", position={"x": 500, "y": 100})
+
+        ctx_menu = page.locator("#context-menu")
+        ctx_menu.wait_for(state="visible", timeout=3000)
+
+        # Find and click vm-manager widget item
+        widget_item = ctx_menu.locator('[data-widget="vm-manager"]')
+        assert widget_item.count() > 0, "vm-manager should be in context menu"
+        widget_item.click()
+
+        page.wait_for_timeout(2000)
+
+        # Verify card appeared
+        new_cards = page.locator("[data-card-id]")
+        assert new_cards.count() > 0, "A card should appear after clicking vm-manager"
+
+        # Verify card contains the VM search input
+        search_input = page.locator("[data-vm-search]")
+        assert search_input.count() > 0, "Card should contain [data-vm-search]"
+
+
+# ── S2: Favorites render with correct status indicators ──────────────────────
+
+
+class TestVmFavoritesStatus:
+    """S2: Favorites render with correct status indicators."""
+
+    def test_favorites_status_indicators(self, page, backend_port):
+        """Seed containers, set favorites, verify status dots and button states."""
+        # Seed 3 containers
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "alpha",
+                    "state": "online",
+                    "image": "node:18",
+                    "status": "Up 2 hours",
+                },
+                {
+                    "name": "beta",
+                    "state": "offline",
+                    "image": "postgres:15",
+                    "status": "Exited",
+                },
+                {
+                    "name": "gamma",
+                    "state": "starting",
+                    "image": "redis:7",
+                    "status": "Created",
+                },
+            ],
+        )
+
+        # Set favorites
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "alpha",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+                {
+                    "name": "beta",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+                {
+                    "name": "gamma",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+            ],
+        )
+
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Verify green dot for alpha (online)
+        alpha_dot = page.evaluate(
+            """() => {
+            const spans = document.querySelectorAll('span[title="Online"]');
+            for (const s of spans) {
+                if (s.closest('[data-card-id]') && s.parentElement.textContent.includes('alpha')) {
+                    return window.getComputedStyle(s).color;
+                }
+            }
+            return null;
+        }"""
+        )
+        assert alpha_dot is not None, "Alpha should have an Online indicator"
+
+        # Verify beta has a Start button
+        start_btn = page.locator('[data-vm-start="beta"]')
+        assert start_btn.count() > 0, "Offline container beta should have Start button"
+
+        # Verify alpha action buttons are NOT dimmed
+        alpha_action = page.locator('[data-vm-action="alpha"]').first
+        if alpha_action.count() > 0:
+            style = alpha_action.get_attribute("style") or ""
+            assert "opacity:0.4" not in style, "Online container actions should not be dimmed"
+
+        # Verify beta action buttons ARE dimmed
+        beta_action = page.locator('[data-vm-action="beta"]').first
+        if beta_action.count() > 0:
+            style = beta_action.get_attribute("style") or ""
+            assert "opacity:0.4" in style or "pointer-events:none" in style, (
+                "Offline container actions should be dimmed"
+            )
+
+
+# ── S3: Search discovers containers and adds to favorites ────────────────────
+
+
+class TestVmSearch:
+    """S3: Search discovers containers and adds to favorites."""
+
+    def test_search_and_add_favorite(self, page, backend_port):
+        """Type in search, find a container, click add, verify it joins favorites."""
+        # Seed containers
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "containerA",
+                    "state": "online",
+                    "image": "img:a",
+                    "status": "Up",
+                },
+                {
+                    "name": "containerB",
+                    "state": "online",
+                    "image": "img:b",
+                    "status": "Up",
+                },
+                {
+                    "name": "containerC",
+                    "state": "offline",
+                    "image": "img:c",
+                    "status": "Exited",
+                },
+                {
+                    "name": "containerD",
+                    "state": "online",
+                    "image": "img:d",
+                    "status": "Up",
+                },
+            ],
+        )
+
+        # Only containerA is a favorite
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "containerA",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                }
+            ],
+        )
+
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Click search input and type
+        search_input = page.locator("[data-vm-search]").first
+        search_input.click()
+        search_input.fill("containerB")
+
+        # Wait for search results
+        page.wait_for_timeout(500)
+        results = page.locator("[data-vm-search-results]").first
+        assert results.is_visible(), "Search results should be visible"
+
+        # Verify containerB appears in results
+        add_btn = page.locator('[data-vm-add="containerB"]')
+        assert add_btn.count() > 0, "containerB should appear in search results"
+
+        # Click add
+        add_btn.click()
+        page.wait_for_timeout(2000)
+
+        # Verify favorites now include containerB
+        favs = get_favorites(page, backend_port)
+        fav_names = [f["name"] for f in favs]
+        assert "containerA" in fav_names, "containerA should still be a favorite"
+        assert "containerB" in fav_names, "containerB should now be a favorite"
+
+
+# ── S4: Remove container from favorites ──────────────────────────────────────
+
+
+class TestVmRemoveFavorite:
+    """S4: Remove container from favorites."""
+
+    def test_remove_favorite(self, page, backend_port):
+        """Click remove button, verify container is removed from favorites."""
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "web-app",
+                    "state": "online",
+                    "image": "node:18",
+                    "status": "Up",
+                },
+                {
+                    "name": "db-server",
+                    "state": "online",
+                    "image": "pg:15",
+                    "status": "Up",
+                },
+            ],
+        )
+
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "web-app",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+                {
+                    "name": "db-server",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+            ],
+        )
+
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Click remove for web-app
+        remove_btn = page.locator('[data-vm-remove="web-app"]')
+        assert remove_btn.count() > 0, "Remove button for web-app should exist"
+        remove_btn.click()
+        page.wait_for_timeout(2000)
+
+        # Verify only db-server remains
+        favs = get_favorites(page, backend_port)
+        fav_names = [f["name"] for f in favs]
+        assert "web-app" not in fav_names, "web-app should be removed"
+        assert "db-server" in fav_names, "db-server should remain"
+
+        # Verify web-app row is gone from the card
+        remove_btn_after = page.locator('[data-vm-remove="web-app"]')
+        assert remove_btn_after.count() == 0, "web-app row should be gone from card"
+
+
+# ── S5: Start offline container via Start button ─────────────────────────────
+
+
+class TestVmStartContainer:
+    """S5: Start offline container via Start button."""
+
+    def test_start_offline_container(self, page, backend_port):
+        """Click Start on offline container, verify it becomes online."""
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "my-db",
+                    "state": "offline",
+                    "image": "postgres:15",
+                    "status": "Exited",
+                },
+            ],
+        )
+
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "my-db",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                }
+            ],
+        )
+
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Verify Start button exists
+        start_btn = page.locator('[data-vm-start="my-db"]')
+        assert start_btn.count() > 0, "Start button for my-db should exist"
+
+        # Click Start
+        start_btn.click()
+
+        # Wait for re-render (container start + render delay)
+        page.wait_for_timeout(3000)
+
+        # Verify container is now online via API
+        containers = get_test_vm_containers(page, backend_port)
+        my_db = next((c for c in containers if c["name"] == "my-db"), None)
+        assert my_db is not None, "my-db should exist in test containers"
+        assert my_db["state"] == "online", "my-db should be online after start"
+
+        # Verify Start button is gone (online containers don't show it)
+        start_btn_after = page.locator('[data-vm-start="my-db"]')
+        assert start_btn_after.count() == 0, "Start button should be gone for online container"
+
+
+# ── S6: Terminal action button spawns a terminal card ────────────────────────
+
+
+class TestVmTerminalAction:
+    """S6: Terminal action button spawns a terminal card."""
+
+    def test_action_spawns_terminal(self, page, backend_port):
+        """Click Terminal action on online container, verify new card spawns."""
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "dev-web",
+                    "state": "online",
+                    "image": "node:18",
+                    "status": "Up 2 hours",
+                },
+            ],
+        )
+
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "dev-web",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                }
+            ],
+        )
+
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Count existing cards
+        initial_count = page.locator("[data-card-id]").count()
+
+        # Click Terminal action
+        action_btn = page.locator('[data-vm-action="dev-web"][data-action-idx="0"]')
+        assert action_btn.count() > 0, "Terminal action button should exist"
+        action_btn.click()
+
+        page.wait_for_timeout(2000)
+
+        # Verify new card appeared
+        new_count = page.locator("[data-card-id]").count()
+        assert new_count > initial_count, "A new card should be spawned after clicking Terminal action"
+
+
+# ── S7: Custom action with shell_prefix ──────────────────────────────────────
+
+
+class TestVmCustomAction:
+    """S7: Custom action with shell_prefix spawns terminal with correct command."""
+
+    def test_custom_action_shell_prefix(self, page, backend_port):
+        """Click custom action, verify terminal card spawns with interpolated command."""
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "claude-dev",
+                    "state": "online",
+                    "image": "ubuntu:22.04",
+                    "status": "Up 1 hour",
+                },
+            ],
+        )
+
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "claude-dev",
+                    "type": "docker",
+                    "actions": [
+                        {"label": "Terminal", "type": "terminal"},
+                        {
+                            "label": "Claude",
+                            "type": "terminal",
+                            "shell_prefix": "cd /workspace && claude --profile ${priority_credential}",
+                            "import_keys": ["priority_credential"],
+                        },
+                    ],
+                }
+            ],
+        )
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Count existing cards
+        initial_count = page.locator("[data-card-id]").count()
+
+        # Click custom action (index 1)
+        action_btn = page.locator('[data-vm-action="claude-dev"][data-action-idx="1"]')
+        assert action_btn.count() > 0, "Custom Claude action button should exist"
+        action_btn.click()
+
+        page.wait_for_timeout(2000)
+
+        # Verify new card spawned
+        new_count = page.locator("[data-card-id]").count()
+        assert new_count > initial_count, "A new terminal card should be spawned for custom action"
+
+
+# ── S8: Action buttons disabled for offline containers ───────────────────────
+
+
+class TestVmActionsDisabledOffline:
+    """S8: Action buttons disabled for offline containers."""
+
+    def test_offline_actions_dimmed(self, page, backend_port):
+        """Verify action buttons are dimmed and non-interactive for offline containers."""
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "stopped-svc",
+                    "state": "offline",
+                    "image": "nginx:latest",
+                    "status": "Exited",
+                },
+            ],
+        )
+
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "stopped-svc",
+                    "type": "docker",
+                    "actions": [
+                        {"label": "Terminal", "type": "terminal"},
+                        {
+                            "label": "Logs",
+                            "type": "terminal",
+                            "shell_prefix": "tail -f /var/log/app.log",
+                        },
+                    ],
+                }
+            ],
+        )
+
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Verify action buttons are dimmed
+        action_btn = page.locator('[data-vm-action="stopped-svc"]').first
+        assert action_btn.count() > 0, "Action button should exist for stopped-svc"
+        style = action_btn.get_attribute("style") or ""
+        assert "opacity:0.4" in style or "pointer-events:none" in style, (
+            "Offline container action buttons should be dimmed"
+        )
+
+        # Click should not spawn a new card
+        initial_count = page.locator("[data-card-id]").count()
+        # Force-click even though pointer-events:none (Playwright can bypass)
+        # but the JS handler checks state !== 'online' and returns early
+        action_btn.dispatch_event("click")
+        page.wait_for_timeout(1000)
+        new_count = page.locator("[data-card-id]").count()
+        assert new_count == initial_count, "No new card should spawn for offline container"
+
+
+# ── S9: Configure actions dialog opens and saves ─────────────────────────────
+
+
+class TestVmConfigureActions:
+    """S9: Configure actions dialog opens and saves."""
+
+    def test_configure_dialog_saves(self, page, backend_port):
+        """Open configure dialog, edit JSON, save, verify updated actions."""
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "my-app",
+                    "state": "online",
+                    "image": "node:18",
+                    "status": "Up 1 hour",
+                },
+            ],
+        )
+
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "my-app",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                }
+            ],
+        )
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Click configure button
+        configure_btn = page.locator('[data-vm-configure="my-app"]')
+        assert configure_btn.count() > 0, "Configure button should exist"
+        configure_btn.click()
+
+        page.wait_for_timeout(500)
+
+        # Verify dialog appeared (fixed overlay with z-index: 100000)
+        dialog = page.locator("div[style*='z-index: 100000']")
+        assert dialog.count() > 0, "Configure dialog should appear"
+
+        # Verify textarea contains current actions JSON
+        textarea = page.locator("[data-actions-json]")
+        assert textarea.count() > 0, "Actions JSON textarea should exist"
+        value = textarea.input_value()
+        assert "Terminal" in value, "Textarea should contain current actions JSON"
+
+        # Clear and type new JSON
+        new_actions = json.dumps(
+            [
+                {"label": "Terminal", "type": "terminal"},
+                {
+                    "label": "Logs",
+                    "type": "terminal",
+                    "shell_prefix": "tail -f /var/log/app.log",
+                },
+            ]
+        )
+        textarea.fill(new_actions)
+
+        # Click Save
+        save_btn = page.locator("[data-save]")
+        save_btn.click()
+
+        page.wait_for_timeout(2000)
+
+        # Verify dialog disappeared
+        dialog_after = page.locator("div[style*='z-index: 100000']")
+        assert dialog_after.count() == 0, "Dialog should be closed after save"
+
+        # Verify favorites were updated
+        favs = get_favorites(page, backend_port)
+        my_app_fav = next((f for f in favs if f["name"] == "my-app"), None)
+        assert my_app_fav is not None, "my-app should still be a favorite"
+        assert len(my_app_fav["actions"]) == 2, "my-app should now have 2 actions"
+        assert my_app_fav["actions"][1]["label"] == "Logs"
+
+
+# ── S10: Configure actions dialog cancel does not save ───────────────────────
+
+
+class TestVmConfigureCancel:
+    """S10: Configure actions dialog cancel does not save."""
+
+    def test_configure_dialog_cancel(self, page, backend_port):
+        """Open configure dialog, modify, cancel, verify actions unchanged."""
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "cancel-test",
+                    "state": "online",
+                    "image": "node:18",
+                    "status": "Up",
+                },
+            ],
+        )
+
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "cancel-test",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                }
+            ],
+        )
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Open configure dialog
+        configure_btn = page.locator('[data-vm-configure="cancel-test"]')
+        configure_btn.click()
+        page.wait_for_timeout(500)
+
+        # Modify textarea
+        textarea = page.locator("[data-actions-json]")
+        textarea.fill('[{"label":"CHANGED","type":"terminal"}]')
+
+        # Click Cancel
+        cancel_btn = page.locator("[data-cancel]")
+        cancel_btn.click()
+        page.wait_for_timeout(500)
+
+        # Verify dialog closed
+        dialog = page.locator("div[style*='z-index: 100000']")
+        assert dialog.count() == 0, "Dialog should close on cancel"
+
+        # Verify favorites unchanged
+        favs = get_favorites(page, backend_port)
+        fav = next((f for f in favs if f["name"] == "cancel-test"), None)
+        assert fav is not None
+        assert fav["actions"][0]["label"] == "Terminal", "Actions should be unchanged after cancel"
+
+
+# ── S11: Configure actions dialog rejects invalid JSON ───────────────────────
+
+
+class TestVmConfigureInvalidJson:
+    """S11: Configure actions dialog rejects invalid JSON."""
+
+    def test_configure_invalid_json_rejected(self, page, backend_port):
+        """Type invalid JSON, click Save, verify alert and dialog stays open."""
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "json-test",
+                    "state": "online",
+                    "image": "node:18",
+                    "status": "Up",
+                },
+            ],
+        )
+
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "json-test",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                }
+            ],
+        )
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Open configure dialog
+        configure_btn = page.locator('[data-vm-configure="json-test"]')
+        configure_btn.click()
+        page.wait_for_timeout(500)
+
+        # Type invalid JSON
+        textarea = page.locator("[data-actions-json]")
+        textarea.fill("not valid json")
+
+        # Intercept dialog (alert)
+        alert_message = []
+        page.on("dialog", lambda dialog: (alert_message.append(dialog.message), dialog.accept()))
+
+        # Click Save
+        save_btn = page.locator("[data-save]")
+        save_btn.click()
+        page.wait_for_timeout(500)
+
+        # Verify alert fired
+        assert len(alert_message) > 0, "An alert should fire for invalid JSON"
+        assert "Invalid JSON" in alert_message[0], "Alert should mention Invalid JSON"
+
+        # Dialog should still be open
+        dialog = page.locator("div[style*='z-index: 100000']")
+        assert dialog.count() > 0, "Dialog should remain open after invalid JSON"
+
+        # Clean up: close dialog
+        cancel_btn = page.locator("[data-cancel]")
+        if cancel_btn.count() > 0:
+            cancel_btn.click()
+
+
+# ── S12: Search filters out already-favorited containers ─────────────────────
+
+
+class TestVmSearchFilters:
+    """S12: Search filters out already-favorited containers."""
+
+    def test_search_excludes_favorites(self, page, backend_port):
+        """Search results should not include containers that are already favorites."""
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {"name": "aaa", "state": "online", "image": "img:1", "status": "Up"},
+                {"name": "aab", "state": "online", "image": "img:2", "status": "Up"},
+                {"name": "aac", "state": "offline", "image": "img:3", "status": "Exited"},
+            ],
+        )
+
+        # aab is a favorite
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "aab",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                }
+            ],
+        )
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Type search query
+        search_input = page.locator("[data-vm-search]").first
+        search_input.click()
+        search_input.fill("aa")
+        page.wait_for_timeout(500)
+
+        # Verify search results
+        add_aaa = page.locator('[data-vm-add="aaa"]')
+        add_aab = page.locator('[data-vm-add="aab"]')
+        add_aac = page.locator('[data-vm-add="aac"]')
+
+        assert add_aaa.count() > 0, "aaa should be in search results"
+        assert add_aab.count() == 0, "aab should NOT be in search results (already a favorite)"
+        assert add_aac.count() > 0, "aac should be in search results"
+
+
+# ── S13: Empty favorites shows placeholder message ───────────────────────────
+
+
+class TestVmEmptyFavorites:
+    """S13: Empty favorites shows placeholder message."""
+
+    def test_empty_favorites_placeholder(self, page, backend_port):
+        """When favorites is empty, show the placeholder text."""
+        seed_containers(page, backend_port, [])
+        set_favorites(page, backend_port, [])
+
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Verify placeholder text
+        body_text = page.evaluate(
+            """() => {
+            const cards = document.querySelectorAll('[data-card-id]');
+            for (const card of cards) {
+                const search = card.querySelector('[data-vm-search]');
+                if (search) return card.textContent;
+            }
+            return '';
+        }"""
+        )
+        assert "No favorites yet" in body_text, "Empty favorites should show placeholder message"
+
+
+# ── S14: VM Manager card persists across canvas save/reload ──────────────────
+
+
+class TestVmPersistence:
+    """S14: VM Manager card persists across canvas save/reload."""
+
+    def test_vm_card_persists_reload(self, page, backend_port):
+        """Save canvas, reload, verify VM Manager card is still present."""
+        # Seed some data so the card has content
+        seed_containers(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "persist-test",
+                    "state": "online",
+                    "image": "node:18",
+                    "status": "Up",
+                },
+            ],
+        )
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": "persist-test",
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                }
+            ],
+        )
+
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Verify VM Manager card exists
+        vm_search = page.locator("[data-vm-search]")
+        assert vm_search.count() > 0, "VM Manager card should exist before save"
+
+        # Save layout
+        page.evaluate(
+            """async () => {
+            if (typeof saveLayout === 'function') saveLayout();
+        }"""
+        )
+        page.wait_for_timeout(1000)
+
+        # Reload
+        page.goto(f"http://localhost:{backend_port}")
+        page.wait_for_load_state("networkidle")
+        page.wait_for_selector("#canvas", timeout=10000)
+        page.wait_for_timeout(3000)
+
+        # Verify VM Manager card is restored
+        vm_search_after = page.locator("[data-vm-search]")
+        assert vm_search_after.count() > 0, "VM Manager card should persist after reload"

--- a/tests/e2e/test_vm_manager_real_e2e.py
+++ b/tests/e2e/test_vm_manager_real_e2e.py
@@ -1,0 +1,601 @@
+"""Playwright E2E tests for the VM Manager card using REAL Docker containers.
+
+These tests launch the real backend with --dev-config vm-manager and exercise
+the actual docker.exe code paths (no test puppeting API, no mock container
+data). Real containers are created/destroyed per test or per module.
+
+Requires Docker Desktop to be running. Skipped entirely if docker.exe is
+not available.
+
+Run:
+    pip install pytest-playwright playwright
+    python -m playwright install chromium
+    python -m pytest tests/e2e/test_vm_manager_real_e2e.py -v
+
+Headed mode (shows the browser window):
+    HEADED=1 python -m pytest tests/e2e/test_vm_manager_real_e2e.py -v
+"""
+
+import subprocess
+import uuid
+
+import pytest
+
+# Skip module entirely if playwright is not installed
+pw = pytest.importorskip("playwright")
+
+
+# ── Markers & skip logic ─────────────────────────────────────────────────────
+
+pytestmark = pytest.mark.real_docker
+
+
+def _docker_available() -> bool:
+    """Return True if docker.exe ps succeeds."""
+    try:
+        r = subprocess.run(
+            ["docker.exe", "ps"],
+            capture_output=True,
+            timeout=10,
+        )
+        return r.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+if not _docker_available():
+    pytest.skip("Docker is not available (docker.exe ps failed)", allow_module_level=True)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def dev_config_preset():
+    """Use the vm-manager dev-config preset."""
+    return "vm-manager"
+
+
+@pytest.fixture(scope="module")
+def running_container():
+    """Create a real running Alpine container for the test module."""
+    name = f"e2e-vm-running-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        ["docker.exe", "run", "-d", "--name", name, "alpine:latest", "sleep", "3600"],
+        check=True,
+        capture_output=True,
+    )
+    yield name
+    subprocess.run(
+        ["docker.exe", "rm", "-f", name],
+        capture_output=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def stopped_container():
+    """Create a real exited Alpine container for the test module.
+
+    Runs 'echo done' which exits immediately, producing state=exited
+    which normalizes to 'offline'.
+    """
+    name = f"e2e-vm-stopped-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        ["docker.exe", "run", "--name", name, "alpine:latest", "echo", "done"],
+        check=True,
+        capture_output=True,
+    )
+    yield name
+    subprocess.run(
+        ["docker.exe", "rm", "-f", name],
+        capture_output=True,
+    )
+
+
+@pytest.fixture()
+def startable_container():
+    """Create a fresh exited container per test (for start tests).
+
+    Runs ``sleep 3600`` then immediately stops it so the container is in
+    *exited* state (normalized to 'offline') but retains the long-running
+    command.  When ``docker start`` is called, the container stays running.
+
+    Using ``docker run … echo done`` would cause the container to exit
+    immediately after start (same short-lived command re-runs).
+    Using ``docker create`` produces state *created* which normalizes to
+    'starting', not 'offline', so the Start button never appears.
+
+    After the test, the container is force-removed regardless of state.
+    """
+    name = f"e2e-vm-startable-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        ["docker.exe", "run", "-d", "--name", name, "alpine:latest", "sleep", "3600"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["docker.exe", "stop", name],
+        check=True,
+        capture_output=True,
+        timeout=15,
+    )
+    yield name
+    subprocess.run(
+        ["docker.exe", "rm", "-f", name],
+        capture_output=True,
+    )
+
+
+@pytest.fixture()
+def bash_container():
+    """Create a running container with bash available (for terminal exec tests).
+
+    Uses the bash:latest image which includes bash.
+    """
+    name = f"e2e-vm-bash-{uuid.uuid4().hex[:8]}"
+    subprocess.run(
+        ["docker.exe", "run", "-d", "--name", name, "bash:latest", "sleep", "3600"],
+        check=True,
+        capture_output=True,
+    )
+    yield name
+    subprocess.run(
+        ["docker.exe", "rm", "-f", name],
+        capture_output=True,
+    )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def set_favorites(page, port, favorites):
+    """PUT favorites to the API."""
+    page.evaluate(
+        """async ([port, favorites]) => {
+        await fetch(`http://localhost:${port}/api/vms/favorites`, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(favorites),
+        });
+    }""",
+        [port, favorites],
+    )
+
+
+def get_favorites(page, port):
+    """GET favorites from the API."""
+    return page.evaluate(
+        """async (port) => {
+        const r = await fetch(`http://localhost:${port}/api/vms/favorites`);
+        return r.json();
+    }""",
+        port,
+    )
+
+
+def refresh_vm_card(page):
+    """Force re-render of all VM Manager widget cards on the canvas."""
+    page.evaluate(
+        """() => {
+        if (typeof cards !== 'undefined') {
+            for (const card of cards) {
+                if (card.widgetType === 'vm-manager' && typeof card.render === 'function') {
+                    card.render();
+                }
+            }
+        }
+    }"""
+    )
+    page.wait_for_timeout(2000)
+
+
+def cleanup_non_vm_cards(page):
+    """Remove all cards except VM Manager widgets to prevent overlap issues."""
+    page.evaluate(
+        """() => {
+        if (typeof cards === 'undefined') return;
+        const toRemove = [];
+        for (let i = cards.length - 1; i >= 0; i--) {
+            if (cards[i].widgetType !== 'vm-manager') {
+                if (typeof cards[i].destroy === 'function') cards[i].destroy();
+                toRemove.push(i);
+            }
+        }
+        for (const idx of toRemove) cards.splice(idx, 1);
+    }"""
+    )
+    page.wait_for_timeout(300)
+
+
+def ensure_vm_card_exists(page):
+    """Ensure at least one VM Manager card exists; spawn one if needed."""
+    vm_cards = page.locator("[data-card-id]").filter(has=page.locator("[data-vm-search]"))
+    if vm_cards.count() > 0:
+        return
+    # Spawn via JS directly
+    page.evaluate("() => spawnWidget('vm-manager', 100, 100)")
+    page.wait_for_timeout(2000)
+
+
+def docker_inspect_state(name: str) -> str:
+    """Return the Docker container state (e.g. 'running', 'exited')."""
+    r = subprocess.run(
+        ["docker.exe", "inspect", "--format", "{{.State.Status}}", name],
+        capture_output=True,
+        text=True,
+    )
+    return r.stdout.strip()
+
+
+# ── S1: Discovery returns real containers with correct state mapping ─────────
+
+
+class TestRealDiscovery:
+    """S1: Discovery shows real running/stopped containers with correct indicators."""
+
+    def test_real_containers_status_indicators(self, page, backend_port, running_container, stopped_container):
+        """Real running container shows Online, exited container shows Offline."""
+        # Set both containers as favorites
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": running_container,
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+                {
+                    "name": stopped_container,
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+            ],
+        )
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Verify running container has Online indicator
+        running_online = page.evaluate(
+            """(name) => {
+            const spans = document.querySelectorAll('span[title="Online"]');
+            for (const s of spans) {
+                if (s.closest('[data-card-id]') && s.parentElement.textContent.includes(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }""",
+            running_container,
+        )
+        assert running_online, "Running container should have an Online indicator"
+
+        # Verify stopped container has Offline indicator
+        stopped_offline = page.evaluate(
+            """(name) => {
+            const spans = document.querySelectorAll('span[title="Offline"]');
+            for (const s of spans) {
+                if (s.closest('[data-card-id]') && s.parentElement.textContent.includes(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }""",
+            stopped_container,
+        )
+        assert stopped_offline, "Stopped container should have an Offline indicator"
+
+        # Running container should NOT have a Start button
+        start_btn_running = page.locator(f'[data-vm-start="{running_container}"]')
+        assert start_btn_running.count() == 0, "Running container should not have a Start button"
+
+        # Stopped container SHOULD have a Start button
+        start_btn_stopped = page.locator(f'[data-vm-start="{stopped_container}"]')
+        assert start_btn_stopped.count() > 0, "Stopped container should have a Start button"
+
+
+# ── S2: Start a real stopped container ───────────────────────────────────────
+
+
+class TestRealStartContainer:
+    """S2: Start a real stopped container and verify state transition."""
+
+    def test_start_real_container(self, page, backend_port, startable_container):
+        """Click Start on a real exited container, verify it becomes running."""
+        # Add the startable container to favorites
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": startable_container,
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+            ],
+        )
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Verify Start button exists
+        start_btn = page.locator(f'[data-vm-start="{startable_container}"]')
+        assert start_btn.count() > 0, "Start button should exist for exited container"
+
+        # Click Start
+        start_btn.click()
+
+        # Wait for the container to start and the card to re-render
+        # The frontend does setTimeout(() => card.render(), 2000) after success
+        page.wait_for_timeout(4000)
+
+        # Verify container is actually running via docker inspect
+        state = docker_inspect_state(startable_container)
+        assert state == "running", f"Container should be running after start, got: {state}"
+
+        # Verify Start button is gone after re-render
+        start_btn_after = page.locator(f'[data-vm-start="{startable_container}"]')
+        assert start_btn_after.count() == 0, "Start button should disappear after container starts"
+
+        # Verify Online indicator appeared
+        online_indicator = page.evaluate(
+            """(name) => {
+            const spans = document.querySelectorAll('span[title="Online"]');
+            for (const s of spans) {
+                if (s.closest('[data-card-id]') && s.parentElement.textContent.includes(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }""",
+            startable_container,
+        )
+        assert online_indicator, "Container should show Online indicator after start"
+
+
+# ── S3: Start a non-existent container surfaces error ────────────────────────
+
+
+class TestRealStartNonExistent:
+    """S3: Start a non-existent container and verify error handling."""
+
+    def test_start_nonexistent_container_error(self, page, backend_port):
+        """Click Start on a bogus container name, verify error indicator appears."""
+        bogus_name = f"e2e-nonexistent-{uuid.uuid4().hex[:8]}"
+
+        # Add bogus name to favorites
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": bogus_name,
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+            ],
+        )
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # The bogus container won't be discovered, so it defaults to offline
+        # and should have a Start button
+        start_btn = page.locator(f'[data-vm-start="{bogus_name}"]')
+        assert start_btn.count() > 0, "Start button should exist for unknown container"
+
+        # Click Start
+        start_btn.click()
+
+        # Wait for the error response
+        page.wait_for_timeout(3000)
+
+        # The frontend sets btn.textContent = '\u2717' and btn.style.color = '#f38ba8' on failure
+        error_btn = page.locator(f'[data-vm-start="{bogus_name}"]')
+        assert error_btn.count() > 0, "Button should still exist after error"
+
+        btn_text = error_btn.text_content()
+        assert "\u2717" in btn_text, f"Button should show error mark after failed start, got: {btn_text}"
+
+        # The button title should contain the Docker error message
+        btn_title = error_btn.get_attribute("title") or ""
+        assert btn_title != "", "Button title should contain error message"
+
+
+# ── S4: Search shows real containers and adding one persists ─────────────────
+
+
+class TestRealSearch:
+    """S4: Search discovers real containers and adds to favorites."""
+
+    def test_search_and_add_real_container(self, page, backend_port, running_container):
+        """Type container name in search, click add, verify it joins favorites."""
+        # Start with empty favorites
+        set_favorites(page, backend_port, [])
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Type a substring of the running container's name in search
+        search_input = page.locator("[data-vm-search]").first
+        search_input.click()
+        # Use the e2e-vm-running prefix to find our container
+        search_input.fill("e2e-vm-running")
+
+        # Wait for search results
+        page.wait_for_timeout(1000)
+        results = page.locator("[data-vm-search-results]").first
+        assert results.is_visible(), "Search results should be visible"
+
+        # Verify our running container appears in results with an Add button
+        add_btn = page.locator(f'[data-vm-add="{running_container}"]')
+        assert add_btn.count() > 0, f"Container {running_container} should appear in search results"
+
+        # Click add
+        add_btn.click()
+        page.wait_for_timeout(2000)
+
+        # Verify favorites now include the container
+        favs = get_favorites(page, backend_port)
+        fav_names = [f["name"] for f in favs]
+        assert running_container in fav_names, f"{running_container} should now be a favorite"
+
+        # Verify the container shows in the favorites list with Online indicator
+        online_indicator = page.evaluate(
+            """(name) => {
+            const spans = document.querySelectorAll('span[title="Online"]');
+            for (const s of spans) {
+                if (s.closest('[data-card-id]') && s.parentElement.textContent.includes(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }""",
+            running_container,
+        )
+        assert online_indicator, "Added container should show Online indicator"
+
+
+# ── S5: Terminal action on a real running container spawns a card ─────────────
+
+
+class TestRealTerminalAction:
+    """S5: Terminal action on a real running container spawns a terminal card."""
+
+    def test_terminal_action_spawns_card(self, page, backend_port, bash_container):
+        """Click Terminal action on a real running container, verify card spawns."""
+        # Add the bash container to favorites
+        set_favorites(
+            page,
+            backend_port,
+            [
+                {
+                    "name": bash_container,
+                    "type": "docker",
+                    "actions": [{"label": "Terminal", "type": "terminal"}],
+                },
+            ],
+        )
+
+        cleanup_non_vm_cards(page)
+        ensure_vm_card_exists(page)
+        refresh_vm_card(page)
+
+        # Count existing cards
+        initial_count = page.locator("[data-card-id]").count()
+
+        # Click Terminal action button
+        action_btn = page.locator(f'[data-vm-action="{bash_container}"][data-action-idx="0"]')
+        assert action_btn.count() > 0, "Terminal action button should exist"
+        action_btn.click()
+
+        # Wait for new card to appear
+        page.wait_for_timeout(3000)
+
+        # Verify new card was spawned
+        new_count = page.locator("[data-card-id]").count()
+        assert new_count > initial_count, "A new card should be spawned after clicking Terminal action"
+
+
+# ── S6: Status accuracy after external state change ──────────────────────────
+
+
+class TestRealStatusAccuracy:
+    """S6: Status indicators reflect external container state changes."""
+
+    def test_status_updates_after_external_stop(self, page, backend_port, running_container, stopped_container):
+        """Stop a running container externally, re-render, verify status flips."""
+        # We need a dedicated container for this test since we'll stop it
+        name = f"e2e-vm-stoppable-{uuid.uuid4().hex[:8]}"
+        subprocess.run(
+            [
+                "docker.exe",
+                "run",
+                "-d",
+                "--name",
+                name,
+                "alpine:latest",
+                "sleep",
+                "3600",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        try:
+            # Add the container to favorites
+            set_favorites(
+                page,
+                backend_port,
+                [
+                    {
+                        "name": name,
+                        "type": "docker",
+                        "actions": [{"label": "Terminal", "type": "terminal"}],
+                    },
+                ],
+            )
+
+            cleanup_non_vm_cards(page)
+            ensure_vm_card_exists(page)
+            refresh_vm_card(page)
+
+            # Verify initially Online
+            online = page.evaluate(
+                """(name) => {
+                const spans = document.querySelectorAll('span[title="Online"]');
+                for (const s of spans) {
+                    if (s.closest('[data-card-id]') && s.parentElement.textContent.includes(name)) {
+                        return true;
+                    }
+                }
+                return false;
+            }""",
+                name,
+            )
+            assert online, "Container should initially show Online"
+
+            # No Start button while running
+            start_btn = page.locator(f'[data-vm-start="{name}"]')
+            assert start_btn.count() == 0, "No Start button while container is running"
+
+            # Stop the container externally
+            subprocess.run(
+                ["docker.exe", "stop", name],
+                check=True,
+                capture_output=True,
+                timeout=15,
+            )
+
+            # Re-render to pick up the state change
+            refresh_vm_card(page)
+
+            # Verify now Offline
+            offline = page.evaluate(
+                """(name) => {
+                const spans = document.querySelectorAll('span[title="Offline"]');
+                for (const s of spans) {
+                    if (s.closest('[data-card-id]') && s.parentElement.textContent.includes(name)) {
+                        return true;
+                    }
+                }
+                return false;
+            }""",
+                name,
+            )
+            assert offline, "Container should show Offline after external stop"
+
+            # Start button should now appear
+            start_btn_after = page.locator(f'[data-vm-start="{name}"]')
+            assert start_btn_after.count() > 0, "Start button should appear after container is stopped"
+
+        finally:
+            subprocess.run(
+                ["docker.exe", "rm", "-f", name],
+                capture_output=True,
+            )

--- a/tests/test_vm_manager.py
+++ b/tests/test_vm_manager.py
@@ -1,0 +1,212 @@
+"""Tests for VM Manager API endpoints."""
+
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from claude_rts import config
+from claude_rts.server import create_app
+
+
+@pytest.fixture
+def app(tmp_path):
+    app_config = config.load(tmp_path / ".sc")
+    return create_app(app_config)
+
+
+@pytest.fixture
+async def client(aiohttp_client, app):
+    return await aiohttp_client(app)
+
+
+# ── Discovery ────────────────────────────────────────────────────────────────
+
+
+def _mock_docker_ps(stdout_text, returncode=0):
+    """Create a mock for asyncio.create_subprocess_exec returning docker ps output."""
+    mock_proc = AsyncMock()
+    mock_proc.returncode = returncode
+    mock_proc.communicate = AsyncMock(return_value=(stdout_text.encode(), b""))
+    return mock_proc
+
+
+async def test_vm_discover_returns_containers(client):
+    docker_output = (
+        "web-app|running|node:18|Up 2 hours\n"
+        "db-server|exited|postgres:15|Exited (0) 3 hours ago\n"
+        "cache|running|redis:7|Up 5 hours\n"
+    )
+    mock_proc = _mock_docker_ps(docker_output)
+    with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
+        resp = await client.get("/api/vms/discover")
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert len(data) == 3
+    # Sorted by name
+    assert data[0]["name"] == "cache"
+    assert data[0]["state"] == "online"
+    assert data[1]["name"] == "db-server"
+    assert data[1]["state"] == "offline"
+    assert data[2]["name"] == "web-app"
+    assert data[2]["state"] == "online"
+
+
+async def test_vm_discover_empty(client):
+    mock_proc = _mock_docker_ps("")
+    with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
+        resp = await client.get("/api/vms/discover")
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == []
+
+
+async def test_vm_discover_docker_failure(client):
+    mock_proc = _mock_docker_ps("", returncode=1)
+    mock_proc.communicate = AsyncMock(return_value=(b"", b"Cannot connect to Docker"))
+    with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
+        resp = await client.get("/api/vms/discover")
+
+    assert resp.status == 500
+    data = await resp.json()
+    assert "error" in data
+
+
+async def test_vm_discover_normalizes_states(client):
+    docker_output = (
+        "c1|running|img:1|Up 1h\n"
+        "c2|created|img:2|Created\n"
+        "c3|restarting|img:3|Restarting\n"
+        "c4|exited|img:4|Exited\n"
+        "c5|dead|img:5|Dead\n"
+    )
+    mock_proc = _mock_docker_ps(docker_output)
+    with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
+        resp = await client.get("/api/vms/discover")
+
+    data = await resp.json()
+    states = {c["name"]: c["state"] for c in data}
+    assert states["c1"] == "online"
+    assert states["c2"] == "starting"
+    assert states["c3"] == "starting"
+    assert states["c4"] == "offline"
+    assert states["c5"] == "offline"
+
+
+# ── Favorites CRUD ───────────────────────────────────────────────────────────
+
+
+async def test_vm_favorites_empty_by_default(client):
+    resp = await client.get("/api/vms/favorites")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data == []
+
+
+async def test_vm_favorites_put_and_get(client):
+    favorites = [
+        {"name": "web-app", "type": "docker", "actions": [{"label": "Terminal", "type": "terminal"}]},
+        {"name": "db-server", "type": "docker", "actions": []},
+    ]
+    resp = await client.put(
+        "/api/vms/favorites",
+        json=favorites,
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert len(data) == 2
+
+    # Verify persistence
+    resp2 = await client.get("/api/vms/favorites")
+    data2 = await resp2.json()
+    assert len(data2) == 2
+    assert data2[0]["name"] == "web-app"
+    assert data2[1]["name"] == "db-server"
+
+
+async def test_vm_favorites_put_with_wrapper(client):
+    """Accept favorites wrapped in {"favorites": [...]}."""
+    resp = await client.put(
+        "/api/vms/favorites",
+        json={"favorites": [{"name": "test-container", "type": "docker"}]},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "test-container"
+
+
+async def test_vm_favorites_persists_in_config(client, app):
+    favorites = [{"name": "my-vm", "type": "docker"}]
+    await client.put("/api/vms/favorites", json=favorites)
+
+    # Read raw config to verify vm_manager section
+    app_config = app["app_config"]
+    raw = config.read_config(app_config)
+    assert "vm_manager" in raw
+    assert raw["vm_manager"]["favorites"] == favorites
+
+
+async def test_vm_favorites_with_custom_actions(client):
+    favorites = [
+        {
+            "name": "devcontainer-web",
+            "type": "docker",
+            "actions": [
+                {"label": "Terminal", "type": "terminal"},
+                {
+                    "label": "Claude (web creds)",
+                    "type": "terminal",
+                    "shell_prefix": "cd /workspace/web && claude --config-dir ${priority_credential}",
+                    "import_keys": ["priority_credential"],
+                },
+            ],
+        }
+    ]
+    resp = await client.put("/api/vms/favorites", json=favorites)
+    assert resp.status == 200
+
+    resp2 = await client.get("/api/vms/favorites")
+    data = await resp2.json()
+    assert len(data[0]["actions"]) == 2
+    assert data[0]["actions"][1]["shell_prefix"].startswith("cd /workspace/web")
+    assert "priority_credential" in data[0]["actions"][1]["import_keys"]
+
+
+# ── Start container ──────────────────────────────────────────────────────────
+
+
+async def test_vm_start_success(client):
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate = AsyncMock(return_value=(b"web-app\n", b""))
+    with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
+        resp = await client.post("/api/vms/web-app/start")
+
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["name"] == "web-app"
+    assert data["state"] == "online"
+
+
+async def test_vm_start_failure(client):
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate = AsyncMock(return_value=(b"", b"No such container"))
+    with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
+        resp = await client.post("/api/vms/nonexistent/start")
+
+    assert resp.status == 500
+    data = await resp.json()
+    assert "error" in data
+
+
+# ── Route registration ───────────────────────────────────────────────────────
+
+
+async def test_vm_routes_registered(app):
+    routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, "resource")]
+    assert "/api/vms/discover" in routes
+    assert "/api/vms/favorites" in routes
+    assert "/api/vms/{name}/start" in routes


### PR DESCRIPTION
Closes #107

## What changed

Added a VM Manager widget card that provides a persistent, actionable view of Docker containers. Users can discover containers, add favorites, see live status, start stopped containers, and launch terminals with configurable actions (including custom shell prefixes with priority credential import).

## Implementation walkthrough

### Backend API (server.py)

- **`vm_discover_handler`** — runs `docker ps -a` to discover all containers (running + stopped), normalizes state to online/offline/starting, returns sorted list with name, state, image, and status text.
- **`vm_favorites_get_handler` / `vm_favorites_put_handler`** — CRUD for the favorites list stored in `config.json` under `vm_manager.favorites`. Accepts both bare array and `{"favorites": [...]}` wrapper formats.
- **`vm_start_handler`** — runs `docker start <name>` to start a stopped container, returns the new state.

### Frontend widget (index.html)

- **`vm-manager` in `WIDGET_REGISTRY`** — full-featured widget with search bar (filters discovered containers, add to favorites), favorites list with status indicators (green/yellow/grey dots), start button for offline containers, configurable action buttons per favorite, and a JSON editor dialog for action configuration.
- Custom actions support `shell_prefix` with `import_keys` resolution — `${priority_credential}` is replaced with the active priority profile from config.

### Config (config.py)

- Added `vm_manager.favorites` to `DEFAULT_CONFIG` so it merges cleanly on first access.

## Default execution path

**Before**: No way to see or interact with non-devcontainer Docker containers from the canvas.

**After**: User spawns VM Manager widget from context menu -> widget fetches `/api/vms/discover` + `/api/vms/favorites` + `/api/config` in parallel -> renders search bar + favorites list with status -> user can search/add/remove favorites, start containers, launch terminals with default or custom actions -> favorites persist in config.json.

## Tier / approach

Tier 2 — Planner -> Coder (backend + frontend) -> Tester -> Reviewer

## Acceptance criteria

- [x] VM Manager card appears in context menu and can be spawned
- [x] Discover endpoint lists all Docker containers (running + stopped) with status
- [x] User can add/remove containers to favorites
- [x] Favorites persist across sessions via config.json
- [x] User can start a stopped container from the card
- [x] Default terminal action spawns a TerminalCard attached to the container
- [x] Custom actions with shell_prefix launch terminals with the custom command
- [x] Custom actions can import priority_credential from config
- [x] All existing tests pass (267 passed), new tests pass (12 tests)
- [x] Ruff lint and format pass

## Outstanding items

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)