### PR TITLE
feat(deps): move pywinpty to [windows] optional extra (#156)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,15 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp>=3.9",
-    "pywinpty>=2.0; sys_platform == 'win32'",
-    "ptyprocess>=0.7; sys_platform != 'win32'",
+    "ptyprocess>=0.7",
     "loguru>=0.7",
     "pyte>=0.8",
 ]
 
 [project.optional-dependencies]
+windows = [
+    "pywinpty>=2.0",
+]
 test = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",


### PR DESCRIPTION
Closes #156

Part of epic #154.

## Summary

- Moves `pywinpty>=2.0; sys_platform == 'win32'` from main dependencies to an optional `[windows]` extra in `pyproject.toml`
- Makes `ptyprocess>=0.7` an unconditional default dependency (removes the `sys_platform != 'win32'` marker)
- Linux/macOS installs no longer require pywinpty or any native wheel
- Windows users can still install with `pip install supreme-claudemander[windows]`

## Test plan
- [ ] `pip install -e .` on Linux succeeds without pywinpty
- [ ] `pip install -e ".[windows]"` includes pywinpty
- [ ] All unit tests pass
- [ ] ruff check and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)