### PR TITLE
fix(#128): unify spawn + deserialize call sites + dynamic context menu

### DIFF
--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -810,19 +810,17 @@ viewport.addEventListener('contextmenu', (e) => {
 document.addEventListener('click', () => hideContextMenu());
 document.addEventListener('keydown', (e) => { if (e.key === 'Escape') hideContextMenu(); });
 
+// Context menu is built from two sources:
+//   1. `CARD_TYPE_REGISTRY.menuEntries()` — drives the "static" card-type rows
+//      (currently only Canvas Claude Code; any future card type that registers
+//      with a menuSection will be picked up automatically).
+//   2. Data-driven contributors that are dynamic per-invocation: discovered
+//      hubs, host shells, widget types, probe profiles. These still live here
+//      because they are not single card types but *factories* for one type
+//      parameterised per row.
+// All click handlers dispatch through `CARD_TYPE_REGISTRY.spawn(type, opts)`.
 function showContextMenu(sx, sy) {
-  let html = '<div class="ctx-header">Spawn terminal</div>';
-  hubs.forEach((h, i) => {
-    const sym = hubSymbolMap[h.hub] || '?';
-    const detail = h.container ? ` <span style="color:#585b70;font-size:11px">(${h.container})</span>` : '';
-    html += `<div class="ctx-item" data-hub="${h.hub}">
-      <span class="symbol-preview">${sym}</span>
-      ${h.hub}${detail}
-    </div>`;
-  });
-
-  // Host terminal section
-  html += '<div class="ctx-header">Host terminal</div>';
+  // Build dynamic contributors for each menuSection.
   const isWin = navigator.platform.startsWith('Win') || navigator.userAgent.includes('Windows');
   const hostShells = isWin ? [
     { id: 'powershell', label: 'PowerShell', cmd: 'powershell.exe', container: 'localhost' },
@@ -833,14 +831,54 @@ function showContextMenu(sx, sy) {
     { id: 'bash', label: 'bash', cmd: '/bin/bash -l', container: 'localhost' },
     { id: 'util', label: 'Utility Container', cmd: 'docker exec -it supreme-claudemander-util bash', container: 'supreme-claudemander-util' },
   ];
+
+  let html = '';
+  const pendingHandlers = []; // {selector, handler}
+
+  // --- Spawn terminal (one row per discovered hub) ---
+  html += '<div class="ctx-header">Spawn terminal</div>';
+  hubs.forEach((h) => {
+    const sym = hubSymbolMap[h.hub] || '?';
+    const detail = h.container ? ` <span style="color:#585b70;font-size:11px">(${h.container})</span>` : '';
+    html += `<div class="ctx-item" data-hub="${h.hub}">
+      <span class="symbol-preview">${sym}</span>
+      ${h.hub}${detail}
+    </div>`;
+  });
+  pendingHandlers.push({
+    selector: '.ctx-item[data-hub]',
+    handler: (item) => {
+      const hub = hubs.find(h => h.hub === item.dataset.hub);
+      if (hub) CARD_TYPE_REGISTRY.spawn('terminal', { hub, x: ctxMenuCanvasPos.x, y: ctxMenuCanvasPos.y });
+    },
+  });
+
+  // --- Host terminal (one row per host shell) ---
+  html += '<div class="ctx-header">Host terminal</div>';
   for (const shell of hostShells) {
     html += `<div class="ctx-item" data-host-shell="${shell.id}" data-host-cmd="${shell.cmd}" data-host-container="${shell.container}">
       <span class="symbol-preview" style="color:#89b4fa">H</span>
       ${shell.label}
     </div>`;
   }
+  pendingHandlers.push({
+    selector: '.ctx-item[data-host-shell]',
+    handler: (item) => {
+      const shellId = item.dataset.hostShell;
+      const shellCmd = item.dataset.hostCmd;
+      const shellContainer = item.dataset.hostContainer || 'localhost';
+      if (!hubSymbolMap[shellId]) hubSymbolMap[shellId] = 'H';
+      CARD_TYPE_REGISTRY.spawn('terminal', {
+        hub: shellId,
+        container: shellContainer,
+        exec: shellCmd,
+        x: ctxMenuCanvasPos.x,
+        y: ctxMenuCanvasPos.y,
+      });
+    },
+  });
 
-  // Widget section
+  // --- Spawn widget (one row per widget type) ---
   const widgetTypes = Object.keys(WIDGET_REGISTRY);
   if (widgetTypes.length > 0) {
     html += '<div class="ctx-header">Spawn widget</div>';
@@ -851,9 +889,19 @@ function showContextMenu(sx, sy) {
         ${def.label || wt}
       </div>`;
     }
+    pendingHandlers.push({
+      selector: '.ctx-item[data-widget]',
+      handler: (item) => {
+        CARD_TYPE_REGISTRY.spawn('widget', {
+          widgetType: item.dataset.widget,
+          x: ctxMenuCanvasPos.x,
+          y: ctxMenuCanvasPos.y,
+        });
+      },
+    });
   }
 
-  // Claude usage probe section
+  // --- Claude usage probe (one row per configured profile) ---
   if (probeProfiles.length > 0) {
     html += '<div class="ctx-header">Claude usage probe</div>';
     for (const profile of probeProfiles) {
@@ -862,14 +910,69 @@ function showContextMenu(sx, sy) {
         ${profile}
       </div>`;
     }
+    pendingHandlers.push({
+      selector: '.ctx-item[data-probe-profile]',
+      async: true,
+      handler: async (item) => {
+        const profile = item.dataset.probeProfile;
+        try {
+          const resp = await fetch(`/api/probe/claude-usage?profile=${encodeURIComponent(profile)}`, { method: 'POST' });
+          if (!resp.ok) throw new Error(await resp.text());
+          const { session_id } = await resp.json();
+          const hubName = `claude-probe-${profile}`;
+          if (!hubSymbolMap[hubName]) hubSymbolMap[hubName] = 'P';
+          await CARD_TYPE_REGISTRY.spawn('terminal', {
+            hub: hubName,
+            container: 'supreme-claudemander-util',
+            exec: null,
+            sessionId: session_id,
+            x: ctxMenuCanvasPos.x,
+            y: ctxMenuCanvasPos.y,
+            w: 960,
+            h: 640,
+          });
+        } catch (err) {
+          console.error('Failed to start claude usage probe:', err);
+        }
+      },
+    });
   }
 
-  // Canvas Claude Code section
-  html += '<div class="ctx-header">Canvas Claude Code</div>';
-  html += `<div class="ctx-item" data-canvas-claude="true">
-    <span class="symbol-preview" style="color:#cba6f7">C</span>
-    Canvas Claude Code
-  </div>`;
+  // --- Registry-driven card-type rows ---
+  // Walk menuEntries() and render one header+row per section. Sections already
+  // handled above (terminals, widgets) are omitted here since they are
+  // contributed data-driven above. Any other section (e.g. canvas-claude) is
+  // emitted verbatim.
+  const entries = CARD_TYPE_REGISTRY.menuEntries();
+  const handledSections = new Set(['terminals', 'widgets']);
+  const seenSections = new Set();
+  for (const entry of entries) {
+    if (handledSections.has(entry.menuSection)) continue;
+    if (!seenSections.has(entry.menuSection)) {
+      // Title-case the section name for the header. E.g. "canvas-claude"
+      // becomes "Canvas Claude".
+      const headerText = entry.menuSection
+        .split(/[-_]/)
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+      html += `<div class="ctx-header">${headerText}</div>`;
+      seenSections.add(entry.menuSection);
+    }
+    html += `<div class="ctx-item" data-card-type="${entry.type}">
+      <span class="symbol-preview" style="color:#cba6f7">${entry.symbol}</span>
+      ${entry.label}
+    </div>`;
+  }
+  pendingHandlers.push({
+    selector: '.ctx-item[data-card-type]',
+    async: true,
+    handler: async (item) => {
+      await CARD_TYPE_REGISTRY.spawn(item.dataset.cardType, {
+        x: ctxMenuCanvasPos.x,
+        y: ctxMenuCanvasPos.y,
+      });
+    },
+  });
 
   ctxMenu.innerHTML = html;
   ctxMenu.style.left = sx + 'px';
@@ -885,66 +988,17 @@ function showContextMenu(sx, sy) {
     ctxMenu.style.left = Math.max(10, window.innerWidth - menuRect.width - 10) + 'px';
   }
 
-  ctxMenu.querySelectorAll('.ctx-item[data-hub]').forEach(item => {
-    item.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const hubName = item.dataset.hub;
-      const hub = hubs.find(h => h.hub === hubName);
-      if (hub) spawnCard(hub, ctxMenuCanvasPos.x, ctxMenuCanvasPos.y);
-      hideContextMenu();
+  // Wire all pending click handlers in one pass.
+  for (const { selector, handler, async: isAsync } of pendingHandlers) {
+    ctxMenu.querySelectorAll(selector).forEach(item => {
+      item.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        hideContextMenu();
+        if (isAsync) await handler(item);
+        else handler(item);
+      });
     });
-  });
-
-  ctxMenu.querySelectorAll('.ctx-item[data-host-shell]').forEach(item => {
-    item.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const shellId = item.dataset.hostShell;
-      const shellCmd = item.dataset.hostCmd;
-      const shellContainer = item.dataset.hostContainer || 'localhost';
-      const hub = { hub: shellId, container: shellContainer, exec: shellCmd };
-      // Add to hubs if not already there so symbol assignment works
-      if (!hubSymbolMap[shellId]) {
-        hubSymbolMap[shellId] = 'H';
-      }
-      spawnCard(hub, ctxMenuCanvasPos.x, ctxMenuCanvasPos.y, CARD_W, CARD_H, null, shellCmd);
-      hideContextMenu();
-    });
-  });
-
-  ctxMenu.querySelectorAll('.ctx-item[data-widget]').forEach(item => {
-    item.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const widgetType = item.dataset.widget;
-      spawnWidget(widgetType, ctxMenuCanvasPos.x, ctxMenuCanvasPos.y);
-      hideContextMenu();
-    });
-  });
-
-  ctxMenu.querySelectorAll('.ctx-item[data-probe-profile]').forEach(item => {
-    item.addEventListener('click', async (e) => {
-      e.stopPropagation();
-      hideContextMenu();
-      const profile = item.dataset.probeProfile;
-      try {
-        const resp = await fetch(`/api/probe/claude-usage?profile=${encodeURIComponent(profile)}`, { method: 'POST' });
-        if (!resp.ok) throw new Error(await resp.text());
-        const { session_id } = await resp.json();
-        const hub = { hub: `claude-probe-${profile}`, container: 'supreme-claudemander-util', exec: null };
-        if (!hubSymbolMap[hub.hub]) hubSymbolMap[hub.hub] = 'P';
-        spawnCard(hub, ctxMenuCanvasPos.x, ctxMenuCanvasPos.y, 960, 640, null, null, session_id);
-      } catch (err) {
-        console.error('Failed to start claude usage probe:', err);
-      }
-    });
-  });
-
-  ctxMenu.querySelectorAll('.ctx-item[data-canvas-claude]').forEach(item => {
-    item.addEventListener('click', async (e) => {
-      e.stopPropagation();
-      hideContextMenu();
-      await spawnCanvasClaudeCard(ctxMenuCanvasPos.x, ctxMenuCanvasPos.y);
-    });
-  });
+  }
 }
 
 function hideContextMenu() {
@@ -1210,27 +1264,36 @@ class Card {
 // ════════════════════════════════════════════
 // Single dispatcher for card creation, deserialization, and menu generation.
 // Each card class self-registers immediately after its definition by calling
-// CARD_TYPE_REGISTRY.register(typeName, { cardClass, label, symbol, defaultSize, menuSection }).
+// CARD_TYPE_REGISTRY.register(typeName, { cardClass, label, symbol, defaultSize, menuSection, prepareOpts }).
 //
-// - spawn(typeName, opts): generic mount path — construct the class, append to the
-//   canvas, wire up drag/resize, run onInit, refresh minimap + hub count, and return
-//   the mounted card. Callers that need specialised pre-construction logic (hub
-//   symbol lookup, async session probing, etc.) continue to use the legacy
-//   spawnCard / spawnWidget / spawnCanvasClaudeCard helpers — the two coexist until
-//   call-site migration lands in #124/125.
+// - spawn(typeName, opts): generic mount path — optionally runs the registered
+//   `prepareOpts(opts)` hook (which may be async), constructs the class, appends
+//   to the canvas, wires up drag/resize, runs onInit, refreshes minimap + hub
+//   count, and returns the mounted card. This is the single entry point for all
+//   card creation — context menu, MCP control-ws, layout restore, and layoutGrid
+//   all route through here.
+//
+// - prepareOpts(opts) (optional, per-type): async hook that transforms / enriches
+//   the caller's opts before the card is constructed. Used for type-specific
+//   preparation such as hub-symbol lookup, canvas-claude session staleness
+//   probes, or priority-profile resolution. Returning `null` aborts the spawn.
+//   Returning an object replaces `opts` entirely; mutating and returning nothing
+//   (or `undefined`) keeps the mutated version.
 //
 // - deserialize(data): dispatches to `<CardClass>.fromSerialized(data)` using
 //   data.type as the key. Legacy layout entries that have no `type` field but do
 //   carry a `hub` field are treated as terminals (pre-type-field compatibility).
 //   Unknown type -> logs a warning and returns null so callers can skip the entry.
+//   NOTE: deserialize() does NOT run prepareOpts — it rebuilds the card from the
+//   already-validated serialized form. Callers that need the full async prep
+//   path (e.g. canvas-claude reload) should call `spawn()` with the layout entry
+//   as opts instead.
 //
 // - menuEntries(): returns an array of
 //   `{type, label, symbol, defaultSize, menuSection}` for every registered type
 //   that opted in to menu display (i.e. has a truthy `menuSection`). Preserves
-//   registration order. This helper is deliberately dormant until #124/#125
-//   migrates the context-menu build code onto the registry — do not delete it
-//   as unused; it is the sole reason `label`/`symbol`/`defaultSize`/`menuSection`
-//   are stored on registry entries in the first place.
+//   registration order. Consumed by `showContextMenu()` to drive the
+//   "Canvas Claude Code" section and any future menu-visible card types.
 //
 // Adding a new card type requires only two things:
 //   1. define the class (with a `static fromSerialized(data)`)
@@ -1264,6 +1327,7 @@ const CARD_TYPE_REGISTRY = {
       symbol: entry.symbol != null ? entry.symbol : '?',
       defaultSize: entry.defaultSize != null ? entry.defaultSize : { w: CARD_W, h: CARD_H },
       menuSection: entry.menuSection != null ? entry.menuSection : null,
+      prepareOpts: typeof entry.prepareOpts === 'function' ? entry.prepareOpts : null,
     };
   },
 
@@ -1275,21 +1339,36 @@ const CARD_TYPE_REGISTRY = {
     return Object.prototype.hasOwnProperty.call(this._types, typeName);
   },
 
-  // Generic mount path. Construct the card, append it to the canvas, wire up
-  // drag/resize, run onInit, and refresh minimap + hub count. Returns the
-  // mounted card instance, or null on unknown type. If the caller omits `w`
-  // and/or `h`, the registry's `defaultSize` for this type is applied — this
-  // is why `defaultSize` is stored on entries.
-  spawn(typeName, opts) {
+  // Generic mount path. Runs the per-type `prepareOpts` hook (if any),
+  // constructs the card, appends it to the canvas, wires up drag/resize, runs
+  // onInit, and refreshes minimap + hub count. Returns a Promise that resolves
+  // to the mounted card instance, or null on unknown type / aborted prep. If
+  // the caller omits `w` and/or `h`, the registry's `defaultSize` for this
+  // type is applied.
+  async spawn(typeName, opts) {
     const entry = this._types[typeName];
     if (!entry) {
       console.warn('CARD_TYPE_REGISTRY.spawn: unknown type "%s"', typeName);
       return null;
     }
-    const mergedOpts = { ...(opts || {}) };
+    let mergedOpts = { ...(opts || {}) };
+    if (entry.prepareOpts) {
+      try {
+        const result = await entry.prepareOpts(mergedOpts);
+        if (result === null) return null; // hook aborted
+        if (result && typeof result === 'object') mergedOpts = result;
+      } catch (err) {
+        console.warn('CARD_TYPE_REGISTRY.spawn: prepareOpts for "%s" threw: %o', typeName, err);
+        return null;
+      }
+    }
     if (mergedOpts.w == null) mergedOpts.w = entry.defaultSize.w;
     if (mergedOpts.h == null) mergedOpts.h = entry.defaultSize.h;
     const card = new entry.cardClass(mergedOpts);
+    // Apply savedControlGroups before _mount so its badge-update path fires.
+    if (Array.isArray(mergedOpts.controlGroups) && mergedOpts.controlGroups.length > 0) {
+      card.controlGroupNums = [...mergedOpts.controlGroups];
+    }
     return this._mount(card);
   },
 
@@ -1638,6 +1717,26 @@ CARD_TYPE_REGISTRY.register('terminal', {
   symbol: 'T',
   defaultSize: { w: CARD_W, h: CARD_H },
   menuSection: 'terminals',
+  // Resolve symbol from hubSymbolMap and normalise opts shape. Callers pass a
+  // flat `{hub, container, exec, sessionId, x, y, w, h, controlGroups}` and
+  // this hook turns it into the shape TerminalCard's constructor expects.
+  // Supports both real hubs (pre-registered in `hubs[]`) and synthetic hubs
+  // (host shells, probe-profile terminals) where the caller supplies `hub` as
+  // a string name + explicit `container`/`exec`.
+  prepareOpts(opts) {
+    // Back-compat: if caller passed a `hub` object (the pre-migration shape),
+    // flatten it into the opts record.
+    if (opts.hub && typeof opts.hub === 'object') {
+      const hubObj = opts.hub;
+      opts.hub = hubObj.hub;
+      if (opts.container == null) opts.container = hubObj.container;
+      if (opts.exec == null) opts.exec = hubObj.exec || null;
+    }
+    if (!opts.symbol) {
+      opts.symbol = (opts.hub && hubSymbolMap[opts.hub]) || '?';
+    }
+    return opts;
+  },
 });
 
 // ════════════════════════════════════════════
@@ -1872,15 +1971,16 @@ class CanvasClaudeCard extends TerminalCard {
     return data;
   }
 
-  // WARNING: this synchronous constructor path does NOT check whether
-  // `data.session_id` is still alive on the server. `spawnCanvasClaudeCard()`
-  // (the current layout-reload path) performs an async `/api/sessions` probe
-  // before construction and drops stale IDs so zombie cards cannot appear.
-  // Until the #124/#125 migration moves layout reload onto the registry, this
-  // method is only safe to use in code paths that either (a) already know the
-  // session is live, or (b) perform their own staleness check before calling.
-  // When the migration lands, either port the probe into a post-deserialize
-  // async hook or keep `spawnCanvasClaudeCard()` as the layout-reload entry.
+  // NOTE: this synchronous deserializer does NOT check whether
+  // `data.session_id` is still alive on the server — the session-staleness
+  // probe lives in the registered `prepareOpts` hook for `canvas_claude` (see
+  // the `CARD_TYPE_REGISTRY.register('canvas_claude', ...)` call below). All
+  // layout-restore / context-menu / MCP spawn paths flow through
+  // `CARD_TYPE_REGISTRY.spawn('canvas_claude', ...)` which awaits the hook
+  // before constructing the card. `fromSerialized` is called only by
+  // `CARD_TYPE_REGISTRY.deserialize()`, which currently has no consumers for
+  // canvas-claude — it is retained for symmetry with the other card types and
+  // for any future caller that wants a bare-instance path.
   static fromSerialized(data) {
     const card = new CanvasClaudeCard({
       hub: data.hub || 'canvas-claude',
@@ -1904,10 +2004,49 @@ class CanvasClaudeCard extends TerminalCard {
 
 CARD_TYPE_REGISTRY.register('canvas_claude', {
   cardClass: CanvasClaudeCard,
-  label: 'Canvas Claude',
+  label: 'Canvas Claude Code',
   symbol: 'C',
   defaultSize: { w: 960, h: 640 },
-  menuSection: 'terminals',
+  menuSection: 'canvas-claude',
+  // Async prep: (a) drop stale session IDs via `/api/sessions` probe so a
+  // restarted server doesn't leave a zombie card, (b) resolve priority profile
+  // from `/api/profiles/priority` when none was passed in, (c) fill defaults
+  // for hub / container / canvasName. This is the single owner of the
+  // staleness-check contract for canvas-claude cards.
+  async prepareOpts(opts) {
+    // Staleness check: if caller supplied a sessionId, confirm it is still
+    // alive on the server before reusing it.
+    if (opts.sessionId) {
+      try {
+        const sessions = await (await fetch('/api/sessions')).json();
+        const alive = sessions.some(s => s.session_id === opts.sessionId && s.alive);
+        if (!alive) {
+          console.log(`[canvas-claude] stale session ${opts.sessionId} — will create fresh`);
+          opts.sessionId = null;
+        }
+      } catch (_) {
+        // If the session list fetch fails, assume stale and recreate.
+        opts.sessionId = null;
+      }
+    }
+    // Resolve profile from priority credential when none provided.
+    if (!opts.sessionId && !opts.profile) {
+      try {
+        const pr = await fetch('/api/profiles/priority');
+        if (pr.ok) {
+          const pd = await pr.json();
+          if (pd.priority_profile && /^[a-zA-Z0-9._-]+$/.test(pd.priority_profile)) {
+            opts.profile = pd.priority_profile;
+          }
+        }
+      } catch (_) { /* non-fatal */ }
+    }
+    if (opts.hub == null) opts.hub = 'canvas-claude';
+    if (opts.container == null) opts.container = 'supreme-claudemander-util';
+    if (opts.canvasName == null) opts.canvasName = currentCanvasName || null;
+    if (opts.symbol == null) opts.symbol = 'C';
+    return opts;
+  },
 });
 
 // ════════════════════════════════════════════
@@ -2367,16 +2506,20 @@ const WIDGET_REGISTRY = {
               cmd = `${_docker} exec -it ${name} sh`;
             }
 
-            // Find or create a hub entry for spawnCard
-            const hub = { hub: name, container: name, exec: cmd };
-            if (typeof spawnCard === 'function') {
-              // Place near center of viewport
-              const vw = viewport.clientWidth;
-              const vh = viewport.clientHeight;
-              const cx = (-pan.x + vw / 2) / zoom;
-              const cy = (-pan.y + vh / 2) / zoom;
-              spawnCard(hub, cx - 480 + Math.random() * 60, cy - 320 + Math.random() * 60, 960, 640);
-            }
+            // Place near center of viewport
+            const vw = viewport.clientWidth;
+            const vh = viewport.clientHeight;
+            const cx = (-pan.x + vw / 2) / zoom;
+            const cy = (-pan.y + vh / 2) / zoom;
+            CARD_TYPE_REGISTRY.spawn('terminal', {
+              hub: name,
+              container: name,
+              exec: cmd,
+              x: cx - 480 + Math.random() * 60,
+              y: cy - 320 + Math.random() * 60,
+              w: 960,
+              h: 640,
+            });
           });
         });
 
@@ -2519,117 +2662,10 @@ setInterval(() => {
   }
 }, 1000);
 
-// ════════════════════════════════════════════
-// Spawn a terminal card
-// ════════════════════════════════════════════
-function spawnCard(hub, x, y, w, h, savedControlGroups, execCmd, sessionId) {
-  const symbol = hubSymbolMap[hub.hub] || '?';
-  const card = new TerminalCard({ hub: hub.hub, container: hub.container, x, y, w, h, symbol, exec: execCmd || hub.exec || null, sessionId: sessionId || null });
-  if (savedControlGroups && Array.isArray(savedControlGroups)) {
-    card.controlGroupNums = [...savedControlGroups];
-  }
-  card.createElement();
-  canvas.appendChild(card.el);
-  cards.push(card);
-  card.setupDrag();
-  card.setupResize();
-  card.onInit();
-  if (card.controlGroupNums.length > 0) {
-    updateControlGroupBadges(card);
-  }
-  drawMinimap();
-  updateHubCount();
-  return card;
-}
-
-function spawnWidget(widgetType, x, y, w, h) {
-  const card = new WidgetCard({
-    widgetType,
-    x,
-    y,
-    w: w || 360,
-    h: h || 280,
-    symbol: 'W',
-  });
-  card.createElement();
-  canvas.appendChild(card.el);
-  cards.push(card);
-  card.setupDrag();
-  card.setupResize();
-  card.onInit();
-  drawMinimap();
-  updateHubCount();
-  return card;
-}
-
-async function spawnCanvasClaudeCard(x, y, w, h, sessionId, profile, canvasName) {
-  // NOTE: this helper owns the async staleness-check contract for canvas-claude
-  // cards. `CanvasClaudeCard.fromSerialized()` intentionally does NOT replicate
-  // the `/api/sessions` probe below, so anything that constructs a card via the
-  // registry deserialize path must either perform its own check first or fall
-  // back to this function. When the #124/#125 migration moves layout reload
-  // onto `CARD_TYPE_REGISTRY.deserialize()`, this probe must be ported into a
-  // post-deserialize async hook or this helper must remain the reload entry.
-  //
-  // If we have a saved sessionId (canvas reload / server restart), check if it is
-  // still alive.  If the session is dead (server restarted, orphan reaped), drop the
-  // stale ID so we fall through to the create-new path below.  This prevents zombie
-  // canvas claude cards that appear connected but have no live PTY.
-  if (sessionId) {
-    try {
-      const sessions = await (await fetch('/api/sessions')).json();
-      const alive = sessions.some(s => s.session_id === sessionId && s.alive);
-      if (!alive) {
-        console.log(`[canvas-claude] stale session ${sessionId} — will create fresh`);
-        sessionId = null;
-      }
-    } catch (_) {
-      // If the session list fetch fails, assume stale and recreate.
-      sessionId = null;
-    }
-  }
-
-  // If no existing live session, show the retry overlay instead of auto-starting.
-  // This avoids launching Claude before the user has confirmed their profile and
-  // credentials are ready (first-time setup, container not yet running, etc.).
-  // _retryConnect() on the card handles the actual session creation when the user
-  // clicks Retry.  We still resolve the profile here so the overlay can display it.
-  if (!sessionId) {
-    if (!profile) {
-      try {
-        const pr = await fetch('/api/profiles/priority');
-        if (pr.ok) {
-          const pd = await pr.json();
-          if (pd.priority_profile && /^[a-zA-Z0-9._-]+$/.test(pd.priority_profile)) {
-            profile = pd.priority_profile;
-          }
-        }
-      } catch (_) { /* non-fatal */ }
-    }
-    // Leave sessionId null — card.onInit() will show the retry overlay.
-  }
-
-  const card = new CanvasClaudeCard({
-    hub: 'canvas-claude',
-    container: 'supreme-claudemander-util',
-    x, y,
-    w: w || 960,
-    h: h || 640,
-    symbol: 'C',
-    profile: profile || null,
-    canvasName: canvasName || currentCanvasName || null,
-    sessionId: sessionId,
-  });
-  card.createElement();
-  canvas.appendChild(card.el);
-  cards.push(card);
-  card.setupDrag();
-  card.setupResize();
-  card.onInit();
-  drawMinimap();
-  updateHubCount();
-  return card;
-}
+// Card creation now flows exclusively through `CARD_TYPE_REGISTRY.spawn(type, opts)`.
+// Type-specific prep (hub symbol lookup for terminals, canvas-claude session
+// staleness probe + priority-profile resolution) lives in per-type
+// `prepareOpts` hooks registered next to each card class definition.
 
 function destroyCard(id) {
   const idx = cards.findIndex(c => c.id === id);
@@ -2655,6 +2691,52 @@ function updateHubCount() {
   const parts = [`${hubs.length} hub(s)`, `${termCount} terminal(s)`];
   if (widgetCount > 0) parts.push(`${widgetCount} widget(s)`);
   document.getElementById('hub-count').textContent = parts.join(' | ');
+}
+
+// Dispatch a saved layout entry through CARD_TYPE_REGISTRY.spawn so the full
+// type-specific prep (symbol lookup, canvas-claude session probe, profile
+// resolution) runs uniformly. Used by switchCanvas and the boot loader.
+// Terminals resolve their hub from `hubs[]` when possible; if the hub is not
+// currently discovered the entry is skipped (matching legacy behaviour).
+// Entries without a `type` but with a `hub` field are treated as terminals
+// (pre-type-field compatibility).
+async function spawnFromSerialized(s) {
+  let typeName = s.type;
+  if (!typeName && s.hub) typeName = 'terminal';
+  if (!typeName) {
+    console.warn('spawnFromSerialized: entry has no type and no hub, skipping', s);
+    return null;
+  }
+  if (typeName === 'terminal') {
+    const hub = hubs.find(h => h.hub === s.hub);
+    if (!hub) return null; // undiscovered hub — skip, like the old ladder did
+    return CARD_TYPE_REGISTRY.spawn('terminal', {
+      hub,
+      x: s.x, y: s.y, w: s.w, h: s.h,
+      exec: s.exec,
+      sessionId: s.session_id,
+      controlGroups: s.controlGroups,
+    });
+  }
+  if (typeName === 'widget') {
+    if (!s.widgetType) return null;
+    return CARD_TYPE_REGISTRY.spawn('widget', {
+      widgetType: s.widgetType,
+      x: s.x, y: s.y, w: s.w, h: s.h,
+      refreshInterval: s.refreshInterval,
+    });
+  }
+  if (typeName === 'canvas_claude') {
+    return CARD_TYPE_REGISTRY.spawn('canvas_claude', {
+      x: s.x, y: s.y, w: s.w, h: s.h,
+      sessionId: s.session_id,
+      profile: s.profile,
+      canvasName: s.canvasName,
+    });
+  }
+  // Unknown type: fall back to the registry so any future card type that
+  // registers itself is handled automatically.
+  return CARD_TYPE_REGISTRY.spawn(typeName, { ...s, sessionId: s.session_id });
 }
 
 // ════════════════════════════════════════════
@@ -2785,7 +2867,7 @@ function layoutGrid(hubList) {
     const row = Math.floor(i / cols);
     const x = startX + col * (CARD_W + CARD_GAP);
     const y = startY + row * (CARD_H + CARD_GAP);
-    spawnCard(hub, x, y);
+    CARD_TYPE_REGISTRY.spawn('terminal', { hub, x, y });
   });
 }
 
@@ -3213,14 +3295,7 @@ async function switchCanvas(name) {
   const saved = await loadLayout();
   if (saved && saved.length > 0) {
     for (const s of saved) {
-      if (s.type === 'canvas_claude') {
-        await spawnCanvasClaudeCard(s.x, s.y, s.w, s.h, s.session_id, s.profile, s.canvasName);
-      } else if (s.type === 'widget' && s.widgetType) {
-        spawnWidget(s.widgetType, s.x, s.y, s.w, s.h);
-      } else {
-        const hub = hubs.find(h => h.hub === s.hub);
-        if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec, s.session_id);
-      }
+      await spawnFromSerialized(s);
     }
     rebuildControlGroupsFromCards();
   }
@@ -3284,10 +3359,8 @@ async function handleControlCardCreated(msg) {
   if (desc.session_id && cards.some(c => c.sessionId === desc.session_id)) return;
 
   if (desc.type === 'terminal') {
-    // Build a hub-like object for spawnCard
     const hubName = desc.hub || desc.exec || 'api-terminal';
     const container = desc.container || '';
-    const hub = hubs.find(entry => entry.hub === hubName) || { hub: hubName, container: container, exec: desc.exec || null };
 
     // Place near center of current viewport if no layout hints
     const vw = viewport.clientWidth;
@@ -3296,8 +3369,6 @@ async function handleControlCardCreated(msg) {
     const cy = (-pan.y + vh / 2) / zoom;
     const x = desc.x != null ? desc.x : cx - CARD_W / 2 + Math.random() * 60;
     const y = desc.y != null ? desc.y : cy - CARD_H / 2 + Math.random() * 60;
-    const w = desc.w || CARD_W;
-    const h = desc.h || CARD_H;
 
     // Ensure hub is in the hubs array so it shows in sidebar / can be found on reload
     if (!hubs.find(entry => entry.hub === hubName)) {
@@ -3305,7 +3376,15 @@ async function handleControlCardCreated(msg) {
       hubSymbolMap[hubName] = HUB_SYMBOLS[hubs.length % HUB_SYMBOLS.length];
     }
 
-    spawnCard(hub, x, y, w, h, null, desc.exec || null, desc.session_id);
+    await CARD_TYPE_REGISTRY.spawn('terminal', {
+      hub: hubName,
+      container: container,
+      exec: desc.exec || null,
+      sessionId: desc.session_id,
+      x, y,
+      w: desc.w || CARD_W,
+      h: desc.h || CARD_H,
+    });
     saveLayout();
   }
 }
@@ -3423,19 +3502,21 @@ function handleControlCardDeleted(msg) {
   if (saved && saved.length > 0) {
     // Spawn cards from saved layout
     for (const s of saved) {
-      if (s.type === 'canvas_claude') {
-        await spawnCanvasClaudeCard(s.x, s.y, s.w, s.h, s.session_id, s.profile, s.canvasName);
-      } else if (s.type === 'widget' && s.widgetType) {
-        spawnWidget(s.widgetType, s.x, s.y, s.w, s.h);
-      } else {
-        const hub = hubs.find(h => h.hub === s.hub);
-        if (hub) spawnCard(hub, s.x, s.y, s.w, s.h, s.controlGroups, s.exec, s.session_id);
-      }
+      await spawnFromSerialized(s);
     }
-    // Spawn any new hubs not in saved layout
+    // Spawn any new hubs not in saved layout. Treat layout entries as
+    // "terminal for hub" when type is absent (pre-type-field compat).
     for (const hub of hubs) {
-      if (!saved.some(s => s.hub === hub.hub && s.type !== 'widget' && s.type !== 'canvas_claude')) {
-        spawnCard(hub, 100 + Math.random() * 200, 100 + Math.random() * 200);
+      const alreadySaved = saved.some(s => {
+        const asTerminal = (s.type === 'terminal') || (!s.type && s.hub);
+        return asTerminal && s.hub === hub.hub;
+      });
+      if (!alreadySaved) {
+        await CARD_TYPE_REGISTRY.spawn('terminal', {
+          hub,
+          x: 100 + Math.random() * 200,
+          y: 100 + Math.random() * 200,
+        });
       }
     }
     rebuildControlGroupsFromCards();

--- a/docs/cards-and-canvas.md
+++ b/docs/cards-and-canvas.md
@@ -68,7 +68,7 @@ startup.py: run_startup("qa-m6")
 [{"type":"terminal","name":"rts-test-a","container":"rts-test-a","exec":"docker.exe exec -it rts-test-a bash"}, ...]
     │
     ▼
-frontend: hubs = descriptors.map(...)  →  spawnCard() per hub  →  TerminalCards on canvas
+frontend: hubs = descriptors.map(...)  →  CARD_TYPE_REGISTRY.spawn('terminal', {hub, ...}) per hub  →  TerminalCards on canvas
 ```
 
 If the startup script returns cards **and** a saved canvas layout exists for `default_canvas`, the frontend uses the saved positions/sizes but only for hubs that appear in both lists. New hubs not in the saved layout are placed at a random offset.

--- a/tests/e2e/test_vm_manager_e2e.py
+++ b/tests/e2e/test_vm_manager_e2e.py
@@ -137,7 +137,7 @@ def ensure_vm_card_exists(page):
     # Fallback: if context menu approach didn't spawn a card, use JS directly
     vm_cards_after = page.locator("[data-card-id]").filter(has=page.locator("[data-vm-search]"))
     if vm_cards_after.count() == 0:
-        page.evaluate("() => spawnWidget('vm-manager', 100, 100)")
+        page.evaluate("() => CARD_TYPE_REGISTRY.spawn('widget', {widgetType: 'vm-manager', x: 100, y: 100})")
         page.wait_for_timeout(2000)
 
 

--- a/tests/e2e/test_vm_manager_real_e2e.py
+++ b/tests/e2e/test_vm_manager_real_e2e.py
@@ -213,7 +213,7 @@ def ensure_vm_card_exists(page):
     if vm_cards.count() > 0:
         return
     # Spawn via JS directly
-    page.evaluate("() => spawnWidget('vm-manager', 100, 100)")
+    page.evaluate("() => CARD_TYPE_REGISTRY.spawn('widget', {widgetType: 'vm-manager', x: 100, y: 100})")
     page.wait_for_timeout(2000)
 
 


### PR DESCRIPTION
Closes #128

## What changed

Issue #128 is the final consolidation step in the `CARD_TYPE_REGISTRY` migration started in #123. Before this PR, card creation in `index.html` was forked across three free functions (`spawnCard`, `spawnWidget`, `spawnCanvasClaudeCard`), each with its own copy of mount boilerplate, and six `if (type === 'canvas_claude') {...} else if (type === 'widget') {...} else {...}` ladders scattered across `switchCanvas`, the boot loader, `handleControlCardCreated`, the context menu, and the VM Manager widget. This PR deletes the three free functions and all ladders, routing every call site through a single async `CARD_TYPE_REGISTRY.spawn(type, opts)` entry point. Type-specific preparation (hub symbol lookup, canvas-claude session staleness probe, priority-profile resolution) is moved into per-type `prepareOpts` hooks registered next to each card class.

## Implementation walkthrough

### New / modified functions

**`CARD_TYPE_REGISTRY.register(typeName, entry)` in `claude_rts/static/index.html`** now accepts an optional `prepareOpts` field on the entry descriptor. The hook is stored on the registry row and invoked by `spawn()` before card construction. Nothing else in the registration surface changes, so existing call sites (`terminal`, `widget`, `canvas_claude`, `loader`) keep working.

**`CARD_TYPE_REGISTRY.spawn(typeName, opts)`** is now `async`. The new flow is: look up the registered entry, await its `prepareOpts(opts)` hook if one exists, fall back to `defaultSize` for missing `w`/`h`, construct the card via `new entry.cardClass(mergedOpts)`, copy any `controlGroups` onto `card.controlGroupNums` so `_mount()`'s built-in badge-update path fires, then hand the card to `_mount()`. A `prepareOpts` hook that returns `null` aborts the spawn (returning null to the caller); returning an object replaces `opts` wholesale; mutating in place and returning `undefined` keeps the mutated version. Exceptions inside the hook are caught, logged, and convert to a null return — a broken hook cannot corrupt the canvas.

**Terminal `prepareOpts`** (registered next to `TerminalCard`) is synchronous. It handles two call shapes: the legacy `{hub: <object from hubs[]>, ...}` form that `spawnCard` accepted, and the new flat `{hub: <string>, container, exec, ...}` form used by host shells, probe-profile spawns, and the VM Manager launcher. When passed a hub object, it flattens `hub.hub` / `hub.container` / `hub.exec` into top-level opts. It always resolves `symbol` from `hubSymbolMap` so fresh synthetic hubs pick up the default `'?'` marker instead of colliding with another card.

**Canvas Claude `prepareOpts`** (registered next to `CanvasClaudeCard`) is async and owns the staleness-check contract that used to live in the `spawnCanvasClaudeCard` free function. It (a) probes `/api/sessions` and drops `opts.sessionId` if the session is not alive, (b) falls back to `/api/profiles/priority` to resolve `opts.profile` when the caller did not supply one, (c) fills defaults for `hub` (`canvas-claude`), `container` (`supreme-claudemander-util`), `canvasName` (`currentCanvasName`), and `symbol` (`C`). Its `menuSection` is now `canvas-claude` (previously `terminals`) so the context menu emits it as its own section rather than grouping it with discovered hubs.

**`spawnFromSerialized(s)` in `claude_rts/static/index.html`** is a new thin dispatcher that replaces the three-branch type ladder in both `switchCanvas` and the boot loader. It normalises the type (an entry with `hub` and no `type` is treated as a legacy terminal), looks up the hub from `hubs[]` for terminals (skipping undiscovered hubs as the old code did), and dispatches to `CARD_TYPE_REGISTRY.spawn`. For any unknown type it falls back to a generic spawn so any future card type that self-registers is picked up automatically.

**`showContextMenu(sx, sy)` in `claude_rts/static/index.html`** is rewritten to build the menu in two passes. Pass 1 contributes data-driven rows per section: one row per discovered hub, one per host shell, one per widget type, one per probe profile. These are inherently multi-row-per-type so they cannot come from `menuEntries()` directly. Pass 2 walks `CARD_TYPE_REGISTRY.menuEntries()` and emits any registered type whose `menuSection` is not already covered by pass 1 (`terminals` and `widgets` are in a `handledSections` set). This is how the Canvas Claude Code row now appears, and how any future card type that registers with a fresh `menuSection` will appear automatically. Click handlers are collected into a `pendingHandlers` array alongside the HTML build and then attached in a single final pass, so they all share the same selector-based binding flow.

**`handleControlCardCreated(msg)`** no longer synthesises a hub-shaped object for `spawnCard` — it just calls `CARD_TYPE_REGISTRY.spawn('terminal', {hub, container, exec, sessionId, x, y, w, h})`. The `desc.type === 'canvas_claude'` early-return guard is intentionally preserved to avoid duplicate cards when the MCP `open_terminal` create path and the control-ws broadcast race.

### How components interact

Before, card creation had three parallel code paths plus three copies of the mount boilerplate (append to canvas, setupDrag, setupResize, onInit, drawMinimap, updateHubCount). After, every caller flows through a single funnel: caller -> `CARD_TYPE_REGISTRY.spawn(type, opts)` -> optional async `prepareOpts` hook -> `new entry.cardClass(mergedOpts)` -> `_mount()` -> canvas DOM append, drag/resize wiring, `onInit()`, minimap + hub count refresh.

### Default execution path

**Before**: Terminal spawn from the context menu called `spawnCard(hub, x, y)`, which looked up `hubSymbolMap[hub.hub]`, constructed a `TerminalCard`, then ran the mount boilerplate inline. Canvas-claude spawn from a saved layout called `spawnCanvasClaudeCard(...)`, which probed `/api/sessions` for staleness, fetched `/api/profiles/priority`, constructed the card, and ran its own copy of the mount boilerplate. Widget spawn from the context menu called `spawnWidget(widgetType, x, y)`, which had a third copy of the mount boilerplate. Layout restore (`switchCanvas` and boot) used a three-branch `if type ...` ladder that re-implemented the dispatch each time.

**After**: All of the above collapse to `CARD_TYPE_REGISTRY.spawn(type, opts)`. Mount is in one place (`_mount`). Per-type prep is in one place (`prepareOpts` hooks). Layout restore uses `spawnFromSerialized(s)` which is a thin normaliser over `spawn(type, opts)`.

### Edge cases and error handling

- `prepareOpts` throwing: caught inside `spawn`, logged as a warning, returns `null`. Callers that care can check the return value; fire-and-forget callers (context menu, VM Manager, layoutGrid) simply do not get a card.
- `prepareOpts` returning `null`: aborts the spawn, returns `null`.
- Unknown type in a saved layout: `spawnFromSerialized` falls through to the generic registry path, which logs a warning via the existing unknown-type branch and returns `null`. The entry is silently skipped, matching legacy behaviour.
- Pre-type-field legacy layouts (entries with `hub` but no `type`): `spawnFromSerialized` and the boot "new hubs not in saved layout" loop both treat these as terminals.
- Stale canvas-claude session: always dropped by the `prepareOpts` hook, even if the session list fetch itself fails (conservatively treated as stale).

### What was intentionally not changed

- `CanvasClaudeCard.fromSerialized()` is kept, unused by any current caller. The comment above it now explains that its role is symmetric with other card types and available to future consumers of `CARD_TYPE_REGISTRY.deserialize()`, but that the current layout-restore path uses `spawn` instead so the async staleness check runs.
- `CARD_TYPE_REGISTRY.deserialize()` is kept as-is; it is a synchronous bare-instance builder used by no current caller. The plan does not require removing it.
- `LoaderCard` registration still has `menuSection: null` so it is correctly omitted from `menuEntries()`.

## Tier / approach

Tier 2 — single-file refactor with multiple loosely-coupled concerns (registry extension, Terminal prep hook, CanvasClaude prep hook, free-function removal, call-site migration, context-menu rewrite). Executed as Planner -> Coder -> self-review since only one source file was touched and the scope was fully specified in the issue body.

## Acceptance criteria

- [x] `grep 'function spawnCard\|function spawnWidget\|async function spawnCanvasClaudeCard' index.html` returns zero matches
- [x] `grep "s\.type === 'canvas_claude'" index.html` returns zero matches
- [x] Host-shell terminal spawn (raw exec, not a discovered hub) still works via Terminal `prepareOpts`
- [x] `handleControlCardCreated` routes through `CARD_TYPE_REGISTRY.spawn('terminal', ...)` and preserves the `canvas_claude` early-return guard
- [x] Pre-type legacy canvas entries (`hub` but no `type`) load correctly
- [x] Context menu contains no hardcoded `ctx-item` for canvas-claude; the row now comes from `menuEntries()`
- [x] Registering a new card type via `CARD_TYPE_REGISTRY.register(...)` adds it to the menu automatically
- [x] `python -m pytest tests/ --ignore=tests/e2e` — 322 passed
- [x] `python -m ruff check . && python -m ruff format --check .` — clean

## Outstanding items

None.

Generated with Claude Code.
