### PR TITLE
fix(#166): replace 4 wait_for_timeout sleeps with condition-based waits

### DIFF
--- a/tests/e2e/test_spawn_registry_e2e.py
+++ b/tests/e2e/test_spawn_registry_e2e.py
@@ -381,10 +381,16 @@ class TestProbeProfileNetworkContract:
             probe_item = page.locator("#context-menu [data-probe-profile]").first
             if probe_item.count() == 0:
                 pytest.skip("No probe-profile row in context menu")
-            probe_item.click()
 
-            # Give the async handler time to fire the fetch
-            page.wait_for_timeout(2000)
+            # Wait for the POST to /api/probe/claude-usage to fire as a direct
+            # consequence of the click — condition-based, no fixed sleep.  The
+            # recorded_requests listener above still captures for the final
+            # assertion.
+            with page.expect_request(
+                lambda req: "probe/claude-usage" in req.url,
+                timeout=5000,
+            ):
+                probe_item.click()
         finally:
             page.remove_listener("request", record_request)
 
@@ -442,8 +448,13 @@ class TestSpawnFromSerializedMixedCanvas:
         clear_canvas(page)
         page.evaluate("() => switchCanvas('mixed-restore')")
 
-        # Wait for spawn to complete (sequential async spawns)
-        page.wait_for_timeout(2000)
+        # Wait for spawn to complete — exactly 3 cards should restore (the
+        # unknown-hub entry is silently skipped).  Condition-based: polls
+        # cards.length instead of sleeping for a fixed duration.
+        page.wait_for_function(
+            "() => typeof cards !== 'undefined' && cards.length === 3",
+            timeout=5000,
+        )
 
         total_cards = get_card_count(page)
         assert total_cards == 3, f"Expected exactly 3 cards (unknown hub skipped); got {total_cards}"
@@ -491,7 +502,12 @@ class TestSpawnFromSerializedMixedCanvas:
 
         clear_canvas(page)
         page.evaluate("() => switchCanvas('mixed-restore-clean')")
-        page.wait_for_timeout(2000)
+        # Wait for the 2-card clean canvas to finish restoring.  Condition-based
+        # on cards.length so we don't sleep past the slowest observed spawn.
+        page.wait_for_function(
+            "() => typeof cards !== 'undefined' && cards.length === 2",
+            timeout=5000,
+        )
 
         page.remove_listener("pageerror", _on_page_error)
         assert len(page_errors) == 0, f"Unexpected page error(s) during restore: {page_errors}"
@@ -527,8 +543,19 @@ class TestCanvasClaudeStalenessCheck:
         clear_canvas(page)
         page.evaluate("() => switchCanvas('cc-stale-test')")
 
-        # prepareOpts does two fetches; allow up to 5 s
-        page.wait_for_timeout(3000)
+        # prepareOpts does two sequential fetches before the card lands.  Wait
+        # for the canvas_claude card to exist AND for its sessionId to no
+        # longer equal the bogus id.  Condition-based replacement for the
+        # previous 3 s fixed sleep — fails fast with a clear timeout error if
+        # the staleness check regressed.
+        page.wait_for_function(
+            f"""() => {{
+                if (typeof cards === 'undefined' || cards.length === 0) return false;
+                const cc = cards.find(c => c.type === 'canvas_claude');
+                return cc !== undefined && cc.sessionId !== {bogus_session_id!r};
+            }}""",
+            timeout=5000,
+        )
 
         total_cards = get_card_count(page)
         assert total_cards >= 1, "Expected at least one canvas_claude card after switchCanvas"


### PR DESCRIPTION
Closes #166

## What changed

The three named tests from issue #166 (`test_hub_row_card_has_symbol`, `test_host_shell_seeds_hub_symbol`, `test_host_shell_row_click_hides_menu_and_spawns_card`) already use the consolidated `clear_canvas` and `open_context_menu` helpers landed by #165, and `clear_canvas` already resets `hubSymbolMap` (conftest.py:180-184) — OQ-2a is resolved. The remaining work in this slice is S4: replacing the four fixed-duration `page.wait_for_timeout(...)` sleeps in `tests/e2e/test_spawn_registry_e2e.py` with condition-based waits keyed to the exact observable each subsequent assertion checks.

## Implementation walkthrough

### Timeout replacements

- **`test_probe_row_posts_to_api`** (was `wait_for_timeout(2000)` after clicking the probe-profile row). Rewritten to wrap the click in `page.expect_request(lambda req: "probe/claude-usage" in req.url, timeout=5000)`. The test now unblocks the instant the POST fires; the outer `recorded_requests` listener still captures the request for the final `>= 1` assertion, which is preserved verbatim.

- **`test_mixed_canvas_restore`** (was `wait_for_timeout(2000)` after `switchCanvas('mixed-restore')`). Replaced with `page.wait_for_function("() => typeof cards !== 'undefined' && cards.length === 3", timeout=5000)`. The subsequent `assert total_cards == 3` is unchanged — the wait now observes the exact invariant the assertion checks.

- **`test_no_console_errors_on_mixed_restore`** (was `wait_for_timeout(2000)` after `switchCanvas('mixed-restore-clean')`). Replaced with `page.wait_for_function("() => typeof cards !== 'undefined' && cards.length === 2", timeout=5000)`. The `page_errors` assertion is preserved.

- **`test_stale_session_id_is_replaced`** (was `wait_for_timeout(3000)` after `switchCanvas('cc-stale-test')`). Replaced with a `wait_for_function` that polls for both (a) the canvas_claude card existing in `cards[]` and (b) its `sessionId !== bogus_session_id`. The wait now fails fast with a clear timeout error if the staleness check regresses, instead of silently passing through a 3 s sleep and then hitting the assertion. All three downstream assertions (`total_cards >= 1`, `cardType == 'canvas_claude'`, `sessionId != bogus_session_id`) are preserved.

### Default execution path

**Before**: click → `wait_for_timeout(N)` → assert observable. Flaky on slow CI (N too short) and wasteful on fast CI (N too long). A regression where the observable never appears still passes the sleep and only surfaces as an assertion failure at line N+1 without a clear "timed out waiting for X" message.

**After**: click → `wait_for_function(predicate on the same observable, timeout=5000)` → assert. The wait surfaces failures with a Playwright timeout error tied to the exact JS predicate, and passes as soon as the predicate is true. No ceiling lowered — the new timeouts (5 s) are equal to or greater than the longest fixed sleep being replaced (3 s), so this change cannot make any previously-passing test start failing for timing reasons.

### What was intentionally not changed

- `tests/e2e/conftest.py` is untouched — `clear_canvas` already resets `hubSymbolMap` and `controlGroups`, which is what OQ-2a asked about.
- The three named tests from the issue body already use the conftest helpers (landed by #165) and are not modified — they were already condition-based through `wait_for_new_card`. This slice does not re-touch them.
- No assertion is removed or weakened; `grep -E '^-.*assert' git-diff` returns empty.

## Tier / approach

Tier 1 — Planner → Coder → Reviewer (single test-file slice, < 50 lines diff).

## Acceptance criteria

- [x] `grep wait_for_timeout tests/e2e/test_spawn_registry_e2e.py` returns empty
- [x] Every `assert` in the file is preserved or strengthened
- [x] `python -m ruff check .` and `python -m ruff format --check .` both pass
- [x] Diff scoped to `tests/e2e/test_spawn_registry_e2e.py` only
- [ ] S1/S2/S3 stability across 10 consecutive CI runs — will be observed post-merge via CI history on the epic branch

## Outstanding items

None. Stability assertions (S1/S2/S3 across 10 runs) are inherent to running the suite in CI and cannot be verified locally by a single test run — they will show up in the epic's green-check history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)