### PR TITLE
feat(cli): add --config-dir flag (#159)

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -129,3 +129,39 @@ def test_electron_flag_skips_browser():
             pass
         # webbrowser.open should never be referenced in startup
         mock_wb.open.assert_not_called()
+
+
+def test_config_dir_flag_passes_resolved_path():
+    """Verify --config-dir passes a resolved Path to config.load."""
+    with (
+        patch("sys.argv", ["supreme-claudemander", "--config-dir", "/tmp/test-config"]),
+        patch("claude_rts.__main__.web") as _mock_web,
+        patch("claude_rts.__main__.create_app") as mock_create,
+        patch("claude_rts.__main__.config") as mock_config,
+    ):
+        import pathlib
+
+        mock_config.load.return_value = MagicMock()
+        mock_create.return_value = MagicMock()
+        try:
+            main()
+        except SystemExit:
+            pass
+        mock_config.load.assert_called_once_with(pathlib.Path("/tmp/test-config").resolve())
+
+
+def test_config_dir_not_provided_uses_default():
+    """Verify config.load() is called with no args when --config-dir is absent."""
+    with (
+        patch("sys.argv", ["supreme-claudemander", "--no-browser"]),
+        patch("claude_rts.__main__.web") as _mock_web,
+        patch("claude_rts.__main__.create_app") as mock_create,
+        patch("claude_rts.__main__.config") as mock_config,
+    ):
+        mock_config.load.return_value = MagicMock()
+        mock_create.return_value = MagicMock()
+        try:
+            main()
+        except SystemExit:
+            pass
+        mock_config.load.assert_called_once_with()


### PR DESCRIPTION
Closes #159

Part of epic #154.

## Summary

- Adds `--config-dir <path>` CLI argument to `__main__.py` (already implemented on base branch)
- When provided, the server uses that directory for config instead of `~/.supreme-claudemander/`
- Default behaviour unchanged when flag is omitted
- Adds two new unit tests in `test_main.py` to verify flag wiring and default fallback

## Test plan
- [ ] `python -m claude_rts --config-dir /tmp/test-config` starts without error
- [ ] All unit tests pass (432 + 2 new = 434 total)
- [ ] ruff check and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)