### PR TITLE
fix(#167): replace wait_for_timeout in ensure_vm_card_exists helper

### DIFF
--- a/tests/e2e/test_vm_manager_real_e2e.py
+++ b/tests/e2e/test_vm_manager_real_e2e.py
@@ -177,13 +177,21 @@ def get_favorites(page, port):
 
 
 def ensure_vm_card_exists(page):
-    """Ensure at least one VM Manager card exists; spawn one if needed."""
+    """Ensure at least one VM Manager card exists; spawn one if needed.
+
+    Condition-based: after spawning, waits for the observable
+    ``[data-vm-search]`` input to appear in the DOM rather than a fixed
+    sleep.  Removes a flaky 2-second ``wait_for_timeout`` from the critical
+    path of every test in this module (see issue #167).
+    """
     vm_cards = page.locator("[data-card-id]").filter(has=page.locator("[data-vm-search]"))
     if vm_cards.count() > 0:
         return
     # Spawn via JS directly
     page.evaluate("() => CARD_TYPE_REGISTRY.spawn('widget', {widgetType: 'vm-manager', x: 100, y: 100})")
-    page.wait_for_timeout(2000)
+    # Wait for the VM Manager card's search input — the first observable
+    # DOM element written by its async render() — instead of sleeping.
+    page.wait_for_selector("[data-vm-search]", timeout=5000)
 
 
 def docker_inspect_state(name: str) -> str:


### PR DESCRIPTION
Closes #167

Part of epic #153. Depends on #165 (merged).

## What changed

`tests/e2e/test_vm_manager_real_e2e.py::ensure_vm_card_exists` previously
called `page.wait_for_timeout(2000)` after spawning the VM Manager card.
The 2-second sleep was the upstream race behind the flaky
`test_terminal_action_spawns_card` on Linux CI: the test's own
observation point (line 472–474) is already condition-based, but setup
helpers still used fixed waits.

This PR replaces the sleep with
`page.wait_for_selector('[data-vm-search]', timeout=5000)`, matching the
condition-based pattern established by the shared helpers consolidated in
issue #165 (`clear_canvas`, `refresh_vm_card`, `cleanup_non_vm_cards`).
`[data-vm-search]` is the first observable DOM element the VM Manager's
async `render()` writes, so the helper returns exactly when the card is
actually ready — no slower than the old sleep on slow machines, and
dramatically faster on fast ones.

## Tier / approach

Tier 1 — single-file, single-helper edit. Planner → Coder → Reviewer.

## Acceptance criteria

- [x] S1 — test body already uses `wait_for_function` with 10s budget; the
  race upstream in `ensure_vm_card_exists` is now removed
- [x] S2 — `grep wait_for_timeout` inside `ensure_vm_card_exists` returns empty
- [x] S3 — the existing assertion (`new_count > initial_count`, "A new
  card should be spawned…") is preserved verbatim

## Scope

Per the issue:

- In scope: the local `ensure_vm_card_exists` helper in
  `test_vm_manager_real_e2e.py`
- Out of scope (deferred to Child 6): remaining `wait_for_timeout` calls
  at lines 310, 413, 423; the duplicate helper in `test_vm_manager_e2e.py`
  (mock file)

## Validation

- `python -m ruff format --check .` — clean
- `python -m ruff check .` — clean
- `python -m pytest tests/ --ignore=tests/e2e` — 432 passed
- Real-Docker e2e requires Windows (`docker.exe`) and cannot be run from
  the Linux devcontainer; CI will exercise the test

🤖 Generated with [Claude Code](https://claude.com/claude-code)