### PR TITLE
feat(#111): release packaging and cross-platform fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -38,13 +37,6 @@ jobs:
         run: |
           pip install ".[test]"
           python -m pytest tests/ -v --ignore=tests/e2e
-
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
-        if: env.TWINE_PASSWORD != ''
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check package metadata
+        run: twine check dist/*
+
+      - name: Install and verify package
+        run: |
+          pip install dist/*.whl
+          supreme-claudemander --version
+          python -c "from importlib.metadata import version; print(version('supreme-claudemander'))"
+
+      - name: Run tests against installed package
+        run: |
+          pip install ".[test]"
+          python -m pytest tests/ -v --ignore=tests/e2e
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*
+        if: env.TWINE_PASSWORD != ''
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*

--- a/claude_rts/__main__.py
+++ b/claude_rts/__main__.py
@@ -5,6 +5,7 @@ import pathlib
 import subprocess
 import sys
 import webbrowser
+from importlib.metadata import version as _pkg_version
 
 from aiohttp import web
 from loguru import logger
@@ -16,8 +17,24 @@ from .server import create_app
 _ELECTRON_DIR = pathlib.Path(__file__).resolve().parent.parent / "electron"
 
 
+def _get_version() -> str:
+    """Return the installed package version, falling back to 'unknown'."""
+    try:
+        return _pkg_version("supreme-claudemander")
+    except Exception:
+        return "unknown"
+
+
 def _check_electron_installed():
-    """Exit with instructions if electron/node_modules is missing."""
+    """Exit with instructions if electron/ directory or node_modules is missing."""
+    if not _ELECTRON_DIR.exists():
+        print(
+            "Electron shell is not available in pip-installed packages.\n"
+            "To use --electron, clone the repository and run 'npm install' in the electron/ directory.\n"
+            "See: https://github.com/hyang0129/supreme-claudemander",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     node_modules = _ELECTRON_DIR / "node_modules"
     if node_modules.exists():
         return
@@ -30,6 +47,7 @@ def _check_electron_installed():
 
 def main():
     parser = argparse.ArgumentParser(description="supreme-claudemander terminal canvas")
+    parser.add_argument("--version", action="version", version=f"supreme-claudemander {_get_version()}")
     parser.add_argument("--port", type=int, default=3000, help="Server port (default: 3000)")
     parser.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
     parser.add_argument("--electron", action="store_true", help="Launch in Electron shell instead of browser")

--- a/claude_rts/cards/canvas_claude_card.py
+++ b/claude_rts/cards/canvas_claude_card.py
@@ -7,9 +7,14 @@ import json as _json
 import pathlib as _pathlib
 import re as _re
 import subprocess as _subprocess
+import sys as _sys
 
 from loguru import logger
+
 from .terminal_card import TerminalCard
+
+# Platform-aware Docker binary — matches pattern in server.py, discovery.py, etc.
+_DOCKER = "docker.exe" if _sys.platform == "win32" else "docker"
 
 # Only alphanumeric, hyphens, and underscores are safe for shell interpolation.
 _SAFE_NAME = _re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -144,7 +149,7 @@ class CanvasClaudeCard(TerminalCard):
         #
         # The MCP server is registered via `claude mcp add` by _seed_claude_settings()
         # so no --mcp-config flag is needed here.
-        docker_bin = "docker.exe"  # Windows host
+        docker_bin = _DOCKER
         if profile:
             claude_cmd = f"env CLAUDE_CONFIG_DIR=/profiles/{profile} claude --dangerously-skip-permissions"
         else:
@@ -191,7 +196,7 @@ class CanvasClaudeCard(TerminalCard):
         """
         src = _pathlib.Path(__file__).parent.parent / "mcp_server.py"
         result = _subprocess.run(
-            ["docker.exe", "cp", str(src), f"{self._effective_container}:/home/util/mcp_server.py"],
+            [_DOCKER, "cp", str(src), f"{self._effective_container}:/home/util/mcp_server.py"],
             timeout=10,
             capture_output=True,
         )
@@ -234,7 +239,7 @@ class CanvasClaudeCard(TerminalCard):
         workspace_path = f"{workspace_dir}/settings.json"
 
         write_cmd = [
-            "docker.exe",
+            _DOCKER,
             "exec",
             self._effective_container,
             "bash",
@@ -283,7 +288,7 @@ class CanvasClaudeCard(TerminalCard):
         mcp_patch_b64 = _b64.b64encode(mcp_patch_script.encode()).decode()
 
         mcp_cmd = [
-            "docker.exe",
+            _DOCKER,
             "exec",
             self._effective_container,
             "bash",
@@ -304,7 +309,7 @@ class CanvasClaudeCard(TerminalCard):
         try:
             result = _subprocess.run(
                 [
-                    "docker.exe",
+                    _DOCKER,
                     "exec",
                     self._effective_container,
                     "tmux",
@@ -330,7 +335,7 @@ class CanvasClaudeCard(TerminalCard):
         try:
             _subprocess.run(
                 [
-                    "docker.exe",
+                    _DOCKER,
                     "exec",
                     self._effective_container,
                     "tmux",
@@ -352,7 +357,7 @@ class CanvasClaudeCard(TerminalCard):
         command attaches to it (resume).  Otherwise, it creates a new tmux
         session running the claude command.
         """
-        docker_bin = "docker.exe"
+        docker_bin = _DOCKER
         if self._has_tmux_session():
             self.cmd = f"{docker_bin} exec -it {self._effective_container} tmux attach-session -t {TMUX_SESSION_NAME}"
             logger.info("CanvasClaudeCard: attaching to existing tmux session {}", TMUX_SESSION_NAME)

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -3718,7 +3718,7 @@ async function handleBlueprintOpenWidget(msg) {
       const hubData = await resp.json();
       hubs = hubData.map(h => ({
         ...h,
-        exec: `docker.exe exec -it -u vscode -w /workspaces/${h.hub} ${h.container} bash -l`,
+        exec: `${(navigator.platform.startsWith('Win') || navigator.userAgent.includes('Windows')) ? 'docker.exe' : 'docker'} exec -it -u vscode -w /workspaces/${h.hub} ${h.container} bash -l`,
       }));
     } catch {
       hubs = [];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,24 @@
 name = "supreme-claudemander"
 version = "0.1.0"
 description = "RTS-style terminal canvas for devcontainer hubs"
+readme = "README.md"
+license = {text = "MIT"}
 requires-python = ">=3.10"
+authors = [
+    {name = "Hong Yang", email = "hooong.yang@gmail.com"},
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Web Environment",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: User Interfaces",
+]
 dependencies = [
     "aiohttp>=3.9",
     "pywinpty>=2.0; sys_platform == 'win32'",
@@ -24,11 +41,25 @@ e2e = [
     "playwright>=1.40",
 ]
 
+[project.urls]
+Homepage = "https://github.com/hyang0129/supreme-claudemander"
+Repository = "https://github.com/hyang0129/supreme-claudemander"
+Issues = "https://github.com/hyang0129/supreme-claudemander/issues"
+
 [project.scripts]
 supreme-claudemander = "claude_rts.__main__:main"
 
 [tool.setuptools.packages.find]
 include = ["claude_rts*"]
+
+[tool.setuptools.package-data]
+claude_rts = [
+    "static/*.html",
+    "static/**/*",
+    "dev_presets/**/*.json",
+    "Dockerfile.util",
+    "mcp_server.py",
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/test_canvas_claude_card.py
+++ b/tests/test_canvas_claude_card.py
@@ -316,7 +316,7 @@ async def test_canvas_claude_card_seed_trust_settings_profile(monkeypatch):
     assert "base64 -d" in shell_script
     # Second call: MCP .claude.json patch via python3
     mcp_cmd = calls[1]
-    assert mcp_cmd[0] == "docker.exe"
+    assert mcp_cmd[0] == _DOCKER
     assert mcp_cmd[1] == "exec"
     assert "my-container" in mcp_cmd
     assert "python3" in mcp_cmd[-1]

--- a/tests/test_canvas_claude_card.py
+++ b/tests/test_canvas_claude_card.py
@@ -2,7 +2,6 @@
 
 import base64
 import json
-import sys
 import time
 
 import pytest

--- a/tests/test_canvas_claude_card.py
+++ b/tests/test_canvas_claude_card.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+import sys
 import time
 
 import pytest
@@ -11,6 +12,7 @@ from claude_rts.cards.canvas_claude_card import (
     CONTAINER_PYTHON3,
     CanvasClaudeCard,
     TMUX_SESSION_NAME,
+    _DOCKER,
     _build_mcp_config,
 )
 from claude_rts.sessions import SessionManager
@@ -306,7 +308,7 @@ async def test_canvas_claude_card_seed_trust_settings_profile(monkeypatch):
     assert len(calls) == 2
     # First call: trust settings write
     cmd = calls[0]
-    assert cmd[0] == "docker.exe"
+    assert cmd[0] == _DOCKER
     assert cmd[1] == "exec"
     assert "my-container" in cmd
     shell_script = cmd[-1]


### PR DESCRIPTION
## Summary
- Add `[tool.setuptools.package-data]` to `pyproject.toml` so `static/index.html`, `dev_presets/**/*.json`, `Dockerfile.util`, and `mcp_server.py` are included in sdist/wheel builds
- Add PyPI metadata: authors, license, classifiers, project URLs, readme reference
- Add `--version` flag to CLI using `importlib.metadata` for installed version reporting
- Make `--electron` fail gracefully with a helpful message when `electron/` directory is missing (pip installs)
- Fix `canvas_claude_card.py`: replace 7 hardcoded `"docker.exe"` references with platform-aware `_DOCKER` constant (`sys.platform == "win32"` guard), matching the pattern used in `server.py`, `discovery.py`, `sessions.py`, etc.
- Fix `index.html`: replace hardcoded `docker.exe` in hub discovery fallback with platform-detecting inline expression
- Add `.github/workflows/release.yml`: triggered on `v*` tags, builds sdist+wheel, runs `twine check`, verifies install + `--version`, runs test suite, publishes to PyPI, creates GitHub Release with auto-generated notes

## Test plan
- [x] All 410 existing tests pass
- [x] `ruff check` and `ruff format --check` pass
- [x] `python -m build` produces wheel with all data files (`static/index.html`, `dev_presets/**`, `Dockerfile.util`, `mcp_server.py`)
- [x] `supreme-claudemander --version` outputs `supreme-claudemander 0.1.0`
- [ ] CI passes on this PR

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)