### PR TITLE
fix(#193): Canvas Claude ephemeral terminals and 10-terminal cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Tests use `MockPty` to avoid needing Docker. E2E tests require Playwright and El
 | POST | `/api/vms/{name}/start` | Start a stopped Docker container |
 | POST | `/api/vms/{name}/stop` | Stop a running Docker container (optional `?timeout=N`) |
 | PUT | `/api/vms/favorites/{name}/actions` | Update actions for a specific favorite container |
-| POST | `/api/claude/terminal/create` | Create a TerminalCard + PTY session (params: cmd, hub, container, cols, rows, x, y, w, h) |
+| POST | `/api/claude/terminal/create` | Create a TerminalCard + PTY session (params: cmd, hub, container, cols, rows, x, y, w, h). Optional: `ephemeral=true` (no card registered, auto-closes on PTY EOF or timeout), `spawner_id=<card_id>` (attributes the spawn to a CanvasClaudeCard for cap enforcement), `timeout=<seconds>` (ephemeral only; default 60, max 120; values outside `[1, 120]` return HTTP 400 `ephemeral_timeout_too_long`). When `spawner_id` is set and the spawner already has 10 live sessions, returns HTTP 429 `terminal_cap_reached` with `live_session_ids`. |
 | POST | `/api/claude/terminal/{id}/send` | Write text to a terminal PTY |
 | GET | `/api/claude/terminal/{id}/read` | Read scrollback (optional: strip_ansi, last_n) |
 | GET | `/api/claude/terminal/{id}/status` | Session metadata (alive, age, idle, cmd) |
@@ -178,9 +178,14 @@ When an action button is clicked, the frontend calls `POST /api/blueprints/spawn
 
 The Canvas Claude card (`claude_rts/mcp_server.py`) exposes a JSON-RPC stdio MCP server so Claude Code, running inside the card, can drive the canvas programmatically. Each tool is a thin wrapper around a REST endpoint.
 
+### Canvas Claude 10-terminal cap
+
+Each `CanvasClaudeCard` enforces a hard cap of 10 live terminals across both `open_terminal` and `run_task` spawns originating from that card. The 11th spawn returns HTTP 429 with `{"error": "terminal_cap_reached", "live_session_ids": [...]}`. The cap decrements on explicit `delete_terminal`, PTY EOF, and `run_task` timeout expiry. On card unregister, all sessions attributed to that spawner are cleaned up automatically. Terminals spawned directly by a user (no `spawner_id`) are not subject to this cap.
+
 | Tool | Wraps | Purpose |
 |---|---|---|
 | `open_terminal` | `POST /api/claude/terminal/create` | Spawn a new terminal card (supports `x, y, w, h, container, hub`). `cmd` is passed through verbatim; reference `/profiles/<main_profile_name>` directly to use the in-use credential (resolve the slot name via `GET /api/profiles/main`; defaults to `main`). |
+| `run_task` | `POST /api/claude/terminal/create` (ephemeral=true) | Run a short-running command in an ephemeral PTY (no visible card, auto-closes on PTY EOF or timeout). Default timeout 60s; max 120s — longer operations must use `open_terminal`. Counts toward the 10-terminal cap. Rejects `timeout > 120` with structured error `ephemeral_timeout_too_long`. Use for: `ls`, `git pull`, probes, one-shot checks. |
 | `read_terminal` | `GET /api/claude/terminal/{id}/read` | Read scrollback (default: strip ANSI) |
 | `write_terminal` | `POST /api/claude/terminal/{id}/send` | Write keystrokes to a terminal |
 | `list_terminals` | `GET /api/claude/terminals` | List active terminal cards |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ The Canvas Claude card (`claude_rts/mcp_server.py`) exposes a JSON-RPC stdio MCP
 
 ### Canvas Claude 10-terminal cap
 
-Each `CanvasClaudeCard` enforces a hard cap of 10 live terminals across both `open_terminal` and `run_task` spawns originating from that card. The 11th spawn returns HTTP 429 with `{"error": "terminal_cap_reached", "live_session_ids": [...]}`. The cap decrements on explicit `delete_terminal`, PTY EOF, and `run_task` timeout expiry. On card unregister, all sessions attributed to that spawner are cleaned up automatically. Terminals spawned directly by a user (no `spawner_id`) are not subject to this cap.
+Each `CanvasClaudeCard` enforces a hard cap of 10 live terminals across both `open_terminal` and `run_task` spawns originating from that card. The 11th spawn returns HTTP 429 with `{"error": "terminal_cap_reached", "live_session_ids": [...]}`. The cap decrements on explicit `delete_terminal`, PTY EOF, and `run_task` timeout expiry. On card unregister, all sessions attributed to that spawner are cleaned up automatically. Terminals spawned directly by a user (no `spawner_id`) are not subject to this cap. **The cap applies to any spawn that carries `spawner_id`, regardless of `ephemeral` — a normal `open_terminal` from Canvas Claude also consumes a slot.**
 
 | Tool | Wraps | Purpose |
 |---|---|---|

--- a/claude_rts/cards/canvas_claude_card.py
+++ b/claude_rts/cards/canvas_claude_card.py
@@ -30,7 +30,7 @@ CONTAINER_PYTHON3 = "/usr/local/bin/python3"
 CONTAINER_MCP_SERVER = "/home/util/mcp_server.py"
 
 
-def _build_mcp_config(api_base_url: str) -> dict:
+def _build_mcp_config(api_base_url: str, spawner_id: str | None = None) -> dict:
     """Build the Claude Code MCP server config for the canvas tools.
 
     Belt-and-suspenders strategy to survive any ``env`` semantics quirk in
@@ -42,21 +42,26 @@ def _build_mcp_config(api_base_url: str) -> dict:
     2. **URL via argv, not env** — ``--api-base <url>`` is passed as an ``args``
        element so ``mcp_server.py`` resolves the API base without depending on
        ``SUPREME_CLAUDEMANDER_API`` at all.
-    3. **Explicit env merge** — PATH / HOME / USER / LANG are re-declared in
+    3. **Spawner ID via argv** — ``--spawner-id <id>`` is passed so the MCP
+       server can attribute terminals to this card and enforce the per-card cap.
+    4. **Explicit env merge** — PATH / HOME / USER / LANG are re-declared in
        ``env`` so that, even if Claude Code replaces (rather than merges with)
        the parent environment, the subprocess still has everything it needs.
        ``SUPREME_CLAUDEMANDER_API`` is also kept for backward compat with older
        MCP servers on disk.
     """
+    args = [
+        CONTAINER_MCP_SERVER,
+        "--api-base",
+        api_base_url,
+    ]
+    if spawner_id:
+        args += ["--spawner-id", spawner_id]
     return {
         "mcpServers": {
             "canvas": {
                 "command": CONTAINER_PYTHON3,
-                "args": [
-                    CONTAINER_MCP_SERVER,
-                    "--api-base",
-                    api_base_url,
-                ],
+                "args": args,
                 "env": {
                     "PATH": "/usr/local/bin:/usr/bin:/bin",
                     "HOME": "/home/util",
@@ -133,14 +138,6 @@ class CanvasClaudeCard(TerminalCard):
         if profile:
             _validate_name(profile, "profile")
 
-        # Build the MCP config JSON. Written into settings.json by
-        # _seed_claude_settings() so Claude loads it automatically on start.
-        mcp_config = _build_mcp_config(api_base_url)
-        mcp_json = _json.dumps(mcp_config)
-        self._mcp_config = mcp_config
-        self._mcp_json = mcp_json
-        self._mcp_sha256 = _hashlib.sha256(mcp_json.encode()).hexdigest()
-
         # Build the inner claude command (without docker/tmux wrapping).
         # The actual PTY command is determined at start() time by
         # _ensure_tmux_session(), which decides between attach vs new-session.
@@ -173,6 +170,16 @@ class CanvasClaudeCard(TerminalCard):
         self.api_base_url = api_base_url
         self.profile = profile
         self.canvas_name = canvas_name
+
+        # Build the MCP config JSON after super().__init__ so self.id is
+        # available (BaseCard generates a uuid if card_id was None).
+        # The spawner_id wires the per-card terminal cap through to the MCP
+        # subprocess via --spawner-id on the mcp_server.py command line.
+        mcp_config = _build_mcp_config(api_base_url, spawner_id=self.id)
+        mcp_json = _json.dumps(mcp_config)
+        self._mcp_config = mcp_config
+        self._mcp_json = mcp_json
+        self._mcp_sha256 = _hashlib.sha256(mcp_json.encode()).hexdigest()
 
     # ── Descriptor serialization ───────────────────────────────────────
 

--- a/claude_rts/mcp_server.py
+++ b/claude_rts/mcp_server.py
@@ -36,7 +36,27 @@ def _resolve_api_base(argv: list[str] | None = None) -> str:
     return os.environ.get("SUPREME_CLAUDEMANDER_API", _DEFAULT_API_BASE)
 
 
+def _resolve_spawner_id(argv: list[str] | None = None) -> str | None:
+    """Resolve the spawner card ID from argv.
+
+    Looks for ``--spawner-id <id>`` or ``--spawner-id=<id>`` on the command
+    line.  Returns None if not provided — callers omit the query param when
+    no spawner is set (user-spawned terminals have no cap).
+    """
+    args = sys.argv[1:] if argv is None else argv
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--spawner-id" and i + 1 < len(args):
+            return args[i + 1]
+        if a.startswith("--spawner-id="):
+            return a.split("=", 1)[1]
+        i += 1
+    return None
+
+
 API_BASE = _resolve_api_base()
+SPAWNER_ID = _resolve_spawner_id()
 
 
 def read_message():
@@ -83,8 +103,79 @@ def tool_open_terminal(args):
     for key in ("hub", "container", "x", "y", "w", "h"):
         if key in args and args[key] is not None:
             params += f"&{key}={urllib.parse.quote(str(args[key]))}"
-    result = http_request("POST", f"/api/claude/terminal/create?{params}")
+    if SPAWNER_ID:
+        params += f"&spawner_id={urllib.parse.quote(SPAWNER_ID)}"
+    try:
+        result = http_request("POST", f"/api/claude/terminal/create?{params}")
+    except RuntimeError as e:
+        err_str = str(e)
+        if "429" in err_str:
+            # Try to parse structured error body
+            try:
+                body_start = err_str.find("{")
+                if body_start != -1:
+                    err_body = json.loads(err_str[body_start:])
+                    live = err_body.get("live_session_ids", [])
+                    return (
+                        f"Error: Terminal cap reached. You have {len(live)} live terminal(s) "
+                        f"from this Canvas Claude card (cap: 10). "
+                        f"Close some terminals first. Live session IDs: {live}"
+                    )
+            except Exception:  # noqa: BLE001
+                pass
+        raise
     return f"Terminal created. session_id: {result.get('session_id')}"
+
+
+def tool_run_task(args):
+    """Run a short-running command in an ephemeral PTY (no visible card)."""
+    cmd = args.get("cmd", "")
+    if not cmd:
+        raise ValueError("cmd is required")
+    timeout = args.get("timeout", 60)
+    try:
+        timeout = int(timeout)
+    except (TypeError, ValueError):
+        raise ValueError("timeout must be an integer")
+    params = f"cmd={urllib.parse.quote(cmd)}&ephemeral=true&timeout={timeout}"
+    for key in ("hub", "container"):
+        if key in args and args[key] is not None:
+            params += f"&{key}={urllib.parse.quote(str(args[key]))}"
+    if SPAWNER_ID:
+        params += f"&spawner_id={urllib.parse.quote(SPAWNER_ID)}"
+    try:
+        result = http_request("POST", f"/api/claude/terminal/create?{params}")
+    except RuntimeError as e:
+        err_str = str(e)
+        if "400" in err_str:
+            try:
+                body_start = err_str.find("{")
+                if body_start != -1:
+                    err_body = json.loads(err_str[body_start:])
+                    if err_body.get("error") == "ephemeral_timeout_too_long":
+                        max_allowed = err_body.get("max_allowed", 120)
+                        return (
+                            f"Error: {err_body.get('message', 'Timeout too long')} "
+                            f"(max_allowed={max_allowed}). "
+                            f"Use open_terminal for commands that need longer than {max_allowed}s."
+                        )
+            except Exception:  # noqa: BLE001
+                pass
+        if "429" in err_str:
+            try:
+                body_start = err_str.find("{")
+                if body_start != -1:
+                    err_body = json.loads(err_str[body_start:])
+                    live = err_body.get("live_session_ids", [])
+                    return (
+                        f"Error: Terminal cap reached. You have {len(live)} live terminal(s) "
+                        f"from this Canvas Claude card (cap: 10). "
+                        f"Close some terminals first. Live session IDs: {live}"
+                    )
+            except Exception:  # noqa: BLE001
+                pass
+        raise
+    return f"Ephemeral task started. session_id: {result.get('session_id')} (timeout: {timeout}s)"
 
 
 def tool_read_terminal(args):
@@ -362,6 +453,7 @@ def tool_blueprint_spawn(args):
 
 TOOL_HANDLERS = {
     "open_terminal": tool_open_terminal,
+    "run_task": tool_run_task,
     "read_terminal": tool_read_terminal,
     "write_terminal": tool_write_terminal,
     "list_terminals": tool_list_terminals,
@@ -469,6 +561,57 @@ TOOL_SCHEMAS = [
                         "h=1200 for a very tall card. Combine with w for a 'big' terminal: "
                         "w=1200, h=800 gives a large card. w=1800, h=1400 fills most of "
                         "the canvas."
+                    ),
+                },
+            },
+            "required": ["cmd"],
+        },
+    },
+    {
+        "name": "run_task",
+        "description": (
+            "Run a short-running command in an ephemeral PTY (no visible card). "
+            "Default timeout 60s. Max timeout 120s — longer operations should use "
+            "`open_terminal` instead. Use for: ls, git pull, probes, one-shot checks. "
+            "The session is automatically destroyed when the command exits (PTY EOF) or "
+            "the timeout elapses, whichever comes first. Returns a session_id that can "
+            "be used with read_terminal / write_terminal / delete_terminal during the "
+            "session's lifetime. A per-Canvas-Claude cap of 10 live terminals applies "
+            "across both run_task and open_terminal — the 11th spawn returns an error "
+            "listing the live session IDs so you can close some first."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "cmd": {
+                    "type": "string",
+                    "description": (
+                        "Command to run in the ephemeral terminal. When 'container' is "
+                        "also set, runs inside that Docker container via docker exec. "
+                        "Examples: 'ls -la', 'git pull', 'pytest tests/ -q'."
+                    ),
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": (
+                        "Seconds before the ephemeral session is force-destroyed. "
+                        "Default: 60. Max: 120. Values > 120 are rejected — use "
+                        "open_terminal for commands that need longer than 120s."
+                    ),
+                },
+                "container": {
+                    "type": "string",
+                    "description": (
+                        "Exact Docker container name to run the command in (optional). "
+                        "When set, cmd runs inside this container via docker exec. "
+                        "Use vm_discover_containers to find available container names."
+                    ),
+                },
+                "hub": {
+                    "type": "string",
+                    "description": (
+                        "Hub name for devcontainer-based sessions (optional). "
+                        "Usually not needed when using 'container' directly."
                     ),
                 },
             },

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -904,13 +904,26 @@ async def claude_terminal_create(request: web.Request) -> web.Response:
     ephemeral = request.query.get("ephemeral", "false").lower() in ("true", "1", "yes")
     spawner_id = request.query.get("spawner_id", "").strip() or None
 
-    # Validate timeout (only meaningful for ephemerals, but parse early for
-    # structured error response even when ephemeral=false).
+    # Validate timeout.  Explicitly passing timeout without ephemeral=true is an
+    # error — the parameter has no effect on non-ephemeral terminals and silently
+    # accepting it would confuse callers.
     timeout_raw = request.query.get("timeout", "60")
     try:
         timeout = int(timeout_raw)
     except ValueError:
         raise web.HTTPBadRequest(text="'timeout' must be an integer")
+
+    if "timeout" in request.query and not ephemeral:
+        return web.json_response(
+            {
+                "error": "timeout_requires_ephemeral",
+                "message": (
+                    "timeout is only meaningful with ephemeral=true. "
+                    "Use run_task (ephemeral) for timed ops, or open_terminal without timeout for visible terminals."
+                ),
+            },
+            status=400,
+        )
 
     if ephemeral:
         if timeout < 1:
@@ -959,44 +972,93 @@ async def claude_terminal_create(request: web.Request) -> web.Response:
     mgr: SessionManager = request.app["session_manager"]
     card_registry: CardRegistry = request.app["card_registry"]
     canvas_claude_spawns: dict[str, set[str]] = request.app["canvas_claude_spawns"]
+    canvas_claude_spawn_locks: dict[str, asyncio.Lock] = request.app["canvas_claude_spawn_locks"]
 
-    # Cap enforcement: when spawner_id is set, refuse if 10 live sessions already
+    # Cap enforcement: when spawner_id is set, refuse if 10 live sessions already.
+    # Acquire a per-spawner lock so the check+add is atomic across concurrent requests.
     if spawner_id is not None:
-        live_ids = canvas_claude_spawns.get(spawner_id, set())
-        # Prune any session ids that are no longer alive
-        live_ids = {sid for sid in live_ids if mgr.get_session(sid) is not None}
-        canvas_claude_spawns[spawner_id] = live_ids
-        if len(live_ids) >= 10:
-            return web.json_response(
-                {
-                    "error": "terminal_cap_reached",
-                    "message": (
-                        "Canvas Claude has reached the 10 live terminal cap. Close one before spawning another."
-                    ),
-                    "live_session_ids": sorted(live_ids),
-                },
-                status=429,
-            )
+        spawner_lock = canvas_claude_spawn_locks.setdefault(spawner_id, asyncio.Lock())
+        async with spawner_lock:
+            live_ids = canvas_claude_spawns.get(spawner_id, set())
+            # Prune any session ids that are no longer alive
+            live_ids = {sid for sid in live_ids if mgr.get_session(sid) is not None}
+            canvas_claude_spawns[spawner_id] = live_ids
+            if len(live_ids) >= 10:
+                return web.json_response(
+                    {
+                        "error": "terminal_cap_reached",
+                        "message": (
+                            "Canvas Claude has reached the 10 live terminal cap. Close one before spawning another."
+                        ),
+                        "live_session_ids": sorted(live_ids),
+                    },
+                    status=429,
+                )
 
-    if ephemeral:
-        # Create PTY session directly without a TerminalCard or CardRegistry entry.
-        try:
-            session = mgr.create_session(
-                cmd,
+            # --- Spawn inside the lock so the new session_id is added before release ---
+            if ephemeral:
+                try:
+                    session = mgr.create_session(
+                        cmd,
+                        hub=hub or None,
+                        container=container or None,
+                        dimensions=(rows, cols),
+                        kind="probe",
+                    )
+                except Exception:
+                    logger.exception("claude_terminal_create (ephemeral): failed for cmd={!r}", cmd)
+                    return web.json_response({"error": "Failed to spawn terminal"}, status=500)
+
+                session_id = session.session_id
+                canvas_claude_spawns.setdefault(spawner_id, set()).add(session_id)
+            else:
+                card = TerminalCard(
+                    session_manager=mgr,
+                    cmd=cmd,
+                    hub=hub or None,
+                    container=container or None,
+                    layout=layout,
+                )
+                try:
+                    await card.start()
+                    card_registry.register(card)
+                except Exception:
+                    logger.exception("claude_terminal_create: failed for cmd={!r}", cmd)
+                    return web.json_response({"error": "Failed to spawn terminal"}, status=500)
+                canvas_claude_spawns.setdefault(spawner_id, set()).add(card.session_id)
+        # Lock released — fall through to common post-spawn logic below.
+    else:
+        # No spawner_id: no cap enforcement, no lock needed.
+        if ephemeral:
+            try:
+                session = mgr.create_session(
+                    cmd,
+                    hub=hub or None,
+                    container=container or None,
+                    dimensions=(rows, cols),
+                    kind="probe",
+                )
+            except Exception:
+                logger.exception("claude_terminal_create (ephemeral): failed for cmd={!r}", cmd)
+                return web.json_response({"error": "Failed to spawn terminal"}, status=500)
+        else:
+            card = TerminalCard(
+                session_manager=mgr,
+                cmd=cmd,
                 hub=hub or None,
                 container=container or None,
-                dimensions=(rows, cols),
-                kind="probe",
+                layout=layout,
             )
-        except Exception:
-            logger.exception("claude_terminal_create (ephemeral): failed for cmd={!r}", cmd)
-            return web.json_response({"error": "Failed to spawn terminal"}, status=500)
+            try:
+                await card.start()
+                card_registry.register(card)
+            except Exception:
+                logger.exception("claude_terminal_create: failed for cmd={!r}", cmd)
+                return web.json_response({"error": "Failed to spawn terminal"}, status=500)
 
-        session_id = session.session_id
-
-        # Track spawner
-        if spawner_id is not None:
-            canvas_claude_spawns.setdefault(spawner_id, set()).add(session_id)
+    # --- Common post-spawn logic ---
+    if ephemeral:
+        session_id = session.session_id  # type: ignore[possibly-undefined]
 
         # Schedule timeout watcher
         timer_task = asyncio.create_task(
@@ -1020,20 +1082,8 @@ async def claude_terminal_create(request: web.Request) -> web.Response:
             }
         )
 
-    # --- Non-ephemeral path (original behaviour) ---
-    card = TerminalCard(
-        session_manager=mgr,
-        cmd=cmd,
-        hub=hub or None,
-        container=container or None,
-        layout=layout,
-    )
-    try:
-        await card.start()
-        card_registry.register(card)
-    except Exception:
-        logger.exception("claude_terminal_create: failed for cmd={!r}", cmd)
-        return web.json_response({"error": "Failed to spawn terminal"}, status=500)
+    # --- Non-ephemeral response ---
+    card = card  # type: ignore[possibly-undefined]
 
     # Resize if non-default dimensions requested
     if cols != 80 or rows != 24:
@@ -1041,10 +1091,6 @@ async def claude_terminal_create(request: web.Request) -> web.Response:
             card.session.pty.setwinsize(rows, cols)
         except Exception:
             pass
-
-    # Track spawner
-    if spawner_id is not None:
-        canvas_claude_spawns.setdefault(spawner_id, set()).add(card.session_id)
 
     desc = card.to_descriptor()
 
@@ -1598,6 +1644,8 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
     app["control_ws_clients"] = []
     # Per-spawner live session tracking for Canvas Claude terminal cap
     app["canvas_claude_spawns"]: dict[str, set[str]] = {}
+    # Per-spawner asyncio.Lock to make the cap-check+add atomic
+    app["canvas_claude_spawn_locks"]: dict[str, asyncio.Lock] = {}
     # Pending ephemeral timeout tasks keyed by session_id
     app["ephemeral_timers"]: dict[str, asyncio.Task] = {}
 
@@ -1718,6 +1766,8 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
                 return
             canvas_claude_spawns: dict[str, set[str]] = app["canvas_claude_spawns"]
             owned = canvas_claude_spawns.pop(spawner_id, set())
+            # Remove the per-spawner lock entry (lock is never re-used after card removal)
+            app["canvas_claude_spawn_locks"].pop(spawner_id, None)
             session_manager: SessionManager = app["session_manager"]
             for sid in list(owned):
                 if session_manager.get_session(sid) is not None:

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -872,13 +872,72 @@ async def probe_claude_usage_handler(request: web.Request) -> web.Response:
 # ── Production Claude terminal control API ─────────────────────────────────
 
 
+async def _ephemeral_timeout_watcher(session_id: str, timeout_seconds: int, mgr: SessionManager) -> None:
+    """Sleep ``timeout_seconds`` then destroy the ephemeral session if still alive."""
+    await asyncio.sleep(timeout_seconds)
+    session = mgr.get_session(session_id)
+    if session is not None and session.alive:
+        logger.info("Ephemeral timeout: destroying session {} after {}s", session_id, timeout_seconds)
+        mgr.destroy_session(session_id)
+
+
 async def claude_terminal_create(request: web.Request) -> web.Response:
-    """POST /api/claude/terminal/create — create a TerminalCard + PTY session."""
+    """POST /api/claude/terminal/create — create a TerminalCard + PTY session.
+
+    New query params (all optional):
+      - ``ephemeral`` — ``"true"`` / ``"false"`` (default false). When true the
+        session is NOT registered in CardRegistry (no visible card, no
+        card:registered broadcast).  read/write/delete_terminal still work via
+        session_id.
+      - ``spawner_id`` — card id of the Canvas Claude card that owns this
+        terminal. When set, the spawn counts toward the per-spawner cap (10).
+      - ``timeout`` — integer seconds (default 60). Only meaningful when
+        ``ephemeral=true``; ignored for regular (non-ephemeral) terminals.
+        Must be in [1, 120].
+    """
     cmd = request.query.get("cmd", "").strip()
     hub = request.query.get("hub", "")
     container = request.query.get("container", "").strip()
     if not cmd:
         raise web.HTTPBadRequest(text="Missing 'cmd' query parameter")
+
+    ephemeral = request.query.get("ephemeral", "false").lower() in ("true", "1", "yes")
+    spawner_id = request.query.get("spawner_id", "").strip() or None
+
+    # Validate timeout (only meaningful for ephemerals, but parse early for
+    # structured error response even when ephemeral=false).
+    timeout_raw = request.query.get("timeout", "60")
+    try:
+        timeout = int(timeout_raw)
+    except ValueError:
+        raise web.HTTPBadRequest(text="'timeout' must be an integer")
+
+    if ephemeral:
+        if timeout < 1:
+            return web.json_response(
+                {
+                    "error": "ephemeral_timeout_too_long",
+                    "message": (
+                        "timeout must be at least 1 second for ephemeral terminals. "
+                        "Use open_terminal for long-running work."
+                    ),
+                    "max_allowed": 120,
+                },
+                status=400,
+            )
+        if timeout > 120:
+            return web.json_response(
+                {
+                    "error": "ephemeral_timeout_too_long",
+                    "message": (
+                        "Timeout > 120s is not permitted for ephemeral terminals — "
+                        "ephemeral terminals are for short-running operations (ls, git pull, probes). "
+                        "Use open_terminal for longer work."
+                    ),
+                    "max_allowed": 120,
+                },
+                status=400,
+            )
 
     try:
         cols = int(request.query.get("cols", 80))
@@ -899,7 +958,69 @@ async def claude_terminal_create(request: web.Request) -> web.Response:
 
     mgr: SessionManager = request.app["session_manager"]
     card_registry: CardRegistry = request.app["card_registry"]
+    canvas_claude_spawns: dict[str, set[str]] = request.app["canvas_claude_spawns"]
 
+    # Cap enforcement: when spawner_id is set, refuse if 10 live sessions already
+    if spawner_id is not None:
+        live_ids = canvas_claude_spawns.get(spawner_id, set())
+        # Prune any session ids that are no longer alive
+        live_ids = {sid for sid in live_ids if mgr.get_session(sid) is not None}
+        canvas_claude_spawns[spawner_id] = live_ids
+        if len(live_ids) >= 10:
+            return web.json_response(
+                {
+                    "error": "terminal_cap_reached",
+                    "message": (
+                        "Canvas Claude has reached the 10 live terminal cap. Close one before spawning another."
+                    ),
+                    "live_session_ids": sorted(live_ids),
+                },
+                status=429,
+            )
+
+    if ephemeral:
+        # Create PTY session directly without a TerminalCard or CardRegistry entry.
+        try:
+            session = mgr.create_session(
+                cmd,
+                hub=hub or None,
+                container=container or None,
+                dimensions=(rows, cols),
+                kind="probe",
+            )
+        except Exception:
+            logger.exception("claude_terminal_create (ephemeral): failed for cmd={!r}", cmd)
+            return web.json_response({"error": "Failed to spawn terminal"}, status=500)
+
+        session_id = session.session_id
+
+        # Track spawner
+        if spawner_id is not None:
+            canvas_claude_spawns.setdefault(spawner_id, set()).add(session_id)
+
+        # Schedule timeout watcher
+        timer_task = asyncio.create_task(
+            _ephemeral_timeout_watcher(session_id, timeout, mgr),
+            name=f"ephemeral-timeout-{session_id}",
+        )
+        request.app["ephemeral_timers"][session_id] = timer_task
+
+        logger.info(
+            "claude_terminal_create: ephemeral session {} created for cmd={!r} (timeout={}s, spawner={})",
+            session_id,
+            cmd,
+            timeout,
+            spawner_id,
+        )
+        return web.json_response(
+            {
+                "session_id": session_id,
+                "ephemeral": True,
+                "cmd": cmd,
+            }
+        )
+
+    # --- Non-ephemeral path (original behaviour) ---
     card = TerminalCard(
         session_manager=mgr,
         cmd=cmd,
@@ -921,6 +1042,10 @@ async def claude_terminal_create(request: web.Request) -> web.Response:
         except Exception:
             pass
 
+    # Track spawner
+    if spawner_id is not None:
+        canvas_claude_spawns.setdefault(spawner_id, set()).add(card.session_id)
+
     desc = card.to_descriptor()
 
     logger.info("claude_terminal_create: created {} for cmd={!r}", card.session_id, cmd)
@@ -928,33 +1053,54 @@ async def claude_terminal_create(request: web.Request) -> web.Response:
 
 
 async def claude_terminal_send(request: web.Request) -> web.Response:
-    """POST /api/claude/terminal/{id}/send — write text to PTY."""
+    """POST /api/claude/terminal/{id}/send — write text to PTY.
+
+    Works for both regular (card-registered) and ephemeral (session-only) terminals.
+    The ``{id}`` path segment is the session_id in both cases.
+    """
     card_id = request.match_info["id"]
     card_registry: CardRegistry = request.app["card_registry"]
+    mgr: SessionManager = request.app["session_manager"]
+
     card = card_registry.get_terminal(card_id)
-    if not card or not card.alive:
-        raise web.HTTPNotFound(text="Terminal not found")
+    if card and card.alive:
+        session = card.session
+    else:
+        # Fallback: check session_manager directly (ephemeral session)
+        session = mgr.get_session(card_id)
+        if not session or not session.alive:
+            raise web.HTTPNotFound(text="Terminal not found")
 
     text = await request.text()
-    card.session.pty.write(text)
+    session.pty.write(text)
     # Touch last_client_time to prevent orphan reaping
-    card.session.last_client_time = time.monotonic()
+    session.last_client_time = time.monotonic()
 
     return web.json_response({"status": "ok", "sent": len(text)})
 
 
 async def claude_terminal_read(request: web.Request) -> web.Response:
-    """GET /api/claude/terminal/{id}/read — return scrollback (optionally ANSI-stripped)."""
+    """GET /api/claude/terminal/{id}/read — return scrollback (optionally ANSI-stripped).
+
+    Works for both regular (card-registered) and ephemeral (session-only) terminals.
+    """
     card_id = request.match_info["id"]
     card_registry: CardRegistry = request.app["card_registry"]
+    mgr: SessionManager = request.app["session_manager"]
+
     card = card_registry.get_terminal(card_id)
-    if not card or not card.alive:
-        raise web.HTTPNotFound(text="Terminal not found")
+    if card and card.alive:
+        session = card.session
+    else:
+        # Fallback: check session_manager directly (ephemeral session)
+        session = mgr.get_session(card_id)
+        if not session or not session.alive:
+            raise web.HTTPNotFound(text="Terminal not found")
 
     # Touch last_client_time to prevent orphan reaping
-    card.session.last_client_time = time.monotonic()
+    session.last_client_time = time.monotonic()
 
-    data = card.session.scrollback.get_all()
+    data = session.scrollback.get_all()
     output = data.decode("utf-8", errors="replace")
 
     do_strip = request.query.get("strip_ansi", "").lower() in ("true", "1", "yes")
@@ -965,7 +1111,7 @@ async def claude_terminal_read(request: web.Request) -> web.Response:
         {
             "output": output,
             "size": len(data),
-            "total_written": card.session.scrollback.total_written,
+            "total_written": session.scrollback.total_written,
         }
     )
 
@@ -996,19 +1142,31 @@ async def claude_terminal_status(request: web.Request) -> web.Response:
 
 
 async def claude_terminal_delete(request: web.Request) -> web.Response:
-    """DELETE /api/claude/terminal/{id} — stop card, clean up."""
+    """DELETE /api/claude/terminal/{id} — stop card, clean up.
+
+    Works for both regular (card-registered) and ephemeral (session-only)
+    terminals.  For ephemerals the on_destroy hook handles spawner-set cleanup
+    and timer cancellation automatically.
+    """
     card_id = request.match_info["id"]
     card_registry: CardRegistry = request.app["card_registry"]
+    mgr: SessionManager = request.app["session_manager"]
 
     card = card_registry.get_terminal(card_id)
-    if not card:
+    if card:
+        # Regular terminal: stop via card lifecycle, then unregister
+        await card.stop()
+        card_registry.unregister(card_id)
+        logger.info("claude_terminal_delete: removed card {}", card_id)
+        return web.json_response({"status": "ok"})
+
+    # Ephemeral (or any) session not in card_registry — look up by session_id
+    session = mgr.get_session(card_id)
+    if not session:
         raise web.HTTPNotFound(text="Terminal not found")
 
-    # Stop card (destroys PTY via SessionManager)
-    await card.stop()
-    card_registry.unregister(card_id)
-
-    logger.info("claude_terminal_delete: removed {}", card_id)
+    mgr.destroy_session(card_id)
+    logger.info("claude_terminal_delete: destroyed ephemeral session {}", card_id)
     return web.json_response({"status": "ok"})
 
 
@@ -1438,6 +1596,10 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
     app["test_mode"] = test_mode
     app["discovered_profiles"] = []
     app["control_ws_clients"] = []
+    # Per-spawner live session tracking for Canvas Claude terminal cap
+    app["canvas_claude_spawns"]: dict[str, set[str]] = {}
+    # Pending ephemeral timeout tasks keyed by session_id
+    app["ephemeral_timers"]: dict[str, asyncio.Task] = {}
 
     # Static + API routes
     app.router.add_get("/", index_handler)
@@ -1532,6 +1694,41 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
 
         event_bus.subscribe("card:registered", _on_card_event)
         event_bus.subscribe("card:unregistered", _on_card_event)
+
+        # Wire SessionManager on_destroy → spawner tracking + timer cancellation
+        def _on_session_destroy(session_id: str, session) -> None:
+            """Prune destroyed session from spawner sets and cancel timeout timer."""
+            canvas_claude_spawns: dict[str, set[str]] = app["canvas_claude_spawns"]
+            for spawner_set in canvas_claude_spawns.values():
+                spawner_set.discard(session_id)
+
+            ephemeral_timers: dict[str, asyncio.Task] = app["ephemeral_timers"]
+            timer = ephemeral_timers.pop(session_id, None)
+            if timer is not None and not timer.done():
+                timer.cancel()
+
+        mgr.add_on_destroy(_on_session_destroy)
+
+        # On CanvasClaudeCard unregister: destroy all sessions owned by that spawner
+        async def _on_canvas_claude_unregistered(event_type: str, payload: dict) -> None:
+            if payload.get("card_type") != "canvas-claude":
+                return
+            spawner_id = payload.get("card_id")
+            if not spawner_id:
+                return
+            canvas_claude_spawns: dict[str, set[str]] = app["canvas_claude_spawns"]
+            owned = canvas_claude_spawns.pop(spawner_id, set())
+            session_manager: SessionManager = app["session_manager"]
+            for sid in list(owned):
+                if session_manager.get_session(sid) is not None:
+                    logger.info(
+                        "canvas-claude unregistered: destroying session {} (spawner={})",
+                        sid,
+                        spawner_id,
+                    )
+                    session_manager.destroy_session(sid)
+
+        event_bus.subscribe("card:unregistered", _on_canvas_claude_unregistered)
 
         # Wire blueprint events → /ws/control broadcast
         async def _on_blueprint_event(event_type: str, payload: dict) -> None:

--- a/claude_rts/sessions.py
+++ b/claude_rts/sessions.py
@@ -10,6 +10,7 @@ import asyncio
 import re
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -114,6 +115,16 @@ class SessionManager:
         self.tmux_enabled = tmux_enabled
         self._reaper_task: Optional[asyncio.Task] = None
         self._tmux_cache: dict[str, bool] = {}
+        self._on_destroy_callbacks: list[Callable[[str, "Session"], None]] = []
+
+    def add_on_destroy(self, cb: Callable[[str, "Session"], None]) -> None:
+        """Register a callback to be called synchronously on session destroy.
+
+        The callback signature is ``cb(session_id: str, session: Session) -> None``.
+        Exceptions raised by the callback are caught and logged individually so
+        one bad callback does not prevent teardown from completing.
+        """
+        self._on_destroy_callbacks.append(cb)
 
     def create_session(
         self,
@@ -197,10 +208,23 @@ class SessionManager:
 
         If kill_tmux is True and the session has a container, also kill the
         tmux session inside the container so it doesn't persist.
+
+        All registered on_destroy callbacks are called synchronously before
+        the PTY is terminated.  Exceptions from individual callbacks are caught
+        and logged so one bad callback does not prevent teardown.
         """
         session = self._sessions.pop(session_id, None)
         if not session:
             return
+
+        # Invoke on_destroy callbacks before actual teardown so callbacks can
+        # still inspect session state if needed.
+        for cb in self._on_destroy_callbacks:
+            try:
+                cb(session_id, session)
+            except Exception:
+                logger.exception("on_destroy callback raised for session {}", session_id)
+
         session.alive = False
         if session.read_task:
             session.read_task.cancel()

--- a/claude_rts/sessions.py
+++ b/claude_rts/sessions.py
@@ -315,6 +315,10 @@ class SessionManager:
         finally:
             session.alive = False
             logger.info("Session {}: read loop ended", session.session_id)
+            # Trigger on_destroy callbacks (prune spawner cap, cancel timeout timer).
+            # destroy_session is idempotent: _sessions.pop(..., None) handles the case
+            # where an explicit DELETE or timeout watcher already removed the session.
+            self.destroy_session(session.session_id)
 
     def start_orphan_reaper(self) -> None:
         """Start background task to clean up orphaned sessions."""

--- a/tests/test_canvas_claude_card.py
+++ b/tests/test_canvas_claude_card.py
@@ -446,3 +446,36 @@ async def test_canvas_claude_card_new_session_kills_tmux(monkeypatch):
     assert len(kill_calls) >= 1
     await card.stop()
     mgr.stop_all()
+
+
+# ── Spawner ID injection tests (#193) ─────────────────────────────────────────
+
+
+def test_build_mcp_config_includes_spawner_id():
+    """_build_mcp_config appends --spawner-id <id> to the args list when provided."""
+    cfg = _build_mcp_config("http://host.docker.internal:3000", spawner_id="card-abc-123")
+    args = cfg["mcpServers"]["canvas"]["args"]
+    assert "--spawner-id" in args
+    idx = args.index("--spawner-id")
+    assert args[idx + 1] == "card-abc-123"
+
+
+def test_build_mcp_config_no_spawner_id_omits_flag():
+    """_build_mcp_config does NOT include --spawner-id when spawner_id is None."""
+    cfg = _build_mcp_config("http://host.docker.internal:3000", spawner_id=None)
+    args = cfg["mcpServers"]["canvas"]["args"]
+    assert "--spawner-id" not in args
+
+
+def test_canvas_claude_card_mcp_args_include_spawner_id(monkeypatch):
+    """CanvasClaudeCard injects --spawner-id <card.id> into MCP subprocess args."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+    card = CanvasClaudeCard(session_manager=mgr, container="my-container")
+
+    mcp_args = card._mcp_config["mcpServers"]["canvas"]["args"]
+    assert "--spawner-id" in mcp_args
+    idx = mcp_args.index("--spawner-id")
+    # The value must match the card's own id
+    assert mcp_args[idx + 1] == card.id
+    mgr.stop_all()

--- a/tests/test_claude_api.py
+++ b/tests/test_claude_api.py
@@ -681,8 +681,8 @@ async def test_ephemeral_timeout_expiry_destroys_session(aiohttp_client, app_fac
     # Session exists immediately after creation
     assert mgr.get_session(session_id) is not None
 
-    # Wait for the timeout watcher to fire (1s + 0.5s margin)
-    await asyncio.sleep(1.5)
+    # Wait for the timeout watcher to fire (1s + 1.0s margin to reduce CI flake)
+    await asyncio.sleep(2.0)
 
     # Session should now be gone
     assert mgr.get_session(session_id) is None
@@ -803,3 +803,76 @@ async def test_card_unregister_clears_spawner_set(aiohttp_client, app_factory):
     # Both sessions should be destroyed
     for sid in sids:
         assert mgr.get_session(sid) is None
+
+
+async def test_pty_eof_decrements_cap(aiohttp_client, app_factory):
+    """PTY EOF triggers destroy_session which prunes the spawner cap set."""
+    client = await aiohttp_client(app_factory())
+    spawner = "sp-eof-test"
+    resp = await client.post(f"/api/claude/terminal/create?cmd=sleep+999&ephemeral=true&spawner_id={spawner}")
+    assert resp.status == 200
+    sid = (await resp.json())["session_id"]
+
+    mgr = client.app["session_manager"]
+    canvas_claude_spawns = client.app["canvas_claude_spawns"]
+
+    # Session is tracked in the spawner set
+    assert sid in canvas_claude_spawns.get(spawner, set())
+
+    # Simulate PTY EOF by calling destroy_session directly — this exercises
+    # the on_destroy callback chain the same way _pty_read_loop's finally block does.
+    mgr.destroy_session(sid)
+
+    # Give the event loop a tick to run any async callbacks
+    await asyncio.sleep(0)
+
+    # Spawner set should be pruned
+    assert sid not in canvas_claude_spawns.get(spawner, set())
+
+
+async def test_timer_cancelled_on_explicit_delete(aiohttp_client, app_factory):
+    """DELETE /api/claude/terminal/{id} cancels the pending ephemeral timeout task."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=sleep+999&ephemeral=true&timeout=60")
+    assert resp.status == 200
+    sid = (await resp.json())["session_id"]
+
+    ephemeral_timers = client.app["ephemeral_timers"]
+    assert sid in ephemeral_timers
+    timer = ephemeral_timers[sid]
+    assert not timer.done()
+
+    # Explicit delete
+    resp = await client.delete(f"/api/claude/terminal/{sid}")
+    assert resp.status == 200
+
+    # Timer should be cancelled and removed
+    assert sid not in ephemeral_timers
+    assert timer.cancelled()
+
+
+async def test_timeout_without_ephemeral_rejected(aiohttp_client, app_factory):
+    """POST with timeout but no ephemeral=true returns HTTP 400 timeout_requires_ephemeral."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=bash&timeout=30")
+    assert resp.status == 400
+    data = await resp.json()
+    assert data["error"] == "timeout_requires_ephemeral"
+
+
+async def test_cap_decrements_on_timeout(aiohttp_client, app_factory):
+    """Ephemeral timeout expiry prunes the spawner set (not just session)."""
+    client = await aiohttp_client(app_factory())
+    spawner = "sp-timeout-cap"
+    resp = await client.post(f"/api/claude/terminal/create?cmd=sleep+999&ephemeral=true&timeout=1&spawner_id={spawner}")
+    assert resp.status == 200
+    sid = (await resp.json())["session_id"]
+
+    canvas_claude_spawns = client.app["canvas_claude_spawns"]
+    assert sid in canvas_claude_spawns.get(spawner, set())
+
+    # Wait for the timeout watcher to fire (1s + 1.0s margin)
+    await asyncio.sleep(2.0)
+
+    # Spawner set should be pruned after timeout-triggered destroy
+    assert sid not in canvas_claude_spawns.get(spawner, set())

--- a/tests/test_claude_api.py
+++ b/tests/test_claude_api.py
@@ -1,5 +1,6 @@
 """Tests for the production Claude terminal control API endpoints."""
 
+import asyncio
 import time
 
 import pytest
@@ -625,3 +626,180 @@ async def test_ws_control_receives_card_updated_on_rename(aiohttp_client, app_fa
         assert msg["type"] == "card_updated"
         assert msg["card_id"] == sid
         assert msg["display_name"] == "Renamed"
+
+
+# ── Ephemeral session tests (#193) ────────────────────────────────────────────
+
+
+async def test_create_ephemeral_session_skips_card_registry(aiohttp_client, app_factory):
+    """POST ?ephemeral=true creates a PTY session but skips CardRegistry."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=echo+hi&ephemeral=true&spawner_id=sp1")
+    assert resp.status == 200
+    data = await resp.json()
+    session_id = data["session_id"]
+    assert session_id
+
+    # Session must exist in session_manager
+    mgr = client.app["session_manager"]
+    assert mgr.get_session(session_id) is not None
+
+    # Must NOT be registered in CardRegistry
+    card_reg = client.app["card_registry"]
+    assert card_reg.get(session_id) is None
+
+
+async def test_ephemeral_timeout_too_long(aiohttp_client, app_factory):
+    """POST with ephemeral=true&timeout=121 returns HTTP 400 with ephemeral_timeout_too_long."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=sleep+200&ephemeral=true&timeout=121")
+    assert resp.status == 400
+    data = await resp.json()
+    assert data["error"] == "ephemeral_timeout_too_long"
+    assert data["max_allowed"] == 120
+
+
+async def test_ephemeral_timeout_too_short(aiohttp_client, app_factory):
+    """POST with ephemeral=true&timeout=0 returns HTTP 400 with ephemeral_timeout_too_long."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=echo+hi&ephemeral=true&timeout=0")
+    assert resp.status == 400
+    data = await resp.json()
+    assert data["error"] == "ephemeral_timeout_too_long"
+    assert data["max_allowed"] == 120
+
+
+async def test_ephemeral_timeout_expiry_destroys_session(aiohttp_client, app_factory):
+    """Ephemeral session with timeout=1 is auto-destroyed after ~1 second."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=sleep+999&ephemeral=true&timeout=1")
+    assert resp.status == 200
+    data = await resp.json()
+    session_id = data["session_id"]
+
+    mgr = client.app["session_manager"]
+    # Session exists immediately after creation
+    assert mgr.get_session(session_id) is not None
+
+    # Wait for the timeout watcher to fire (1s + 0.5s margin)
+    await asyncio.sleep(1.5)
+
+    # Session should now be gone
+    assert mgr.get_session(session_id) is None
+
+
+async def test_spawner_cap_enforced_at_11th(aiohttp_client, app_factory):
+    """The 11th spawn with the same spawner_id returns HTTP 429 terminal_cap_reached."""
+    client = await aiohttp_client(app_factory())
+    live_ids = []
+    for _ in range(10):
+        resp = await client.post("/api/claude/terminal/create?cmd=bash&spawner_id=capX")
+        assert resp.status == 200
+        data = await resp.json()
+        live_ids.append(data["session_id"])
+
+    # 11th spawn should be rejected
+    resp = await client.post("/api/claude/terminal/create?cmd=bash&spawner_id=capX")
+    assert resp.status == 429
+    data = await resp.json()
+    assert data["error"] == "terminal_cap_reached"
+    assert len(data["live_session_ids"]) == 10
+
+
+async def test_cap_decrements_on_delete(aiohttp_client, app_factory):
+    """Deleting a spawner-tracked terminal frees a slot so the 11th succeeds."""
+    client = await aiohttp_client(app_factory())
+    sids = []
+    for _ in range(10):
+        resp = await client.post("/api/claude/terminal/create?cmd=bash&spawner_id=capY")
+        assert resp.status == 200
+        sids.append((await resp.json())["session_id"])
+
+    # Delete one
+    resp = await client.delete(f"/api/claude/terminal/{sids[0]}")
+    assert resp.status == 200
+
+    # Now the 11th spawn should succeed
+    resp = await client.post("/api/claude/terminal/create?cmd=bash&spawner_id=capY")
+    assert resp.status == 200
+
+
+async def test_cap_counts_open_terminal_too(aiohttp_client, app_factory):
+    """The cap applies across ephemeral and non-ephemeral spawns for the same spawner."""
+    client = await aiohttp_client(app_factory())
+    # 5 regular + 5 ephemeral = 10 total
+    for _ in range(5):
+        resp = await client.post("/api/claude/terminal/create?cmd=bash&spawner_id=capZ")
+        assert resp.status == 200
+    for _ in range(5):
+        resp = await client.post("/api/claude/terminal/create?cmd=bash&ephemeral=true&spawner_id=capZ")
+        assert resp.status == 200
+
+    # 11th (either kind) should be rejected
+    resp = await client.post("/api/claude/terminal/create?cmd=bash&spawner_id=capZ")
+    assert resp.status == 429
+    data = await resp.json()
+    assert data["error"] == "terminal_cap_reached"
+
+
+async def test_user_spawned_no_spawner_id_uncapped(aiohttp_client, app_factory):
+    """Spawns without spawner_id are not capped (user-facing terminals)."""
+    client = await aiohttp_client(app_factory())
+    # Spawn 12 terminals without spawner_id — all should succeed
+    for _ in range(12):
+        resp = await client.post("/api/claude/terminal/create?cmd=bash")
+        assert resp.status == 200
+
+
+async def test_delete_works_on_ephemeral_session(aiohttp_client, app_factory):
+    """DELETE /api/claude/terminal/{id} works on ephemeral sessions (no card in registry)."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=sleep+999&ephemeral=true")
+    assert resp.status == 200
+    data = await resp.json()
+    session_id = data["session_id"]
+
+    # Verify session exists, no card
+    mgr = client.app["session_manager"]
+    card_reg = client.app["card_registry"]
+    assert mgr.get_session(session_id) is not None
+    assert card_reg.get(session_id) is None
+
+    # Delete should succeed
+    resp = await client.delete(f"/api/claude/terminal/{session_id}")
+    assert resp.status == 200
+
+    # Session should be gone
+    assert mgr.get_session(session_id) is None
+
+
+async def test_card_unregister_clears_spawner_set(aiohttp_client, app_factory):
+    """Emitting card:unregistered for a canvas-claude card destroys its owned sessions."""
+    client = await aiohttp_client(app_factory())
+    spawner = "sp-canvas-2"
+
+    # Spawn 2 ephemeral sessions under this spawner
+    sids = []
+    for _ in range(2):
+        resp = await client.post(f"/api/claude/terminal/create?cmd=sleep+999&ephemeral=true&spawner_id={spawner}")
+        assert resp.status == 200
+        sids.append((await resp.json())["session_id"])
+
+    mgr = client.app["session_manager"]
+    canvas_claude_spawns = client.app["canvas_claude_spawns"]
+    assert spawner in canvas_claude_spawns
+    assert len(canvas_claude_spawns[spawner]) == 2
+
+    # Emit card:unregistered for this spawner as a canvas-claude card
+    event_bus = client.app["event_bus"]
+    await event_bus.emit("card:unregistered", {"card_id": spawner, "card_type": "canvas-claude"})
+
+    # Allow the async callback to run
+    await asyncio.sleep(0.1)
+
+    # Spawner set should be removed
+    assert spawner not in canvas_claude_spawns
+
+    # Both sessions should be destroyed
+    for sid in sids:
+        assert mgr.get_session(sid) is None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -11,11 +11,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from claude_rts.mcp_server import (
     _DEFAULT_API_BASE,
     _resolve_api_base,
+    _resolve_spawner_id,
     handle_request,
     tool_delete_terminal,
     tool_list_terminals,
     tool_open_terminal,
     tool_read_terminal,
+    tool_run_task,
     tool_write_terminal,
     tool_rename_terminal,
     tool_set_recovery_script,
@@ -188,6 +190,7 @@ def test_handle_request_tools_list():
     names = {t["name"] for t in tools}
     assert names == {
         "open_terminal",
+        "run_task",
         "read_terminal",
         "write_terminal",
         "list_terminals",
@@ -416,7 +419,8 @@ def test_tools_list_includes_vm_and_blueprint_tools():
     assert "rename_terminal" in names
     assert "set_recovery_script" in names
     assert "get_recovery_script" in names
-    assert len(names) == 21
+    assert "run_task" in names
+    assert len(names) == 22
 
 
 # ── vm_get_container_actions ──────────────────────────────────────────────
@@ -818,3 +822,130 @@ def test_handle_request_tools_call_rename():
     assert resp["id"] == 99
     assert resp["result"]["isError"] is False
     assert "Test" in resp["result"]["content"][0]["text"]
+
+
+# ── _resolve_spawner_id tests (#193) ─────────────────────────────────────────
+
+
+def test_resolve_spawner_id_space_separated():
+    """--spawner-id <id> is parsed correctly."""
+    result = _resolve_spawner_id(["--spawner-id", "my-card-abc"])
+    assert result == "my-card-abc"
+
+
+def test_resolve_spawner_id_equals_form():
+    """--spawner-id=<id> is also recognised."""
+    result = _resolve_spawner_id(["--spawner-id=my-card-def"])
+    assert result == "my-card-def"
+
+
+def test_resolve_spawner_id_not_present():
+    """Without --spawner-id, returns None."""
+    result = _resolve_spawner_id(["--api-base", "http://x:3000"])
+    assert result is None
+
+
+def test_resolve_spawner_id_with_other_flags():
+    """--spawner-id parsed correctly when mixed with other flags."""
+    result = _resolve_spawner_id(["--api-base", "http://x:3000", "--spawner-id", "card-xyz", "--foo"])
+    assert result == "card-xyz"
+
+
+# ── tool_run_task tests (#193) ────────────────────────────────────────────────
+
+
+def test_tool_run_task_forwards_params():
+    """tool_run_task POSTs with ephemeral=true and correct timeout."""
+    mock_resp = make_mock_response({"session_id": "rts-ephemeral-1", "ephemeral": True})
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+        result = tool_run_task({"cmd": "ls -la", "timeout": 30})
+    assert "rts-ephemeral-1" in result
+    call_args = mock_open.call_args
+    req = call_args[0][0]
+    assert "ephemeral=true" in req.full_url
+    assert "timeout=30" in req.full_url
+    assert "cmd=ls" in req.full_url or "cmd=" in req.full_url
+    assert req.method == "POST"
+
+
+def test_tool_run_task_default_timeout():
+    """tool_run_task uses timeout=60 by default."""
+    mock_resp = make_mock_response({"session_id": "rts-ephemeral-2", "ephemeral": True})
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+        result = tool_run_task({"cmd": "echo hi"})
+    assert "rts-ephemeral-2" in result
+    req = mock_open.call_args[0][0]
+    assert "timeout=60" in req.full_url
+
+
+def test_tool_run_task_includes_spawner_id_when_set(monkeypatch):
+    """tool_run_task appends spawner_id query param when SPAWNER_ID is set."""
+    import claude_rts.mcp_server as mcp_mod
+
+    original = mcp_mod.SPAWNER_ID
+    try:
+        mcp_mod.SPAWNER_ID = "spawner-card-999"
+        mock_resp = make_mock_response({"session_id": "rts-eph-3", "ephemeral": True})
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+            tool_run_task({"cmd": "pwd"})
+        req = mock_open.call_args[0][0]
+        assert "spawner_id=spawner-card-999" in req.full_url
+    finally:
+        mcp_mod.SPAWNER_ID = original
+
+
+def test_tool_run_task_surfaces_timeout_error():
+    """tool_run_task returns clear error message on HTTP 400 ephemeral_timeout_too_long."""
+    import urllib.error
+
+    err_body = json.dumps(
+        {
+            "error": "ephemeral_timeout_too_long",
+            "message": "Timeout > 120s is not permitted for ephemeral terminals",
+            "max_allowed": 120,
+        }
+    ).encode()
+    http_err = urllib.error.HTTPError("http://test/api/claude/terminal/create", 400, "Bad Request", {}, None)
+    http_err.read = lambda: err_body
+
+    with patch("urllib.request.urlopen", side_effect=http_err):
+        result = tool_run_task({"cmd": "sleep 200", "timeout": 200})
+
+    assert "Error" in result
+    assert "120" in result
+    assert "open_terminal" in result or "timeout" in result.lower()
+
+
+def test_tool_run_task_surfaces_cap_error():
+    """tool_run_task returns error message with live_session_ids on HTTP 429."""
+    import urllib.error
+
+    live_ids = ["rts-1", "rts-2", "rts-3", "rts-4", "rts-5", "rts-6", "rts-7", "rts-8", "rts-9", "rts-10"]
+    err_body = json.dumps(
+        {
+            "error": "terminal_cap_reached",
+            "message": "Canvas Claude has reached the 10 live terminal cap.",
+            "live_session_ids": live_ids,
+        }
+    ).encode()
+    http_err = urllib.error.HTTPError("http://test/api/claude/terminal/create", 429, "Too Many Requests", {}, None)
+    http_err.read = lambda: err_body
+
+    with patch("urllib.request.urlopen", side_effect=http_err):
+        result = tool_run_task({"cmd": "ls"})
+
+    assert "Error" in result
+    assert "10" in result
+    assert "cap" in result.lower() or "live" in result.lower()
+
+
+def test_tool_run_task_missing_cmd():
+    """tool_run_task raises ValueError when cmd is missing."""
+    with pytest.raises(ValueError, match="cmd is required"):
+        tool_run_task({})
+
+
+def test_tool_run_task_invalid_timeout():
+    """tool_run_task raises ValueError when timeout is not numeric."""
+    with pytest.raises(ValueError, match="timeout must be an integer"):
+        tool_run_task({"cmd": "ls", "timeout": "bad"})


### PR DESCRIPTION
## What changed

This PR implements issue #193: Canvas Claude ephemeral terminals and a per-card terminal cap. A new MCP tool `run_task` creates invisible, auto-closing PTY sessions for short-lived operations (probes, `ls`, `git pull`) without cluttering the canvas with terminal cards. A hard cap of 10 live terminals per Canvas Claude card (enforced across both `run_task` and `open_terminal`) prevents runaway plans from exhausting PTY or Docker exec slots. The cap is enforced atomically via per-spawner `asyncio.Lock`, and the spawner set is pruned automatically on PTY EOF, timeout expiry, explicit delete, or card unregister.

## Implementation walkthrough

### New / modified functions

**`tool_run_task` (`claude_rts/mcp_server.py`)** — New MCP tool handler. Accepts `cmd`, `timeout` (default 60, max 120), `container`, and `hub`. Forwards to `POST /api/claude/terminal/create` with `ephemeral=true`, `timeout=<value>`, and the global `SPAWNER_ID`. Parses structured HTTP 400 (`ephemeral_timeout_too_long`) and 429 (`terminal_cap_reached`) error bodies into user-readable strings that include `live_session_ids` on cap overflow so Canvas Claude knows which sessions to close. Error detection uses substring matching on the formatted `"HTTP {code}: {body}"` string (a known fragility noted in the review).

**`_resolve_spawner_id` (`claude_rts/mcp_server.py`)** — Companion to the existing `_resolve_api_base`. Walks `sys.argv` looking for `--spawner-id <id>` or `--spawner-id=<id>`. Returns `None` if not present; callers omit the `spawner_id` query param when `None`, leaving user-spawned terminals uncapped.

**`_ephemeral_timeout_watcher` (`claude_rts/server.py`)** — A plain `async def` that sleeps `timeout_seconds` and then calls `mgr.destroy_session(session_id)` if the session is still alive. Scheduled via `asyncio.create_task` immediately after session creation; the task handle is stored in `app["ephemeral_timers"][session_id]`. The `on_destroy` callback cancels this task when the session is destroyed by any other path first.

**`_on_session_destroy` (`claude_rts/server.py`, registered via `add_on_destroy`)** — Synchronous callback registered at server init. On every `destroy_session` call it discards `session_id` from all spawner sets in `app["canvas_claude_spawns"]` and cancels the pending timer in `app["ephemeral_timers"]`. This is the single teardown path for both explicit deletes and timeout-triggered destroys.

**`_on_canvas_claude_unregistered` (`claude_rts/server.py`)** — Async EventBus subscriber on `card:unregistered`. Filters for `card_type == "canvas-claude"`, pops the spawner's entire set from `canvas_claude_spawns`, removes the per-spawner lock entry, and calls `destroy_session` for each session still alive. This handles the CanvasClaudeCard restart / removal case where the card's previous spawner set would otherwise remain in memory indefinitely.

**`claude_terminal_create` handler (`claude_rts/server.py`)** — Extended with three new optional query params: `ephemeral`, `spawner_id`, and `timeout`. When `timeout` is provided without `ephemeral=true` the handler returns HTTP 400 `timeout_requires_ephemeral`. Ephemeral timeout is validated to `[1, 120]`; out-of-range values return 400 `ephemeral_timeout_too_long`. When `spawner_id` is set, a per-spawner `asyncio.Lock` (stored in `app["canvas_claude_spawn_locks"]`) is acquired before the cap check and held through session creation and `canvas_claude_spawns` update, making the check-add atomic across concurrent requests. Ephemeral sessions skip `CardRegistry.register` and the `card:registered` broadcast entirely; the session is still accessible via the existing `read_terminal` / `write_terminal` / `delete_terminal` endpoints using `session_id`.

**`_pty_read_loop` change (`claude_rts/sessions.py`)** — The `finally` block previously only set `session.alive = False`. It now also calls `self.destroy_session(session.session_id)`, which is idempotent (`_sessions.pop(..., None)` handles re-entrant calls). This ensures the `on_destroy` callback chain fires on natural PTY EOF, decrementing the spawner cap and cancelling the timeout timer without waiting for the ephemeral timeout or orphan reaper.

**`SessionManager.add_on_destroy` / updated `destroy_session` (`claude_rts/sessions.py`)** — `add_on_destroy` appends a `(session_id, session) -> None` callable to `_on_destroy_callbacks`. `destroy_session` pops the session from `_sessions` first (idempotent), then iterates callbacks with per-callback exception isolation, then sets `session.alive = False` and terminates the PTY. Callbacks therefore see the session object while it still exists but after it has been removed from the live registry.

**`_build_mcp_config` (`claude_rts/cards/canvas_claude_card.py`)** — Now accepts an optional `spawner_id` parameter. When set, `--spawner-id <id>` is appended to the MCP subprocess `args` list so `mcp_server.py` picks it up via `_resolve_spawner_id`.

### How components interact

```mermaid
sequenceDiagram
    participant CC as CanvasClaudeCard
    participant MCP as mcp_server.py
    participant API as POST /api/claude/terminal/create
    participant SM as SessionManager
    participant TW as EphemeralTimeoutWatcher
    participant OD as on_destroy callbacks

    CC->>MCP: spawn subprocess with --spawner-id card_id
    MCP->>API: POST cmd=ls ephemeral=true timeout=60 spawner_id=card_id
    API->>API: validate timeout in range 1 to 120
    API->>API: acquire per-spawner lock
    API->>API: prune stale IDs check cap less than 10
    API->>SM: create_session cmd=ls kind=probe
    SM-->>API: session object
    API->>API: add session_id to canvas_claude_spawns set
    API->>API: release lock
    API->>TW: asyncio.create_task timeout watcher
    API-->>MCP: 200 session_id ephemeral=true
    MCP-->>CC: Ephemeral task started session_id
    Note over SM,TW: PTY runs in background
    alt PTY EOF before timeout
        SM->>SM: _pty_read_loop finally calls destroy_session
        SM->>OD: invoke on_destroy callbacks
        OD->>OD: discard session_id from spawner set
        OD->>TW: cancel timer task
    else Timeout fires first
        TW->>SM: destroy_session if still alive
        SM->>OD: invoke on_destroy callbacks
        OD->>OD: discard session_id from spawner set
    end
    Note over CC,API: Card unregister path
    CC->>API: card unregistered event
    API->>API: _on_canvas_claude_unregistered handler
    API->>SM: destroy_session for each owned session_id
```

### Default execution path

**Before (open_terminal only):** every MCP `open_terminal` call registered a visible `TerminalCard` in `CardRegistry`, broadcast `card:registered` over `/ws/control`, and left the PTY alive until the orphan reaper (5 min) or an explicit `delete_terminal`. No cap existed.

**After — `run_task` call:** `mcp_server.py` POSTs to `/api/claude/terminal/create?ephemeral=true&timeout=60&spawner_id=<card_id>`. The handler validates the timeout, acquires the spawner lock, checks the cap, calls `mgr.create_session(..., kind="probe")` without touching `CardRegistry`, schedules the timeout watcher, adds the session to the spawner set, and returns `{session_id, ephemeral: true}`. Canvas Claude can call `read_terminal` / `write_terminal` on the session_id throughout its lifetime. When the command exits the read loop fires `destroy_session` which prunes the set and cancels the timer.

**After — `open_terminal` call with spawner_id:** Behaves as before (visible card, `CardRegistry.register`) but now also counts toward the 10-cap because `canvas_claude_spawns[spawner_id].add(card.session_id)` runs inside the spawner lock. User-spawned terminals (no `spawner_id`) are completely unaffected.

### Edge cases and error handling

- **`ephemeral_timeout_too_long` (HTTP 400):** returned when `timeout > 120` or `timeout < 1`. `tool_run_task` surfaces a human-readable message telling Canvas Claude to use `open_terminal` instead.
- **`timeout_requires_ephemeral` (HTTP 400):** returned when `timeout` is present in the query string but `ephemeral` is not `true`. Prevents silent misconfiguration.
- **`terminal_cap_reached` (HTTP 429):** returned when the spawner already has 10 live entries. Response includes `live_session_ids` (sorted) so Canvas Claude can choose which to close. Both `tool_run_task` and `tool_open_terminal` parse and surface this error.
- **TOCTOU:** the cap check and `canvas_claude_spawns.add` are wrapped in a per-spawner `asyncio.Lock` (stored in `app["canvas_claude_spawn_locks"]`). Two concurrent spawns at the 9-slot mark cannot both pass the gate.
- **Card unregister cleanup:** `_on_canvas_claude_unregistered` destroys all sessions owned by the departing card and removes the lock entry, preventing stale state on CanvasClaudeCard restart.

### What was intentionally not changed

`open_terminal`'s MCP schema and return shape are unchanged — it still creates a visible, persistent `TerminalCard` with the same parameters as before. User-spawned terminals (those without a `spawner_id` in the request) have no cap and no new lifecycle hooks. No frontend changes were needed; ephemeral sessions are invisible by design.

## Tier / approach

Tier 2 (medium). The feature touches four source files and three test files with no schema or frontend changes. Complexity comes from the cross-cutting concern (spawner attribution must flow from MCP argv through the REST endpoint into `SessionManager` callbacks) rather than from algorithmic depth. A per-spawner asyncio.Lock is used for atomicity rather than a global lock to keep unrelated Canvas Claude cards independent.

## Acceptance criteria

- [x] New MCP tool `run_task(cmd, timeout=60, container=None, hub=None)` exists and is documented.
- [x] `run_task` creates a PTY session and does NOT register a card in `card_registry`; no `card:registered` broadcast.
- [x] `run_task` rejects `timeout > 120` with a structured `ephemeral_timeout_too_long` error (HTTP 400 at the REST layer).
- [x] `run_task` rejects `timeout < 1` similarly.
- [x] Ephemeral sessions are destroyed on PTY EOF **or** at `timeout` seconds, whichever comes first.
- [x] `read_terminal` / `write_terminal` / `delete_terminal` work on ephemeral session_ids during their lifetime.
- [x] 10-terminal cap enforced per-spawner across both `run_task` and `open_terminal`; 11th call returns HTTP 429 `terminal_cap_reached` with `live_session_ids`.
- [x] Counter decrements on explicit delete, PTY EOF, and timeout-triggered destroy.
- [x] `CanvasClaudeCard` injects `--spawner-id <self.id>` into the MCP subprocess args; spawner set is cleared on card unregister.
- [x] User-spawned terminals (no `spawner_id`) are unaffected.
- [x] All existing tests pass; new tests cover `run_task` happy path, timeout expiry, timeout validation, cap enforcement, EOF cleanup, and card-unregister cleanup.
- [x] `ruff check` and `ruff format --check` are clean.

## Outstanding items

These are non-blocking and can be addressed in a follow-up:

1. **MCP error-code parse fragility** (minor): `tool_run_task` and `tool_open_terminal` detect HTTP status codes via substring match on `"HTTP 429: ..."`. A future refactor of `http_request` to raise a typed exception carrying `status` would make this more robust.
2. **Timeout-expiry test margin** (minor): `test_ephemeral_timeout_expiry_destroys_session` uses a 0.5s margin after a 1s timeout sleep. Under CI load this can flake; raising the margin to 1.0s (total sleep 2.0s) would reduce false failures.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)