### PR TITLE
feat: build-from-source install docs and electron dir env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,41 @@ An RTS-style terminal canvas for managing devcontainer hubs. Terminal shells liv
 - Python 3.10+
 - Running devcontainers (with `devcontainer.local_folder` label)
 
-### Install and run
+### Build and install from source
 
 ```bash
 git clone https://github.com/hyang0129/supreme-claudemander.git
 cd supreme-claudemander
-pip install -e .
-python -m claude_rts
+pip install build
+python -m build
+python -m venv ~/.supreme-claudemander/venv
+~/.supreme-claudemander/venv/Scripts/pip install dist/supreme_claudemander-*.whl
+```
+
+Then run:
+
+```bash
+~/.supreme-claudemander/venv/Scripts/supreme-claudemander
 ```
 
 The server starts on `http://localhost:3000` and opens your browser automatically. Press `Ctrl+C` to stop — your containers keep running.
 
+#### Electron shell (optional)
+
+The `--electron` flag requires Node.js and the repo's `electron/` dependencies:
+
+```bash
+cd electron && npm install && cd ..
+SUPREME_CLAUDEMANDER_ELECTRON_DIR=/path/to/repo/electron \
+  ~/.supreme-claudemander/venv/Scripts/supreme-claudemander --electron
+```
+
 ### Options
 
 ```
-python -m claude_rts --port 4000       # custom port
-python -m claude_rts --no-browser      # don't auto-open browser
+supreme-claudemander --port 4000       # custom port
+supreme-claudemander --no-browser      # don't auto-open browser
+supreme-claudemander --electron        # launch in Electron shell
 ```
 
 ## Controls

--- a/claude_rts/__main__.py
+++ b/claude_rts/__main__.py
@@ -1,6 +1,7 @@
 """CLI entry point: start server and open browser/electron."""
 
 import argparse
+import os
 import pathlib
 import subprocess
 import sys
@@ -13,8 +14,12 @@ from loguru import logger
 from . import config
 from .server import create_app
 
-# Resolve electron/ directory relative to this package
-_ELECTRON_DIR = pathlib.Path(__file__).resolve().parent.parent / "electron"
+# Resolve electron/ directory: env var override → repo-relative fallback
+_env_electron_dir = os.environ.get("SUPREME_CLAUDEMANDER_ELECTRON_DIR")
+if _env_electron_dir:
+    _ELECTRON_DIR = pathlib.Path(_env_electron_dir).resolve()
+else:
+    _ELECTRON_DIR = pathlib.Path(__file__).resolve().parent.parent / "electron"
 
 
 def _get_version() -> str:
@@ -30,7 +35,8 @@ def _check_electron_installed():
     if not _ELECTRON_DIR.exists():
         print(
             "Electron shell is not available in pip-installed packages.\n"
-            "To use --electron, clone the repository and run 'npm install' in the electron/ directory.\n"
+            "Option 1: set SUPREME_CLAUDEMANDER_ELECTRON_DIR to the 'electron/' directory in your local clone.\n"
+            "Option 2: clone the repository and run 'npm install' in the electron/ directory.\n"
             "See: https://github.com/hyang0129/supreme-claudemander",
             file=sys.stderr,
         )


### PR DESCRIPTION
## Summary

- **README**: replaces `pip install -e .` quick-start with the full build → dedicated venv → wheel install workflow matching how the package is actually shipped
- **`__main__.py`**: adds `SUPREME_CLAUDEMANDER_ELECTRON_DIR` env var so pip-installed packages can point `--electron` at the `electron/` directory in a local clone, instead of failing with a hard exit

## Test plan

- [ ] `python -m build` produces wheel in `dist/`
- [ ] Install wheel into fresh venv and `supreme-claudemander --version` works
- [ ] `supreme-claudemander --electron` without env var prints the updated two-option error message
- [ ] `SUPREME_CLAUDEMANDER_ELECTRON_DIR=.../electron supreme-claudemander --electron` launches Electron normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)