### PR TITLE
refactor(docker): remove docker.exe ternaries (#158)

### DIFF
--- a/claude_rts/discovery.py
+++ b/claude_rts/discovery.py
@@ -2,9 +2,8 @@
 
 import asyncio
 import re
-import sys
 
-_DOCKER = "docker.exe" if sys.platform == "win32" else "docker"
+_DOCKER = "docker"
 
 
 async def discover_hubs() -> list[dict]:

--- a/claude_rts/sessions.py
+++ b/claude_rts/sessions.py
@@ -13,13 +13,11 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Optional
 
-import sys
-
 from aiohttp import web
 from loguru import logger
 from .pty_compat import PtyProcess
 
-_DOCKER = "docker.exe" if sys.platform == "win32" else "docker"
+_DOCKER = "docker"
 
 
 class ScrollbackBuffer:


### PR DESCRIPTION
Closes #158

Part of epic #154.

## Summary

- Replaces `_DOCKER = "docker.exe" if sys.platform == "win32" else "docker"` with `_DOCKER = "docker"` in `discovery.py` and `sessions.py`
- Removes unused `sys.platform` imports where applicable

## Test plan
- [ ] All unit tests pass
- [ ] ruff check and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)