### PR TITLE
feat(#147): prebuilt util image on ghcr.io, runtime mcp_server.py mount

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           python-version: "3.12"
       - run: pip install -e ".[test]" pytest-playwright playwright pytest-timeout
       - run: python -m playwright install chromium --with-deps
+      - name: Pre-pull utility container image
+        run: |
+          docker pull ghcr.io/hyang0129/supreme-claudemander-util:latest \
+            && docker tag ghcr.io/hyang0129/supreme-claudemander-util:latest supreme-claudemander-util:latest \
+            || echo "GHCR pull failed — server will fall back to local build"
       - name: Run Playwright smoke tests (headless)
         run: python -m pytest tests/e2e/ -v --timeout=120
         env:

--- a/.github/workflows/publish-util-image.yml
+++ b/.github/workflows/publish-util-image.yml
@@ -36,4 +36,6 @@ jobs:
           context: claude_rts
           file: claude_rts/Dockerfile.util
           push: true
-          tags: ${{ env.IMAGE_NAME }}:latest
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/publish-util-image.yml
+++ b/.github/workflows/publish-util-image.yml
@@ -1,0 +1,39 @@
+name: Publish Util Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "claude_rts/Dockerfile.util"
+
+  # Allow manual trigger for initial publish or re-publish
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/hyang0129/supreme-claudemander-util
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: claude_rts
+          file: claude_rts/Dockerfile.util
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest

--- a/claude_rts/Dockerfile.util
+++ b/claude_rts/Dockerfile.util
@@ -27,7 +27,7 @@ RUN useradd -m -s /bin/bash util
 USER util
 WORKDIR /home/util
 
-# Copy MCP server for Canvas Claude Code integration
-COPY --chown=util:util mcp_server.py /home/util/mcp_server.py
+# mcp_server.py is bind-mounted at runtime by start_container()
+# so changes don't require an image rebuild.
 
 CMD ["sleep", "infinity"]

--- a/claude_rts/util_container.py
+++ b/claude_rts/util_container.py
@@ -19,8 +19,11 @@ from loguru import logger  # noqa: E402
 from .config import AppConfig, read_config  # noqa: E402
 
 DOCKERFILE = pathlib.Path(__file__).parent / "Dockerfile.util"
+MCP_SERVER_PY = pathlib.Path(__file__).parent / "mcp_server.py"
+CONTAINER_MCP_PATH = "/home/util/mcp_server.py"
 DEFAULT_CONTAINER_NAME = "supreme-claudemander-util"
 DEFAULT_IMAGE_NAME = "supreme-claudemander-util:latest"
+GHCR_IMAGE = "ghcr.io/hyang0129/supreme-claudemander-util:latest"
 
 
 def _get_config(app_config: AppConfig) -> dict:
@@ -59,14 +62,31 @@ async def is_util_running(app_config: AppConfig) -> bool:
 
 
 async def build_image(app_config: AppConfig) -> bool:
-    """Build the utility container image if not already built."""
+    """Build the utility container image if not already built.
+
+    Tries, in order:
+    1. Use existing local image (instant).
+    2. Pull prebuilt image from ghcr.io and tag it locally.
+    3. Fall back to a local ``docker build`` (slow, but works offline).
+    """
     cfg = _get_config(app_config)
-    # Check if image exists
+    # Check if image exists locally
     rc, stdout, _ = await _run(f"{_DOCKER} images -q {cfg['image']}")
     if rc == 0 and stdout.strip():
         logger.debug("Utility image {} already exists", cfg["image"])
         return True
 
+    # Try pulling the prebuilt image from GHCR
+    logger.info("Pulling prebuilt utility image from {}...", GHCR_IMAGE)
+    rc, _, stderr = await _run(f"{_DOCKER} pull {GHCR_IMAGE}", timeout=120)
+    if rc == 0:
+        # Tag as the local image name so subsequent checks find it
+        await _run(f"{_DOCKER} tag {GHCR_IMAGE} {cfg['image']}")
+        logger.info("Pulled and tagged prebuilt utility image as {}", cfg["image"])
+        return True
+    logger.warning("GHCR pull failed ({}), falling back to local build", stderr)
+
+    # Fall back to local build
     logger.info("Building utility container image {}...", cfg["image"])
     rc, stdout, stderr = await _run(
         f'{_DOCKER} build -t {cfg["image"]} -f "{DOCKERFILE}" "{DOCKERFILE.parent}"',
@@ -91,8 +111,16 @@ async def start_container(app_config: AppConfig) -> bool:
     if not await build_image(app_config):
         return False
 
-    # Build mount args
+    # Build mount args — always bind-mount mcp_server.py so the container
+    # has the latest tool definitions without an image rebuild.
     mount_args = ""
+    if MCP_SERVER_PY.exists():
+        mcp_src = MCP_SERVER_PY.as_posix()
+        mount_args += f' -v "{mcp_src}:{CONTAINER_MCP_PATH}"'
+        logger.info("Mounting mcp_server.py {} -> {}", mcp_src, CONTAINER_MCP_PATH)
+    else:
+        logger.warning("mcp_server.py not found at {}, container will lack MCP tools", MCP_SERVER_PY)
+
     for host_path, container_path in cfg["mounts"].items():
         # Expand ~ in host path and normalize to forward slashes for Docker
         expanded_path = pathlib.Path(host_path.replace("~", str(pathlib.Path.home())))
@@ -235,7 +263,10 @@ async def discover_profiles(app_config: AppConfig) -> list[str]:
 
 
 async def _mounts_match(app_config: AppConfig) -> bool:
-    """Return True if the running container's bind mounts match the configured mounts."""
+    """Return True if the running container's bind mounts match the configured mounts.
+
+    Checks both user-configured mounts and the hardcoded mcp_server.py mount.
+    """
     cfg = _get_config(app_config)
     rc, stdout, _ = await _run(f'{_DOCKER} inspect {cfg["name"]} --format "{{{{json .Mounts}}}}"')
     if rc != 0:
@@ -243,6 +274,18 @@ async def _mounts_match(app_config: AppConfig) -> bool:
     actual = {
         m["Destination"]: pathlib.Path(m["Source"]) for m in json.loads(stdout or "[]") if m.get("Type") == "bind"
     }
+
+    # Check the hardcoded mcp_server.py mount
+    if MCP_SERVER_PY.exists():
+        if actual.get(CONTAINER_MCP_PATH) != MCP_SERVER_PY:
+            logger.debug(
+                "_mounts_match: {} expected {} got {}",
+                CONTAINER_MCP_PATH,
+                MCP_SERVER_PY,
+                actual.get(CONTAINER_MCP_PATH),
+            )
+            return False
+
     for host_path, container_path in cfg["mounts"].items():
         expanded = pathlib.Path(host_path.replace("~", str(pathlib.Path.home())))
         if not expanded.exists():

--- a/claude_rts/util_container.py
+++ b/claude_rts/util_container.py
@@ -81,10 +81,13 @@ async def build_image(app_config: AppConfig) -> bool:
     rc, _, stderr = await _run(f"{_DOCKER} pull {GHCR_IMAGE}", timeout=120)
     if rc == 0:
         # Tag as the local image name so subsequent checks find it
-        await _run(f"{_DOCKER} tag {GHCR_IMAGE} {cfg['image']}")
-        logger.info("Pulled and tagged prebuilt utility image as {}", cfg["image"])
-        return True
-    logger.warning("GHCR pull failed ({}), falling back to local build", stderr)
+        tag_rc, _, tag_err = await _run(f"{_DOCKER} tag {GHCR_IMAGE} {cfg['image']}")
+        if tag_rc == 0:
+            logger.info("Pulled and tagged prebuilt utility image as {}", cfg["image"])
+            return True
+        logger.warning("GHCR pull succeeded but tag failed ({}), falling back to local build", tag_err)
+    else:
+        logger.warning("GHCR pull failed ({}), falling back to local build", stderr)
 
     # Fall back to local build
     logger.info("Building utility container image {}...", cfg["image"])


### PR DESCRIPTION
## Summary
- Remove `COPY mcp_server.py` from `Dockerfile.util` and bind-mount it at container start via `start_container()`, so MCP tool changes no longer require an image rebuild
- `build_image()` now tries `docker pull` from `ghcr.io/hyang0129/supreme-claudemander-util:latest` before falling back to a local build, keeping offline/no-registry dev working
- New `.github/workflows/publish-util-image.yml` builds and pushes the image on `Dockerfile.util` changes to main (plus manual dispatch)
- e2e CI job pre-pulls the GHCR image so the server never races a cold build during tests
- `_mounts_match()` updated to verify the hardcoded mcp_server.py mount, triggering container recreation if missing

## Test plan
- [x] All 410 unit tests pass
- [ ] CI lint/format/test checks pass
- [ ] Manual: trigger publish workflow via `workflow_dispatch`, verify image appears on ghcr.io
- [ ] Manual: delete local image, start server, verify it pulls from GHCR and mounts mcp_server.py
- [ ] Manual: disconnect network, delete local image, start server, verify local build fallback works

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)