### PR TITLE
fix(e2e): sweep wait_for_timeout in test_compat.py + test_blueprint_e2e.py (#170)

### DIFF
--- a/tests/e2e/test_blueprint_e2e.py
+++ b/tests/e2e/test_blueprint_e2e.py
@@ -46,7 +46,7 @@ def wait_for_session(backend_port, *, timeout=10.0, exclude=()):
         new = [s for s in sessions if s["session_id"] not in exclude]
         if new:
             return new[0]
-        time.sleep(0.3)
+        time.sleep(0.1)
     return None
 
 
@@ -202,6 +202,8 @@ class TestBlueprintTerminalInjection:
                 if result:
                     captured.append(result)
                     break
+                # 50ms polling interval for an ephemeral card that may vanish between
+                # polls; retained as a ≤100ms stabilization per epic #153 intent.
                 page.wait_for_timeout(50)
 
             t.join(timeout=3)

--- a/tests/e2e/test_compat.py
+++ b/tests/e2e/test_compat.py
@@ -91,7 +91,8 @@ class TestUnknownTypeSkip:
         put_canvas(page, "compat-unknown-type", fixture)
 
         page.evaluate("() => switchCanvas('compat-unknown-type')")
-        page.wait_for_timeout(2000)
+        # unknown_type_canvas.json has 2 entries; the 'foo' entry is skipped → 1 card.
+        page.wait_for_function("() => cards.length === 1", timeout=5000)
 
         page.remove_listener("pageerror", _on_page_error)
         assert len(page_errors) == 0, f"Unexpected page error(s): {page_errors}"
@@ -104,7 +105,7 @@ class TestUnknownTypeSkip:
         put_canvas(page, "compat-unknown-type-count", fixture)
 
         page.evaluate("() => switchCanvas('compat-unknown-type-count')")
-        page.wait_for_timeout(2000)
+        page.wait_for_function("() => cards.length === 1", timeout=5000)
 
         total = get_card_count(page)
         assert total == 1, f"Expected 1 card (unknown type skipped), got {total}"
@@ -117,7 +118,7 @@ class TestUnknownTypeSkip:
         put_canvas(page, "compat-unknown-type-foo", fixture)
 
         page.evaluate("() => switchCanvas('compat-unknown-type-foo')")
-        page.wait_for_timeout(2000)
+        page.wait_for_function("() => cards.length === 1", timeout=5000)
 
         foo_count = count_cards_by_type(page, "foo")
         assert foo_count == 0, f"Expected 0 cards with type 'foo', got {foo_count}"
@@ -130,7 +131,7 @@ class TestUnknownTypeSkip:
         put_canvas(page, "compat-unknown-type-widget", fixture)
 
         page.evaluate("() => switchCanvas('compat-unknown-type-widget')")
-        page.wait_for_timeout(2000)
+        page.wait_for_function("() => cards.length === 1", timeout=5000)
 
         widget_count = count_cards_by_type(page, "widget")
         assert widget_count == 1, f"Expected 1 widget card, got {widget_count}"
@@ -166,10 +167,10 @@ class TestPreTypeLegacyCompat:
         put_canvas(page, "compat-legacy-count", fixture)
 
         page.evaluate("() => switchCanvas('compat-legacy-count')")
-        page.wait_for_timeout(2000)
+        expected = len(fixture["cards"])
+        page.wait_for_function(f"() => cards.length === {expected}", timeout=5000)
 
         total = get_card_count(page)
-        expected = len(fixture["cards"])
         assert total == expected, f"Expected {expected} cards from legacy fixture, got {total}"
 
     def test_legacy_all_cards_are_terminals(self, page):
@@ -190,7 +191,8 @@ class TestPreTypeLegacyCompat:
         put_canvas(page, "compat-legacy-type", fixture)
 
         page.evaluate("() => switchCanvas('compat-legacy-type')")
-        page.wait_for_timeout(2000)
+        expected = len(fixture["cards"])
+        page.wait_for_function(f"() => cards.length === {expected}", timeout=5000)
 
         card_types = page.evaluate("() => cards.map(c => c.type)")
         for i, ct in enumerate(card_types):
@@ -222,7 +224,8 @@ class TestPreTypeLegacyCompat:
         put_canvas(page, "compat-legacy-errors", fixture)
 
         page.evaluate("() => switchCanvas('compat-legacy-errors')")
-        page.wait_for_timeout(2000)
+        expected = len(fixture["cards"])
+        page.wait_for_function(f"() => cards.length === {expected}", timeout=5000)
 
         page.remove_listener("pageerror", _on_page_error)
         assert len(page_errors) == 0, f"Unexpected page error(s) during legacy restore: {page_errors}"


### PR DESCRIPTION
Closes #170

Part of epic #153.

- test_compat.py: 7 `wait_for_timeout(2000)` instances replaced with `wait_for_function` on expected `cards.length` (1 for unknown_type fixture with one skipped entry; `len(fixture["cards"])` = 2 for pre-type legacy fixture)
- test_blueprint_e2e.py: 50ms in-loop stabilization retained with a comment per epic intent (≤100ms permitted); `wait_for_session` Python-side polling interval reduced from 300ms to 100ms

All asserts preserved verbatim.

Generated with Claude Code