### PR TITLE
fix(#200): guard vm_stop_container against non-canvas-claude containers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ Each `CanvasClaudeCard` enforces a hard cap of 10 live terminals across both `op
 | `vm_append_container_action` | `GET` + `PUT` (atomic) | Append one blueprint-action without dropping existing entries |
 | `vm_add_favorite` | `GET` + `PUT /api/vms/favorites` | Add a container to favorites (default: empty actions) |
 | `vm_start_container` | `POST /api/vms/{name}/start` | Start a stopped container |
-| `vm_stop_container` | `POST /api/vms/{name}/stop` | Stop a running container (optional `timeout`) |
+| `vm_stop_container` | `POST /api/vms/{name}/stop?via=canvas-claude` | Stop a running container (optional `timeout`). Guarded: server rejects with HTTP 403 `not_canvas_claude_owned` unless the container carries the Docker label `created_by=canvas-claude`. Human UI calls omit `via=canvas-claude` and are unguarded. |
 | `blueprint_list` | `GET /api/blueprints` | List all saved blueprint names |
 | `blueprint_get` | `GET /api/blueprints/{name}` | Get a single blueprint definition |
 | `blueprint_save` | `PUT /api/blueprints/{name}` (upsert) | Save or update a blueprint definition |

--- a/claude_rts/mcp_server.py
+++ b/claude_rts/mcp_server.py
@@ -352,15 +352,23 @@ def tool_vm_start_container(args):
 
 
 def tool_vm_stop_container(args):
-    """Stop a running Docker container via POST /api/vms/{name}/stop."""
+    """Stop a running Docker container via POST /api/vms/{name}/stop.
+
+    Carries the ``via=canvas-claude`` origin signal so the server enforces the
+    ``created_by=canvas-claude`` Docker-label guard. Containers that were not
+    created by Canvas Claude cannot be stopped through this tool (HTTP 403
+    ``not_canvas_claude_owned``). Humans stopping containers via the UI bypass
+    the guard because the UI does not set this query param.
+    """
     name = args.get("name", "") or args.get("container", "")
     if not name:
         raise ValueError("name is required")
     safe_name = urllib.parse.quote(name, safe="")
-    path = f"/api/vms/{safe_name}/stop"
+    params = ["via=canvas-claude"]
     timeout = args.get("timeout")
     if timeout is not None:
-        path += f"?timeout={int(timeout)}"
+        params.append(f"timeout={int(timeout)}")
+    path = f"/api/vms/{safe_name}/stop?{'&'.join(params)}"
     result = http_request("POST", path)
     return f"Stopped {name}: {json.dumps(result)}"
 

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -254,9 +254,84 @@ async def vm_start_handler(request: web.Request) -> web.Response:
     return web.json_response({"name": name, "state": "online"})
 
 
+async def _require_canvas_claude_owned(request: web.Request, name: str) -> web.Response | None:
+    """Guard: if the request originates from Canvas Claude (MCP), verify the container
+    carries the Docker label ``created_by=canvas-claude``. Returns a 403 JSON response
+    if the guard rejects, 500 if ``docker inspect`` fails, or None if the request is
+    allowed (either not Canvas-Claude-originated, or label matches).
+
+    Origin signal: query param ``via=canvas-claude`` OR header ``X-Canvas-Claude-Spawner``.
+    Human UI requests do NOT set these and bypass the guard entirely.
+    """
+    via = request.query.get("via", "").strip().lower()
+    spawner_hdr = request.headers.get("X-Canvas-Claude-Spawner", "").strip()
+    is_canvas_claude = via == "canvas-claude" or bool(spawner_hdr)
+    if not is_canvas_claude:
+        return None
+
+    # Test-mode hook: label lookup table keyed by container name
+    test_labels = request.app.get("_test_vm_labels")
+    if test_labels is not None:
+        label = test_labels.get(name, {}).get("created_by")
+        if label != "canvas-claude":
+            return web.json_response(
+                {"error": "not_canvas_claude_owned", "container": name},
+                status=403,
+            )
+        return None
+
+    # Real Docker path: inspect the container's created_by label
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            _DOCKER_CMD,
+            "inspect",
+            "--format",
+            '{{index .Config.Labels "created_by"}}',
+            "--",
+            name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+    except Exception as exc:
+        logger.warning("created_by guard: docker inspect failed for '{}': {}", name, exc)
+        return web.json_response(
+            {"error": "docker_inspect_failed", "container": name, "detail": str(exc)},
+            status=500,
+        )
+    if proc.returncode != 0:
+        err = stderr.decode().strip() if stderr else "docker inspect failed"
+        logger.warning("created_by guard: docker inspect failed for '{}': {}", name, err)
+        return web.json_response(
+            {"error": "docker_inspect_failed", "container": name, "detail": err},
+            status=500,
+        )
+    label = stdout.decode().strip()
+    # `docker inspect --format '{{index .Config.Labels "created_by"}}'` returns
+    # the literal string "<no value>" when the label is missing.
+    if label != "canvas-claude":
+        logger.info(
+            "created_by guard: rejected Canvas-Claude stop of '{}' (label={!r})",
+            name,
+            label,
+        )
+        return web.json_response(
+            {"error": "not_canvas_claude_owned", "container": name},
+            status=403,
+        )
+    return None
+
+
 async def vm_stop_handler(request: web.Request) -> web.Response:
     """Stop a running Docker container by name."""
     name = request.match_info["name"]
+
+    # Authorization guard: when the request originates from Canvas Claude (MCP),
+    # enforce that the container was created by Canvas Claude. Human UI calls do
+    # NOT set the origin signal and are unaffected.
+    guard_resp = await _require_canvas_claude_owned(request, name)
+    if guard_resp is not None:
+        return guard_resp
 
     # In test mode, flip mock container state instead of calling Docker
     test_containers = request.app.get("_test_vm_containers")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -540,7 +540,7 @@ def test_vm_start_container_missing_name():
 
 
 def test_vm_stop_container_calls_rest():
-    """vm_stop_container POSTs to /api/vms/{name}/stop."""
+    """vm_stop_container POSTs to /api/vms/{name}/stop with via=canvas-claude."""
     mock_resp = make_mock_response({"name": "foo-dev", "state": "offline"})
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
         result = tool_vm_stop_container({"name": "foo-dev"})
@@ -548,7 +548,8 @@ def test_vm_stop_container_calls_rest():
     req = mock_open.call_args[0][0]
     assert req.method == "POST"
     assert "/api/vms/foo-dev/stop" in req.full_url
-    assert "timeout=" not in req.full_url
+    # Guard origin signal must be present so server enforces created_by label
+    assert "via=canvas-claude" in req.full_url
 
 
 def test_vm_stop_container_with_timeout():
@@ -558,6 +559,36 @@ def test_vm_stop_container_with_timeout():
         tool_vm_stop_container({"name": "foo-dev", "timeout": 30})
     req = mock_open.call_args[0][0]
     assert "timeout=30" in req.full_url
+    assert "via=canvas-claude" in req.full_url
+
+
+def test_vm_stop_container_always_sends_origin_signal():
+    """vm_stop_container MUST carry via=canvas-claude so the server enforces
+    the created_by=canvas-claude Docker-label guard. Regression guard for #200."""
+    mock_resp = make_mock_response({"name": "foo", "state": "offline"})
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+        tool_vm_stop_container({"name": "foo"})
+    req = mock_open.call_args[0][0]
+    assert "via=canvas-claude" in req.full_url
+
+
+def test_vm_stop_container_propagates_403_guard_rejection():
+    """When the server returns 403 not_canvas_claude_owned, the MCP tool surfaces
+    the error instead of reporting success."""
+    import urllib.error
+
+    err_body = json.dumps({"error": "not_canvas_claude_owned", "container": "foo"}).encode()
+    http_err = urllib.error.HTTPError(
+        url="http://x/api/vms/foo/stop",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=None,
+    )
+    http_err.read = lambda: err_body  # type: ignore[assignment]
+    with patch("urllib.request.urlopen", side_effect=http_err):
+        with pytest.raises(RuntimeError, match="403"):
+            tool_vm_stop_container({"name": "foo"})
 
 
 def test_vm_stop_container_missing_name():

--- a/tests/test_vm_manager.py
+++ b/tests/test_vm_manager.py
@@ -289,6 +289,107 @@ async def test_vm_stop_invalid_timeout(client):
     assert "timeout" in body["error"]
 
 
+# ── created_by=canvas-claude guard (issue #200) ────────────────────────────
+
+
+async def test_vm_stop_guard_allows_when_label_matches(client):
+    """MCP-origin stop (via=canvas-claude) succeeds when container carries
+    created_by=canvas-claude label."""
+    app = client.app
+    app["_test_vm_containers"] = [
+        {"name": "cc-owned", "state": "online", "image": "ubuntu:24.04", "status": "Up 1m"},
+    ]
+    app["_test_vm_labels"] = {"cc-owned": {"created_by": "canvas-claude"}}
+
+    resp = await client.post("/api/vms/cc-owned/stop?via=canvas-claude")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["state"] == "offline"
+
+
+async def test_vm_stop_guard_rejects_when_label_missing(client):
+    """MCP-origin stop returns 403 not_canvas_claude_owned when the container
+    has no created_by label."""
+    app = client.app
+    app["_test_vm_containers"] = [
+        {"name": "human-owned", "state": "online", "image": "ubuntu:24.04", "status": "Up 1h"},
+    ]
+    app["_test_vm_labels"] = {"human-owned": {}}  # no created_by
+
+    resp = await client.post("/api/vms/human-owned/stop?via=canvas-claude")
+    assert resp.status == 403
+    data = await resp.json()
+    assert data["error"] == "not_canvas_claude_owned"
+    assert data["container"] == "human-owned"
+
+    # Guard must NOT have flipped state
+    assert app["_test_vm_containers"][0]["state"] == "online"
+
+
+async def test_vm_stop_guard_rejects_when_label_mismatched(client):
+    """MCP-origin stop is rejected when created_by is set to a different value."""
+    app = client.app
+    app["_test_vm_containers"] = [
+        {"name": "other", "state": "online", "image": "x", "status": "Up"},
+    ]
+    app["_test_vm_labels"] = {"other": {"created_by": "someone-else"}}
+
+    resp = await client.post("/api/vms/other/stop?via=canvas-claude")
+    assert resp.status == 403
+    data = await resp.json()
+    assert data["error"] == "not_canvas_claude_owned"
+
+
+async def test_vm_stop_human_ui_path_bypasses_guard(client):
+    """UI requests (no via/header) are not guarded — humans may stop any
+    container they own, including ones without the canvas-claude label."""
+    app = client.app
+    app["_test_vm_containers"] = [
+        {"name": "human-owned", "state": "online", "image": "x", "status": "Up"},
+    ]
+    app["_test_vm_labels"] = {"human-owned": {}}  # no label
+
+    resp = await client.post("/api/vms/human-owned/stop")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["state"] == "offline"
+
+
+async def test_vm_stop_guard_via_spawner_header(client):
+    """The X-Canvas-Claude-Spawner header is an alternate origin signal
+    equivalent to ?via=canvas-claude."""
+    app = client.app
+    app["_test_vm_containers"] = [
+        {"name": "human-owned", "state": "online", "image": "x", "status": "Up"},
+    ]
+    app["_test_vm_labels"] = {"human-owned": {}}
+
+    resp = await client.post(
+        "/api/vms/human-owned/stop",
+        headers={"X-Canvas-Claude-Spawner": "card-abc123"},
+    )
+    assert resp.status == 403
+    data = await resp.json()
+    assert data["error"] == "not_canvas_claude_owned"
+
+
+async def test_vm_stop_guard_docker_inspect_failure_maps_to_500(client):
+    """When docker inspect itself fails, guard returns 500 with a stable error
+    key (docker_inspect_failed) rather than silently allowing or rejecting."""
+    # Not setting _test_vm_labels → real docker inspect path. Mock subprocess
+    # to simulate docker inspect returning non-zero.
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate = AsyncMock(return_value=(b"", b"No such object: ghost"))
+    with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
+        resp = await client.post("/api/vms/ghost/stop?via=canvas-claude")
+
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["error"] == "docker_inspect_failed"
+    assert data["container"] == "ghost"
+
+
 # ── Per-container actions endpoint ──────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #200

Part of epic #199 (epic/199-container-manager).

## Summary

Adds a `created_by=canvas-claude` Docker-label guard to the `vm_stop_container` path so Canvas Claude (MCP) cannot stop a container it did not create. Hard 403 per epic intent OQ-2 decision. Human UI calls are unaffected.

## Authorization model

- **MCP tool path (Canvas Claude):** `tool_vm_stop_container` appends `via=canvas-claude` to the query. The server helper `_require_canvas_claude_owned` runs `docker inspect --format '{{index .Config.Labels "created_by"}}' <name>`. If the label is not `canvas-claude`, the request is rejected with HTTP 403 `{"error": "not_canvas_claude_owned", "container": name}`.
- **Human UI path:** `index.html`'s stop button hits `/api/vms/{name}/stop` with no origin signal and bypasses the guard entirely (humans own everything).
- **Alternate origin signal:** the header `X-Canvas-Claude-Spawner` is also recognised, for future MCP tools that carry a spawner id.
- **Docker inspect failure** maps to HTTP 500 with stable key `docker_inspect_failed` so callers can distinguish infra errors from authorization rejections.

## Changes

- `claude_rts/server.py`: new `_require_canvas_claude_owned()` helper + wrap `vm_stop_handler` with the guard. Test-mode hook: `app["_test_vm_labels"]` overrides the `docker inspect` call.
- `claude_rts/mcp_server.py`: `tool_vm_stop_container` always carries `via=canvas-claude`; docstring documents the guard.
- `tests/test_mcp_server.py`: assertion that `via=canvas-claude` is always in the outbound URL; regression test that a 403 response surfaces as a `RuntimeError`.
- `tests/test_vm_manager.py`: 6 new server-side tests — label matches, label missing, label mismatched, UI path bypass, header origin signal, docker-inspect-failure 500 mapping.
- `CLAUDE.md`: documents the guard on the `vm_stop_container` row of the MCP tools table.

## Test plan

- [x] `python -m pytest tests/test_mcp_server.py tests/test_vm_manager.py -v` — 103 pass
- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)