### PR TITLE
fix(#165): consolidate shared e2e helpers into conftest + fix startup timeout

### DIFF
--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -3805,6 +3805,7 @@ async function handleBlueprintOpenWidget(msg) {
 // Boot
 // ════════════════════════════════════════════
 (async function() {
+  try {
   // Load settings first (determines default_canvas)
   await loadSettings();
   currentCanvasName = settings.default_canvas || 'probe-qa';
@@ -3925,10 +3926,12 @@ async function handleBlueprintOpenWidget(msg) {
 
   // Center viewport on the cards
   setTimeout(fitAll, 200);
-
+  } finally {
   // Boot complete — observable signal for E2E tests that need a ready
-  // condition instead of a fixed timeout.
+  // condition instead of a fixed timeout. Always set regardless of how
+  // the IIFE exits (early return, exception, or normal completion).
   window.__claudeRtsBootComplete = true;
+  }
 })();
 </script>
 </body>

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -3925,6 +3925,10 @@ async function handleBlueprintOpenWidget(msg) {
 
   // Center viewport on the cards
   setTimeout(fitAll, 200);
+
+  // Boot complete — observable signal for E2E tests that need a ready
+  // condition instead of a fixed timeout.
+  window.__claudeRtsBootComplete = true;
 })();
 </script>
 </body>

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -177,6 +177,16 @@ def clear_canvas(page):
             }
             cards.length = 0;
         }
+        if (typeof hubSymbolMap !== 'undefined') {
+            hubSymbolMap.clear
+                ? hubSymbolMap.clear()
+                : Object.keys(hubSymbolMap).forEach(k => delete hubSymbolMap[k]);
+        }
+        if (typeof controlGroups !== 'undefined') {
+            controlGroups.clear
+                ? controlGroups.clear()
+                : Object.keys(controlGroups).forEach(k => delete controlGroups[k]);
+        }
         const el = document.getElementById('canvas');
         if (el) el.innerHTML = '';
         // Reset context menu and pan/zoom so residual DOM state cannot
@@ -221,6 +231,11 @@ def clear_canvas(page):
                         const msg = JSON.parse(ev.data);
                         if (msg.type === 'card_created') handleControlCardCreated(msg);
                         else if (msg.type === 'card_deleted') handleControlCardDeleted(msg);
+                        else if (msg.type === 'card_updated') handleControlCardUpdated(msg);
+                        else if (msg.type === 'blueprint:log') handleBlueprintLog(msg);
+                        else if (msg.type === 'blueprint:completed') handleBlueprintCompleted(msg);
+                        else if (msg.type === 'blueprint:failed') handleBlueprintFailed(msg);
+                        else if (msg.type === 'blueprint:open_widget') handleBlueprintOpenWidget(msg);
                     } catch(e) {}
                 };
             } catch(e) {}
@@ -279,8 +294,9 @@ def refresh_vm_card(page):
             const searchInputs = document.querySelectorAll('[data-vm-search]');
             if (searchInputs.length === 0) return false;
             if (favs.length === 0) {
-                // Empty favorites renders the placeholder — accept as ready.
-                return true;
+                // Empty favorites: confirm no remove buttons exist (clean render) and search input present
+                const removeBtns = document.querySelectorAll('[data-vm-remove]');
+                return removeBtns.length === 0 && searchInputs.length > 0;
             }
             for (const fav of favs) {
                 const btn = document.querySelector(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,6 +5,17 @@ app in a Chromium browser via Playwright.
 
 The dev-config preset defaults to "stress-test" and can be overridden
 per-module by defining a ``dev_config_preset`` fixture.
+
+This module is also the single source of truth for shared helpers used
+across e2e test files:
+
+- ``clear_canvas``          — destroy all cards + clear canvas DOM, condition-based
+- ``open_context_menu``     — right-click viewport and wait for menu
+- ``refresh_vm_card``       — re-render VM Manager widgets, condition-based
+- ``cleanup_non_vm_cards``  — remove non-VM cards, condition-based
+
+Test files should import these helpers from conftest rather than
+redefining them locally (see issue #165).
 """
 
 import os
@@ -120,11 +131,196 @@ def page(backend_server, backend_port):
     pg.goto(f"http://localhost:{backend_port}")
     pg.wait_for_load_state("networkidle")
     pg.wait_for_selector("#canvas", timeout=15000)
-    # Give the startup script time to spawn cards
-    pg.wait_for_timeout(3000)
+    # Wait for the observable boot-complete signal set at the end of the
+    # boot IIFE in static/index.html.  Replaces a fixed 3-second sleep so
+    # the suite doesn't pay that cost on every module and is insulated from
+    # fast/slow-start variance.
+    pg.wait_for_function(
+        "() => window.__claudeRtsBootComplete === true",
+        timeout=15000,
+    )
 
     yield pg
 
     pg.close()
     browser.close()
     pw.stop()
+
+
+# ── Shared helpers (single source of truth — see issue #165) ─────────────────
+
+
+def clear_canvas(page):
+    """Destroy all cards, clear the canvas DOM, and reset shared state.
+
+    Condition-based: waits for ``cards.length === 0`` AND
+    ``#canvas.children.length === 0`` before returning.  No fixed sleeps.
+    The control-WebSocket ``onmessage`` handler is nulled while draining so
+    a late ``card_created`` broadcast cannot race the cleanup; it is
+    re-attached once the canvas is confirmed empty.
+    """
+    page.evaluate(
+        """() => {
+        // Silence queued control-ws messages while we drain cards.  Cards
+        // destroyed below may not yet have a sessionId if the server was
+        // slow to respond; in that case _markSessionDestroyed(null) is a
+        // no-op and a delayed card_created broadcast would otherwise slip
+        // through the guard.  Keeping the handler null until after
+        // wait_for_function prevents ghost cards from appearing while we
+        // wait for the canvas to drain.
+        if (typeof controlWs !== 'undefined' && controlWs) {
+            try { controlWs.onmessage = null; } catch(e) {}
+        }
+        if (typeof cards !== 'undefined') {
+            for (const card of cards) {
+                if (typeof card.destroy === 'function') card.destroy();
+            }
+            cards.length = 0;
+        }
+        const el = document.getElementById('canvas');
+        if (el) el.innerHTML = '';
+        // Reset context menu and pan/zoom so residual DOM state cannot
+        // block the right-click handler on subsequent tests.
+        if (typeof hideContextMenu === 'function') hideContextMenu();
+        if (typeof pan === 'object' && pan !== null) { pan.x = 0; pan.y = 0; }
+        if (typeof zoom !== 'undefined') { zoom = 1; }
+        if (typeof applyTransform === 'function') applyTransform();
+        if (typeof focusedCardId !== 'undefined') { focusedCardId = null; }
+    }"""
+    )
+    # Wait until the canvas DOM is truly empty.  Re-clear on every poll to
+    # evict ghost cards that snuck in while a card_created handler was
+    # already mid-execution when we nulled controlWs.onmessage above.
+    page.wait_for_function(
+        """() => {
+            if (typeof controlWs !== 'undefined' && controlWs) {
+                try { controlWs.onmessage = null; } catch(e) {}
+            }
+            if (typeof cards !== 'undefined' && cards.length > 0) {
+                for (const card of cards) {
+                    if (typeof card.destroy === 'function') card.destroy();
+                }
+                cards.length = 0;
+            }
+            const el = document.getElementById('canvas');
+            if (el && el.children.length > 0) el.innerHTML = '';
+            return el !== null && el.children.length === 0 &&
+                   ((typeof cards !== 'undefined') ? cards.length : 0) === 0;
+        }""",
+        timeout=3000,
+    )
+    # Re-attach the control-ws message handler now that the canvas is
+    # confirmed empty.  Any broadcast that arrives from this point on goes
+    # through the normal handleControlCardCreated guard logic.
+    page.evaluate(
+        """() => {
+        if (typeof controlWs !== 'undefined' && controlWs) {
+            try {
+                controlWs.onmessage = (ev) => {
+                    try {
+                        const msg = JSON.parse(ev.data);
+                        if (msg.type === 'card_created') handleControlCardCreated(msg);
+                        else if (msg.type === 'card_deleted') handleControlCardDeleted(msg);
+                    } catch(e) {}
+                };
+            } catch(e) {}
+        }
+    }"""
+    )
+
+
+def open_context_menu(page, x=500, y=500):
+    """Right-click the viewport at ``(x, y)`` and wait for #context-menu visible with items."""
+    # Dismiss any leftover menu from a prior test before right-clicking,
+    # otherwise the visible menu intercepts pointer events.
+    page.evaluate("() => { if (typeof hideContextMenu === 'function') hideContextMenu(); }")
+    page.locator("#viewport").click(button="right", position={"x": x, "y": y})
+    # Wait for menu to be visible AND contain at least one item.
+    # If the right-click was intercepted by a ghost card, showContextMenu never
+    # fires and this times out with a clear error.
+    page.locator(
+        "#context-menu.visible .ctx-item[data-hub], #context-menu.visible .ctx-item[data-host-shell]"
+    ).first.wait_for(state="visible", timeout=5000)
+
+
+def refresh_vm_card(page):
+    """Force re-render of all VM Manager widget cards; wait until the DOM
+    reflects the current ``/api/vms/favorites`` response.
+
+    The VM Manager ``render()`` method is async (fetches favorites +
+    discover + config before writing ``body.innerHTML``).  We read the
+    expected favorite names from the API and poll until every favorite has
+    a ``[data-vm-remove="<name>"]`` button in the DOM (or favorites is
+    empty and ``[data-vm-search]`` is present).  This replaces fixed
+    ``wait_for_timeout`` delays that were 1.5 s in mock tests and 3 s in
+    real-Docker tests — both readily slower than the slowest observed
+    render and prone to flakes on busy CI.
+    """
+    page.evaluate(
+        """() => {
+        if (typeof cards !== 'undefined') {
+            for (const card of cards) {
+                if (card.widgetType === 'vm-manager' && typeof card.render === 'function') {
+                    card.render();
+                }
+            }
+        }
+    }"""
+    )
+    # Fetch expected favorite names, then wait for them to appear.  Using
+    # data-vm-remove (one per favorite, regardless of state) is the most
+    # reliable observable for render completion.
+    page.wait_for_function(
+        """async () => {
+            const r = await fetch('/api/vms/favorites');
+            if (!r.ok) return false;
+            const favs = await r.json();
+            // The VM Manager card must be present in the DOM.
+            const searchInputs = document.querySelectorAll('[data-vm-search]');
+            if (searchInputs.length === 0) return false;
+            if (favs.length === 0) {
+                // Empty favorites renders the placeholder — accept as ready.
+                return true;
+            }
+            for (const fav of favs) {
+                const btn = document.querySelector(
+                    `[data-vm-remove="${CSS.escape(fav.name)}"]`
+                );
+                if (!btn) return false;
+            }
+            return true;
+        }""",
+        timeout=10000,
+    )
+
+
+def cleanup_non_vm_cards(page):
+    """Remove all cards except VM Manager widgets.
+
+    Terminal cards spawned by earlier tests can intercept pointer events
+    on the VM Manager card.  This helper destroys them and waits until
+    every remaining ``[data-card-id]`` contains a ``[data-vm-search]``
+    descendant (i.e. only VM Manager cards remain) — no fixed sleep.
+    """
+    page.evaluate(
+        """() => {
+        if (typeof cards === 'undefined') return;
+        const toRemove = [];
+        for (let i = cards.length - 1; i >= 0; i--) {
+            if (cards[i].widgetType !== 'vm-manager') {
+                if (typeof cards[i].destroy === 'function') cards[i].destroy();
+                toRemove.push(i);
+            }
+        }
+        for (const idx of toRemove) cards.splice(idx, 1);
+    }"""
+    )
+    page.wait_for_function(
+        """() => {
+            const all = document.querySelectorAll('[data-card-id]');
+            return Array.from(all).every(
+                c => c.querySelector('[data-vm-search]') !== null
+            );
+        }""",
+        timeout=3000,
+    )

--- a/tests/e2e/test_compat.py
+++ b/tests/e2e/test_compat.py
@@ -28,7 +28,7 @@ import pytest
 pw = pytest.importorskip("playwright")
 
 # Shared helpers live in conftest (single source of truth — see issue #165).
-from tests.e2e.conftest import clear_canvas  # noqa: E402,F401
+from tests.e2e.conftest import clear_canvas  # noqa: E402
 
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 

--- a/tests/e2e/test_compat.py
+++ b/tests/e2e/test_compat.py
@@ -27,6 +27,9 @@ import pytest
 # Skip module entirely if playwright is not installed
 pw = pytest.importorskip("playwright")
 
+# Shared helpers live in conftest (single source of truth — see issue #165).
+from tests.e2e.conftest import clear_canvas  # noqa: E402,F401
+
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 
 
@@ -41,51 +44,6 @@ def get_card_count(page):
 def count_cards_by_type(page, card_type):
     """Count cards where card.type === card_type via JS."""
     return page.evaluate("(t) => cards.filter(c => c.type === t).length", card_type)
-
-
-def clear_canvas(page):
-    """Destroy all cards, clear the canvas DOM element, and reset shared state."""
-    page.evaluate(
-        """() => {
-        if (typeof controlWs !== 'undefined' && controlWs) {
-            try { controlWs.onmessage = null; } catch(e) {}
-        }
-        if (typeof cards !== 'undefined') {
-            for (const card of cards) {
-                if (typeof card.destroy === 'function') card.destroy();
-            }
-            cards.length = 0;
-        }
-        const el = document.getElementById('canvas');
-        if (el) el.innerHTML = '';
-        if (typeof hideContextMenu === 'function') hideContextMenu();
-        if (typeof pan === 'object' && pan !== null) { pan.x = 0; pan.y = 0; }
-        if (typeof zoom !== 'undefined') { zoom = 1; }
-        if (typeof applyTransform === 'function') applyTransform();
-        if (typeof focusedCardId !== 'undefined') { focusedCardId = null; }
-        if (typeof controlWs !== 'undefined' && controlWs) {
-            try {
-                controlWs.onmessage = (ev) => {
-                    try {
-                        const msg = JSON.parse(ev.data);
-                        if (msg.type === 'card_created') handleControlCardCreated(msg);
-                        else if (msg.type === 'card_deleted') handleControlCardDeleted(msg);
-                    } catch(e) {}
-                };
-            } catch(e) {}
-        }
-    }"""
-    )
-    # Wait until the canvas DOM is truly empty (no ghost cards from queued
-    # control-ws broadcasts) instead of a fixed 300ms sleep.
-    page.wait_for_function(
-        """() => {
-            const el = document.getElementById('canvas');
-            const c = (typeof cards !== 'undefined') ? cards.length : 0;
-            return el !== null && el.children.length === 0 && c === 0;
-        }""",
-        timeout=3000,
-    )
 
 
 def put_canvas(page, canvas_name, payload):

--- a/tests/e2e/test_spawn_registry_e2e.py
+++ b/tests/e2e/test_spawn_registry_e2e.py
@@ -18,22 +18,11 @@ import pytest
 # Skip module entirely if playwright is not installed
 pw = pytest.importorskip("playwright")
 
+# Shared helpers live in conftest (single source of truth — see issue #165).
+from tests.e2e.conftest import clear_canvas, open_context_menu  # noqa: E402,F401
+
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
-
-
-def open_context_menu(page, x=500, y=500):
-    """Right-click viewport at (x, y) and wait for #context-menu visible with items."""
-    # Dismiss any leftover menu from a prior test before right-clicking,
-    # otherwise the visible menu intercepts pointer events.
-    page.evaluate("() => { if (typeof hideContextMenu === 'function') hideContextMenu(); }")
-    page.locator("#viewport").click(button="right", position={"x": x, "y": y})
-    # Wait for menu to be visible AND contain at least one item.
-    # If the right-click was intercepted by a ghost card, showContextMenu never
-    # fires and this times out with a clear error.
-    page.locator(
-        "#context-menu.visible .ctx-item[data-hub], #context-menu.visible .ctx-item[data-host-shell]"
-    ).first.wait_for(state="visible", timeout=5000)
 
 
 def count_cards_by_type(page, card_type):
@@ -73,80 +62,6 @@ def get_menu_section_headers(page):
 def get_card_count(page):
     """Return the current length of the JS cards[] array."""
     return page.evaluate("() => cards.length")
-
-
-def clear_canvas(page):
-    """Destroy all cards, clear the canvas DOM element, and reset shared state."""
-    page.evaluate(
-        """() => {
-        // Silence queued control-ws messages.  Cards destroyed below may not
-        // yet have a sessionId if the server was slow to respond; in that case
-        // _markSessionDestroyed(null) is a no-op and a delayed card_created
-        // broadcast would slip through the guard.  Keeping the handler null
-        // until after wait_for_function prevents ghost cards from appearing
-        // while we wait for the canvas to drain.
-        if (typeof controlWs !== 'undefined' && controlWs) {
-            try { controlWs.onmessage = null; } catch(e) {}
-        }
-        if (typeof cards !== 'undefined') {
-            for (const card of cards) {
-                if (typeof card.destroy === 'function') card.destroy();
-            }
-            cards.length = 0;
-        }
-        const el = document.getElementById('canvas');
-        if (el) el.innerHTML = '';
-        // Reset context menu and pan/zoom so residual DOM state cannot
-        // block the right-click handler on subsequent tests.
-        if (typeof hideContextMenu === 'function') hideContextMenu();
-        if (typeof pan === 'object' && pan !== null) { pan.x = 0; pan.y = 0; }
-        if (typeof zoom !== 'undefined') { zoom = 1; }
-        if (typeof applyTransform === 'function') applyTransform();
-        if (typeof focusedCardId !== 'undefined') { focusedCardId = null; }
-        // controlWs.onmessage intentionally left null here — re-attached
-        // in a separate evaluate() call after wait_for_function confirms the
-        // canvas is empty.
-    }"""
-    )
-    # Wait until the canvas DOM is truly empty.  Re-clear on every poll to
-    # evict ghost cards that snuck in while a card_created handler was already
-    # mid-execution when we nulled controlWs.onmessage above.
-    page.wait_for_function(
-        """() => {
-            if (typeof controlWs !== 'undefined' && controlWs) {
-                try { controlWs.onmessage = null; } catch(e) {}
-            }
-            if (typeof cards !== 'undefined' && cards.length > 0) {
-                for (const card of cards) {
-                    if (typeof card.destroy === 'function') card.destroy();
-                }
-                cards.length = 0;
-            }
-            const el = document.getElementById('canvas');
-            if (el && el.children.length > 0) el.innerHTML = '';
-            return el !== null && el.children.length === 0 &&
-                   ((typeof cards !== 'undefined') ? cards.length : 0) === 0;
-        }""",
-        timeout=3000,
-    )
-    # Re-attach the control-ws message handler now that the canvas is
-    # confirmed empty.  Any broadcast that arrives from this point on goes
-    # through the normal handleControlCardCreated guard logic.
-    page.evaluate(
-        """() => {
-        if (typeof controlWs !== 'undefined' && controlWs) {
-            try {
-                controlWs.onmessage = (ev) => {
-                    try {
-                        const msg = JSON.parse(ev.data);
-                        if (msg.type === 'card_created') handleControlCardCreated(msg);
-                        else if (msg.type === 'card_deleted') handleControlCardDeleted(msg);
-                    } catch(e) {}
-                };
-            } catch(e) {}
-        }
-    }"""
-    )
 
 
 def wait_for_new_card(page, initial_count, timeout_ms=3000):

--- a/tests/e2e/test_spawn_registry_e2e.py
+++ b/tests/e2e/test_spawn_registry_e2e.py
@@ -19,7 +19,7 @@ import pytest
 pw = pytest.importorskip("playwright")
 
 # Shared helpers live in conftest (single source of truth — see issue #165).
-from tests.e2e.conftest import clear_canvas, open_context_menu  # noqa: E402,F401
+from tests.e2e.conftest import clear_canvas, open_context_menu  # noqa: E402
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/tests/e2e/test_vm_manager_e2e.py
+++ b/tests/e2e/test_vm_manager_e2e.py
@@ -20,7 +20,7 @@ import pytest
 pw = pytest.importorskip("playwright")
 
 # Shared helpers live in conftest (single source of truth — see issue #165).
-from tests.e2e.conftest import cleanup_non_vm_cards, refresh_vm_card  # noqa: E402,F401
+from tests.e2e.conftest import cleanup_non_vm_cards, refresh_vm_card  # noqa: E402
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────

--- a/tests/e2e/test_vm_manager_e2e.py
+++ b/tests/e2e/test_vm_manager_e2e.py
@@ -19,6 +19,9 @@ import pytest
 # Skip module entirely if playwright is not installed
 pw = pytest.importorskip("playwright")
 
+# Shared helpers live in conftest (single source of truth — see issue #165).
+from tests.e2e.conftest import cleanup_non_vm_cards, refresh_vm_card  # noqa: E402,F401
+
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -94,44 +97,6 @@ def save_blueprint(page, backend_port, name, blueprint_def):
     }""",
         [backend_port, name, blueprint_def],
     )
-
-
-def refresh_vm_card(page):
-    """Force re-render of all VM Manager widget cards on the canvas."""
-    page.evaluate(
-        """() => {
-        if (typeof cards !== 'undefined') {
-            for (const card of cards) {
-                if (card.widgetType === 'vm-manager' && typeof card.render === 'function') {
-                    card.render();
-                }
-            }
-        }
-    }"""
-    )
-    page.wait_for_timeout(1500)
-
-
-def cleanup_non_vm_cards(page):
-    """Remove all cards except VM Manager widgets to prevent overlap issues.
-
-    Terminal cards spawned by earlier tests can intercept pointer events
-    on the VM Manager card.  This helper destroys them.
-    """
-    page.evaluate(
-        """() => {
-        if (typeof cards === 'undefined') return;
-        const toRemove = [];
-        for (let i = cards.length - 1; i >= 0; i--) {
-            if (cards[i].widgetType !== 'vm-manager') {
-                if (typeof cards[i].destroy === 'function') cards[i].destroy();
-                toRemove.push(i);
-            }
-        }
-        for (const idx of toRemove) cards.splice(idx, 1);
-    }"""
-    )
-    page.wait_for_timeout(300)
 
 
 def ensure_vm_card_exists(page):

--- a/tests/e2e/test_vm_manager_real_e2e.py
+++ b/tests/e2e/test_vm_manager_real_e2e.py
@@ -25,7 +25,7 @@ import pytest
 pw = pytest.importorskip("playwright")
 
 # Shared helpers live in conftest (single source of truth — see issue #165).
-from tests.e2e.conftest import cleanup_non_vm_cards, refresh_vm_card  # noqa: E402,F401
+from tests.e2e.conftest import cleanup_non_vm_cards, refresh_vm_card  # noqa: E402
 
 
 # ── Markers & skip logic ─────────────────────────────────────────────────────

--- a/tests/e2e/test_vm_manager_real_e2e.py
+++ b/tests/e2e/test_vm_manager_real_e2e.py
@@ -24,6 +24,9 @@ import pytest
 # Skip module entirely if playwright is not installed
 pw = pytest.importorskip("playwright")
 
+# Shared helpers live in conftest (single source of truth — see issue #165).
+from tests.e2e.conftest import cleanup_non_vm_cards, refresh_vm_card  # noqa: E402,F401
+
 
 # ── Markers & skip logic ─────────────────────────────────────────────────────
 
@@ -170,48 +173,6 @@ def get_favorites(page, port):
         return r.json();
     }""",
         port,
-    )
-
-
-def refresh_vm_card(page):
-    """Force re-render of all VM Manager widget cards on the canvas."""
-    page.evaluate(
-        """() => {
-        if (typeof cards !== 'undefined') {
-            for (const card of cards) {
-                if (card.widgetType === 'vm-manager' && typeof card.render === 'function') {
-                    card.render();
-                }
-            }
-        }
-    }"""
-    )
-    page.wait_for_timeout(3000)
-
-
-def cleanup_non_vm_cards(page):
-    """Remove all cards except VM Manager widgets to prevent overlap issues."""
-    page.evaluate(
-        """() => {
-        if (typeof cards === 'undefined') return;
-        const toRemove = [];
-        for (let i = cards.length - 1; i >= 0; i--) {
-            if (cards[i].widgetType !== 'vm-manager') {
-                if (typeof cards[i].destroy === 'function') cards[i].destroy();
-                toRemove.push(i);
-            }
-        }
-        for (const idx of toRemove) cards.splice(idx, 1);
-    }"""
-    )
-    page.wait_for_function(
-        """() => {
-            const all = document.querySelectorAll('[data-card-id]');
-            return Array.from(all).every(
-                c => c.querySelector('[data-vm-search]') !== null
-            );
-        }""",
-        timeout=3000,
     )
 
 


### PR DESCRIPTION
Closes #165
Part of epic #153.

## Summary

- Move `clear_canvas`, `open_context_menu`, `refresh_vm_card`, and `cleanup_non_vm_cards` into `tests/e2e/conftest.py` as the single authoritative source. Delete the four duplicate/drifted copies scattered across `test_spawn_registry_e2e.py`, `test_compat.py`, `test_vm_manager_e2e.py`, and `test_vm_manager_real_e2e.py` — each now imports the helpers from conftest.
- Replace the fixed `wait_for_timeout(3000)` in the `page` fixture with `wait_for_function(() => window.__claudeRtsBootComplete === true, 15000)`. The boot IIFE in `claude_rts/static/index.html` sets that flag at the end, so readiness is an observable condition instead of a guess. This removes the root-level race every e2e module was paying.
- Unify `refresh_vm_card`: it now re-renders VM Manager widgets, then polls `/api/vms/favorites` and waits until every favorite has its `[data-vm-remove]` button in the DOM (empty favorites accepts `[data-vm-search]` as the ready signal). Replaces the mock's 1.5s sleep and the real-Docker 3s sleep with one condition-based helper.
- `cleanup_non_vm_cards` now uses the condition-based form (waits until every remaining `[data-card-id]` contains `[data-vm-search]`).

No test assertions were changed or weakened — this is a consolidation + flakiness fix.

## Acceptance criteria (from issue)

- [x] **S1** — `grep -n "^def (clear_canvas|open_context_menu|refresh_vm_card|cleanup_non_vm_cards)" tests/e2e` returns exactly one match per helper, all in `conftest.py`.
- [x] **S2** — `clear_canvas` body contains no `wait_for_timeout`; uses `wait_for_function` for drain.
- [x] **S3** — `refresh_vm_card` body contains no `wait_for_timeout`; uses `wait_for_function` on a render-complete observable.
- [x] **S4** — `cleanup_non_vm_cards` body contains no `wait_for_timeout`; uses `wait_for_function` on the VM-only predicate.
- [x] **S5** — `conftest.py` `page` fixture no longer contains `wait_for_timeout(3000)`; uses `wait_for_function` on `window.__claudeRtsBootComplete`.
- [x] **S6** — 432 non-e2e tests still pass locally; 101 e2e tests collect cleanly.

## Test plan

- [x] `python -m ruff check . && python -m ruff format --check .` — clean
- [x] `python -m pytest tests/ --ignore=tests/e2e` — 432 passed
- [x] `python -m pytest tests/e2e/ --collect-only` — 101 tests collected, no import errors
- [ ] CI runs the full e2e suite on the epic branch (Playwright + Electron not available in devcontainer for local run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Review summary
- Cycles run: 1
- Findings fixed: 5 (1 critical, 2 major, 2 minor)
- Intent validation: clean
- Outstanding: 3 deferred minor nits (non-blocking)

## History
Rebased onto `epic/153-fix-e2e-flaky-tests` — already up to date, no conflicts.

## Merge instructions
Merge via **squash merge** (not merge commit or rebase merge).