### PR TITLE
ci: expand test matrix to Linux/Mac primary, Windows informational (#160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ jobs:
       - run: ruff format --check .
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -27,6 +30,17 @@ jobs:
           python-version: "3.12"
       - run: pip install -e ".[test]"
       - run: python -m pytest tests/ -v --ignore=tests/e2e
+
+  windows-unit:
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[test,windows]"
+      - run: python -m pytest tests/ -v --ignore=tests/e2e -m "not requires_pty"
 
   e2e:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ claude_rts = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "requires_pty: marks tests as requiring a real PTY (deselect with -m 'not requires_pty')",
+]
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
Closes #160

Part of epic #154.

## Summary

- `test` job now matrices over `[ubuntu-latest, macos-latest]`
- `windows-unit` job added as informational (`continue-on-error: true`), installs `.[windows]`
- Registers `requires_pty` pytest marker in `pyproject.toml` to suppress warnings
- Existing `e2e` job on `ubuntu-latest` unchanged

## Test plan
- [ ] CI passes on ubuntu-latest and macos-latest
- [ ] Windows job runs but doesn't block merge if it fails
- [ ] ruff check and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)