### PR TITLE
feat(#201): rename vm_* to container_* (routes, MCP tools, UI, tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Verify the port is free before starting. Running multiple instances causes port 
 - **Session persistence**: SessionManager decouples PTY lifetime from WebSocket. PTYs run in server memory with a 64KB scrollback ring buffer. Orphan reaper cleans up after 5 min.
 - **Single HTML file**: All JS/CSS is inline in `index.html`. External libs (xterm.js) load from CDN. No npm, no bundler.
 - **Card class hierarchy**: `Card` base → `TerminalCard`, `WidgetCard`, `LoaderCard`. Enables mixed dashboards.
-- **Limited container lifecycle (start/stop only)**: supreme-claudemander can start and stop Docker containers via the VM Manager card. Creating, removing, and image management remain out of scope.
+- **Limited container lifecycle (start/stop only)**: supreme-claudemander can start and stop Docker containers via the Container Manager card. Creating, removing, and image management remain out of scope.
 - **Plain `docker` binary**: Always use `docker` (no `.exe`). The runtime is Linux/macOS-native. Windows is community-supported best-effort.
 
 ## Dev Config Presets
@@ -101,7 +101,7 @@ The devcontainer is configured to run the full E2E suite including Docker-gated 
 | `test_terminal_card.py` | 18 | TerminalCard lifecycle, CardRegistry, server integration, display_name, recovery_script |
 | `test_claude_api.py` | 38 | Claude terminal control API (CRUD, send/read, strip_ansi, /ws/control, full lifecycle, cmd pass-through, rename, recovery-script, card_updated broadcast) |
 | `test_event_bus.py` | 14 | EventBus core (subscribe, emit, unsubscribe, wildcard, async, errors, clear) + integration (ServiceCard bus emit, CardRegistry events) |
-| `test_vm_manager.py` | 18 | VM Manager API (discover containers, favorites CRUD, start/stop container, per-container actions, route registration) |
+| `test_container_manager.py` | 18 | Container Manager API (discover containers, favorites CRUD, start/stop container, per-container actions, route registration) |
 | `test_mcp_server.py` | 64 | MCP server tool functions (terminal CRUD/rename/recovery + VM discover/favorites/actions/start/stop/append/get + blueprint list/get/save/delete/spawn) and JSON-RPC dispatch |
 | `e2e/test_smoke.py` | 7 | Playwright Electron smoke tests — launch, spawn, drag, resize, widgets, pan/zoom, save/reload |
 
@@ -120,11 +120,11 @@ Tests use `MockPty` to avoid needing Docker. E2E tests require Playwright and El
 | GET | `/api/widgets/system-info` | System info widget data |
 | GET | `/api/profiles` | Probe profiles with usage data, sorted by burn rate |
 | GET/PUT | `/api/profiles/main` | Read the main profile slot name / promote a tracked profile (credential copy) |
-| GET | `/api/vms/discover` | Discover all Docker containers (running + stopped) with status |
-| GET/PUT | `/api/vms/favorites` | Read/write VM Manager favorites list |
-| POST | `/api/vms/{name}/start` | Start a stopped Docker container |
-| POST | `/api/vms/{name}/stop` | Stop a running Docker container (optional `?timeout=N`) |
-| PUT | `/api/vms/favorites/{name}/actions` | Update actions for a specific favorite container |
+| GET | `/api/containers/discover` | Discover all Docker containers (running + stopped) with status |
+| GET/PUT | `/api/containers/favorites` | Read/write Container Manager favorites list |
+| POST | `/api/containers/{name}/start` | Start a stopped Docker container |
+| POST | `/api/containers/{name}/stop` | Stop a running Docker container (optional `?timeout=N`) |
+| PUT | `/api/containers/favorites/{name}/actions` | Update actions for a specific favorite container |
 | POST | `/api/claude/terminal/create` | Create a TerminalCard + PTY session (params: cmd, hub, container, cols, rows, x, y, w, h). Optional: `ephemeral=true` (no card registered, auto-closes on PTY EOF or timeout), `spawner_id=<card_id>` (attributes the spawn to a CanvasClaudeCard for cap enforcement), `timeout=<seconds>` (ephemeral only; default 60, max 120; values outside `[1, 120]` return HTTP 400 `ephemeral_timeout_too_long`). When `spawner_id` is set and the spawner already has 10 live sessions, returns HTTP 429 `terminal_cap_reached` with `live_session_ids`. |
 | POST | `/api/claude/terminal/{id}/send` | Write text to a terminal PTY |
 | GET | `/api/claude/terminal/{id}/read` | Read scrollback (optional: strip_ansi, last_n) |
@@ -158,7 +158,7 @@ Stored in `~/.supreme-claudemander/config.json`:
 
 Canvas layouts stored in `~/.supreme-claudemander/canvases/{name}.json`.
 
-## VM Manager Action Schema
+## Container Manager Action Schema
 
 Each favorite container has an `actions` array of blueprint-action objects. Actions spawn blueprints scoped to the container:
 
@@ -193,14 +193,14 @@ Each `CanvasClaudeCard` enforces a hard cap of 10 live terminals across both `op
 | `rename_terminal` | `PUT /api/claude/terminal/{id}/rename` | Set a display name on a terminal card |
 | `set_recovery_script` | `PUT /api/claude/terminal/{id}/recovery-script` | Set recovery script on a terminal card |
 | `get_recovery_script` | `GET /api/claude/terminal/{id}/recovery-script` | Get recovery script for a terminal card |
-| `vm_discover_containers` | `GET /api/vms/discover` | List all Docker containers (running + stopped) |
-| `vm_get_favorites` | `GET /api/vms/favorites` | Read the VM Manager favorites list with blueprint-actions |
-| `vm_get_container_actions` | `GET /api/vms/favorites` (filtered) | Return one favorite's `actions` array; errors on unknown container |
-| `vm_set_container_actions` | `PUT /api/vms/favorites/{name}/actions` | Replace the full actions array for a favorite |
-| `vm_append_container_action` | `GET` + `PUT` (atomic) | Append one blueprint-action without dropping existing entries |
-| `vm_add_favorite` | `GET` + `PUT /api/vms/favorites` | Add a container to favorites (default: empty actions) |
-| `vm_start_container` | `POST /api/vms/{name}/start` | Start a stopped container |
-| `vm_stop_container` | `POST /api/vms/{name}/stop?via=canvas-claude` | Stop a running container (optional `timeout`). Guarded: server rejects with HTTP 403 `not_canvas_claude_owned` unless the container carries the Docker label `created_by=canvas-claude`. Human UI calls omit `via=canvas-claude` and are unguarded. |
+| `container_discover` | `GET /api/containers/discover` | List all Docker containers (running + stopped) |
+| `container_get_favorites` | `GET /api/containers/favorites` | Read the Container Manager favorites list with blueprint-actions |
+| `container_get_actions` | `GET /api/containers/favorites` (filtered) | Return one favorite's `actions` array; errors on unknown container |
+| `container_set_actions` | `PUT /api/containers/favorites/{name}/actions` | Replace the full actions array for a favorite |
+| `container_append_action` | `GET` + `PUT` (atomic) | Append one blueprint-action without dropping existing entries |
+| `container_add_favorite` | `GET` + `PUT /api/containers/favorites` | Add a container to favorites (default: empty actions) |
+| `container_start` | `POST /api/containers/{name}/start` | Start a stopped container |
+| `container_stop` | `POST /api/containers/{name}/stop?via=canvas-claude` | Stop a running container (optional `timeout`). Guarded: server rejects with HTTP 403 `not_canvas_claude_owned` unless the container carries the Docker label `created_by=canvas-claude`. Human UI calls omit `via=canvas-claude` and are unguarded. |
 | `blueprint_list` | `GET /api/blueprints` | List all saved blueprint names |
 | `blueprint_get` | `GET /api/blueprints/{name}` | Get a single blueprint definition |
 | `blueprint_save` | `PUT /api/blueprints/{name}` (upsert) | Save or update a blueprint definition |

--- a/claude_rts/cards/blueprint_card.py
+++ b/claude_rts/cards/blueprint_card.py
@@ -238,7 +238,7 @@ class BlueprintCard(BaseCard):
             raise RuntimeError("No app reference — cannot discover containers")
 
         # Use mock data if in test mode
-        test_containers = self._app.get("_test_vm_containers")
+        test_containers = self._app.get("_test_containers")
         if test_containers is not None:
             containers = [c["name"] for c in test_containers]
             await self._log(f"  Discovered {len(containers)} container(s): {containers}")

--- a/claude_rts/cards/container_starter_card.py
+++ b/claude_rts/cards/container_starter_card.py
@@ -13,7 +13,7 @@ class ContainerStarterCard(BaseCard):
     """Transient service card that starts a Docker container and probes exec-readiness.
 
     Lifecycle:
-    1. Calls POST /api/vms/{name}/start (via the app reference)
+    1. Calls POST /api/containers/{name}/start (via the app reference)
     2. Probes exec-readiness: ``docker exec <name> true`` with exponential backoff
     3. On success: emits ``container:ready:{name}`` with result payload; self-closes
     4. On timeout/failure: emits ``container:failed:{name}`` with error; self-closes
@@ -106,7 +106,7 @@ class ContainerStarterCard(BaseCard):
         """Start the container via docker start."""
         # In test mode, check for mock containers
         if self._app is not None:
-            test_containers = self._app.get("_test_vm_containers")
+            test_containers = self._app.get("_test_containers")
             if test_containers is not None:
                 for c in test_containers:
                     if c["name"] == name:
@@ -132,7 +132,7 @@ class ContainerStarterCard(BaseCard):
         """Probe exec-readiness with exponential backoff until success or timeout."""
         # In test mode with mock containers, skip the real docker exec probe
         if self._app is not None:
-            test_containers = self._app.get("_test_vm_containers")
+            test_containers = self._app.get("_test_containers")
             if test_containers is not None:
                 # Mock mode: container is already "started", consider it ready
                 return

--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -63,7 +63,7 @@ DEFAULT_CONFIG = {
         "scrollback_size": 65536,
         "tmux_persistence": True,
     },
-    "vm_manager": {
+    "container_manager": {
         "favorites": [],
     },
 }

--- a/claude_rts/dev_presets/container-actions-qa/canvases/container-actions-qa.json
+++ b/claude_rts/dev_presets/container-actions-qa/canvases/container-actions-qa.json
@@ -1,10 +1,10 @@
 {
-  "name": "vm-actions-qa",
+  "name": "container-actions-qa",
   "canvas_size": [3840, 2160],
   "cards": [
     {
       "type": "widget",
-      "widgetType": "vm-manager",
+      "widgetType": "container-manager",
       "x": 100,
       "y": 100,
       "w": 520,

--- a/claude_rts/dev_presets/container-actions-qa/config.json
+++ b/claude_rts/dev_presets/container-actions-qa/config.json
@@ -1,6 +1,6 @@
 {
   "startup_script": "util-terminal",
-  "default_canvas": "vm-actions-qa",
+  "default_canvas": "container-actions-qa",
   "main_profile_name": "main",
   "probe_profiles": [],
   "sessions": {
@@ -17,7 +17,7 @@
       "~/.claude-profiles": "/profiles"
     }
   },
-  "vm_manager": {
+  "container_manager": {
     "favorites": [
       {
         "name": "supreme-claudemander-util",

--- a/claude_rts/dev_presets/container-manager/canvases/container-qa.json
+++ b/claude_rts/dev_presets/container-manager/canvases/container-qa.json
@@ -1,10 +1,10 @@
 {
-  "name": "vm-qa",
+  "name": "container-qa",
   "canvas_size": [3840, 2160],
   "cards": [
     {
       "type": "widget",
-      "widgetType": "vm-manager",
+      "widgetType": "container-manager",
       "x": 100,
       "y": 100,
       "w": 500,

--- a/claude_rts/dev_presets/container-manager/config.json
+++ b/claude_rts/dev_presets/container-manager/config.json
@@ -1,6 +1,6 @@
 {
   "startup_script": "util-terminal",
-  "default_canvas": "vm-qa",
+  "default_canvas": "container-qa",
   "main_profile_name": "main",
   "probe_profiles": [],
   "sessions": {
@@ -17,7 +17,7 @@
       "~/.claude-profiles": "/profiles"
     }
   },
-  "vm_manager": {
+  "container_manager": {
     "favorites": [
       {
         "name": "supreme-claudemander-util",

--- a/claude_rts/dev_presets/human-qa/canvases/human-qa.json
+++ b/claude_rts/dev_presets/human-qa/canvases/human-qa.json
@@ -12,7 +12,7 @@
     },
     {
       "type": "widget",
-      "widgetType": "vm-manager",
+      "widgetType": "container-manager",
       "x": 900,
       "y": 50,
       "w": 520,

--- a/claude_rts/dev_presets/human-qa/config.json
+++ b/claude_rts/dev_presets/human-qa/config.json
@@ -17,7 +17,7 @@
       "~/.claude-profiles": "/profiles"
     }
   },
-  "vm_manager": {
+  "container_manager": {
     "favorites": [
       {
         "name": "supreme-claudemander-util",

--- a/claude_rts/mcp_server.py
+++ b/claude_rts/mcp_server.py
@@ -269,8 +269,8 @@ def tool_get_recovery_script(args):
     return result.get("recovery_script", "")
 
 
-def tool_vm_discover_containers(args):  # noqa: ARG001
-    result = http_request("GET", "/api/vms/discover")
+def tool_container_discover(args):  # noqa: ARG001
+    result = http_request("GET", "/api/containers/discover")
     if not isinstance(result, list):
         return f"Error discovering containers: {result}"
     if not result:
@@ -283,12 +283,12 @@ def tool_vm_discover_containers(args):  # noqa: ARG001
     return "\n".join(lines)
 
 
-def tool_vm_get_favorites(args):  # noqa: ARG001
-    result = http_request("GET", "/api/vms/favorites")
+def tool_container_get_favorites(args):  # noqa: ARG001
+    result = http_request("GET", "/api/containers/favorites")
     return json.dumps(result, indent=2)
 
 
-def tool_vm_set_container_actions(args):
+def tool_container_set_actions(args):
     container = args.get("container", "")
     if not container:
         raise ValueError("container is required")
@@ -296,25 +296,25 @@ def tool_vm_set_container_actions(args):
     safe_name = urllib.parse.quote(container, safe="")
     result = http_request(
         "PUT",
-        f"/api/vms/favorites/{safe_name}/actions",
+        f"/api/containers/favorites/{safe_name}/actions",
         body=json.dumps(actions),
     )
     return f"Actions updated for {container}: {json.dumps(result)}"
 
 
-def tool_vm_get_container_actions(args):
+def tool_container_get_actions(args):
     """Return just one favorite's actions array; error if not found."""
     container = args.get("container", "") or args.get("name", "")
     if not container:
         raise ValueError("container is required")
-    favorites = http_request("GET", "/api/vms/favorites")
+    favorites = http_request("GET", "/api/containers/favorites")
     for fav in favorites:
         if fav.get("name") == container:
             return json.dumps(fav.get("actions", []), indent=2)
     raise ValueError(f"Favorite not found: {container}")
 
 
-def tool_vm_append_container_action(args):
+def tool_container_append_action(args):
     """Atomically append one action to a favorite's actions array."""
     container = args.get("container", "") or args.get("name", "")
     if not container:
@@ -322,7 +322,7 @@ def tool_vm_append_container_action(args):
     action = args.get("action")
     if not isinstance(action, dict):
         raise ValueError("action (object) is required")
-    favorites = http_request("GET", "/api/vms/favorites")
+    favorites = http_request("GET", "/api/containers/favorites")
     target = None
     for fav in favorites:
         if fav.get("name") == container:
@@ -335,24 +335,24 @@ def tool_vm_append_container_action(args):
     safe_name = urllib.parse.quote(container, safe="")
     result = http_request(
         "PUT",
-        f"/api/vms/favorites/{safe_name}/actions",
+        f"/api/containers/favorites/{safe_name}/actions",
         body=json.dumps(existing),
     )
     return f"Appended action to {container}: {json.dumps(result)}"
 
 
-def tool_vm_start_container(args):
-    """Start a stopped Docker container via POST /api/vms/{name}/start."""
+def tool_container_start(args):
+    """Start a stopped Docker container via POST /api/containers/{name}/start."""
     name = args.get("name", "") or args.get("container", "")
     if not name:
         raise ValueError("name is required")
     safe_name = urllib.parse.quote(name, safe="")
-    result = http_request("POST", f"/api/vms/{safe_name}/start")
+    result = http_request("POST", f"/api/containers/{safe_name}/start")
     return f"Started {name}: {json.dumps(result)}"
 
 
-def tool_vm_stop_container(args):
-    """Stop a running Docker container via POST /api/vms/{name}/stop.
+def tool_container_stop(args):
+    """Stop a running Docker container via POST /api/containers/{name}/stop.
 
     Carries the ``via=canvas-claude`` origin signal so the server enforces the
     ``created_by=canvas-claude`` Docker-label guard. Containers that were not
@@ -368,24 +368,24 @@ def tool_vm_stop_container(args):
     timeout = args.get("timeout")
     if timeout is not None:
         params.append(f"timeout={int(timeout)}")
-    path = f"/api/vms/{safe_name}/stop?{'&'.join(params)}"
+    path = f"/api/containers/{safe_name}/stop?{'&'.join(params)}"
     result = http_request("POST", path)
     return f"Stopped {name}: {json.dumps(result)}"
 
 
-def tool_vm_add_favorite(args):
+def tool_container_add_favorite(args):
     name = args.get("name", "")
     if not name:
         raise ValueError("name is required")
     actions = args.get("actions", [])
     # GET current favorites, append, PUT back
-    favorites = http_request("GET", "/api/vms/favorites")
+    favorites = http_request("GET", "/api/containers/favorites")
     # Check if already exists
     for fav in favorites:
         if fav.get("name") == name:
             return f"Container {name} is already a favorite"
     favorites.append({"name": name, "type": "docker", "actions": actions})
-    http_request("PUT", "/api/vms/favorites", body=json.dumps(favorites))
+    http_request("PUT", "/api/containers/favorites", body=json.dumps(favorites))
     return f"Added {name} to favorites with {len(actions)} action(s)"
 
 
@@ -469,14 +469,14 @@ TOOL_HANDLERS = {
     "rename_terminal": tool_rename_terminal,
     "set_recovery_script": tool_set_recovery_script,
     "get_recovery_script": tool_get_recovery_script,
-    "vm_discover_containers": tool_vm_discover_containers,
-    "vm_get_favorites": tool_vm_get_favorites,
-    "vm_set_container_actions": tool_vm_set_container_actions,
-    "vm_get_container_actions": tool_vm_get_container_actions,
-    "vm_append_container_action": tool_vm_append_container_action,
-    "vm_start_container": tool_vm_start_container,
-    "vm_stop_container": tool_vm_stop_container,
-    "vm_add_favorite": tool_vm_add_favorite,
+    "container_discover": tool_container_discover,
+    "container_get_favorites": tool_container_get_favorites,
+    "container_set_actions": tool_container_set_actions,
+    "container_get_actions": tool_container_get_actions,
+    "container_append_action": tool_container_append_action,
+    "container_start": tool_container_start,
+    "container_stop": tool_container_stop,
+    "container_add_favorite": tool_container_add_favorite,
     "blueprint_list": tool_blueprint_list,
     "blueprint_get": tool_blueprint_get,
     "blueprint_save": tool_blueprint_save,
@@ -529,9 +529,9 @@ TOOL_SCHEMAS = [
                     "type": "string",
                     "description": (
                         "Exact Docker container name to connect to. When set, cmd runs inside "
-                        "this container via docker exec. Use vm_discover_containers to find "
+                        "this container via docker exec. Use container_discover to find "
                         "available container names (e.g. 'supreme-claudemander-util'). "
-                        "The container must be running — use vm_start_container first if needed."
+                        "The container must be running — use container_start first if needed."
                     ),
                 },
                 "x": {
@@ -612,7 +612,7 @@ TOOL_SCHEMAS = [
                     "description": (
                         "Exact Docker container name to run the command in (optional). "
                         "When set, cmd runs inside this container via docker exec. "
-                        "Use vm_discover_containers to find available container names."
+                        "Use container_discover to find available container names."
                     ),
                 },
                 "hub": {
@@ -779,12 +779,12 @@ TOOL_SCHEMAS = [
         },
     },
     {
-        "name": "vm_discover_containers",
+        "name": "container_discover",
         "description": (
             "List all Docker containers on the host (both running and stopped). "
             "Returns each container's name, state (online/offline), image, and status. "
             "Use the container names from this list as the 'container' or 'name' parameter "
-            "in other tools (open_terminal, vm_start_container, vm_add_favorite, etc.)."
+            "in other tools (open_terminal, container_start, container_add_favorite, etc.)."
         ),
         "inputSchema": {
             "type": "object",
@@ -792,9 +792,9 @@ TOOL_SCHEMAS = [
         },
     },
     {
-        "name": "vm_get_favorites",
+        "name": "container_get_favorites",
         "description": (
-            "Get the VM Manager favorites list — containers the user has bookmarked "
+            "Get the Container Manager favorites list — containers the user has bookmarked "
             "for quick access. Each favorite has: name (string), type ('docker'), "
             "actions (array of blueprint-action objects). Actions define buttons in the UI "
             "that spawn blueprints scoped to the container. "
@@ -808,11 +808,11 @@ TOOL_SCHEMAS = [
         },
     },
     {
-        "name": "vm_set_container_actions",
+        "name": "container_set_actions",
         "description": (
             "REPLACE the entire actions array for a favorite container. WARNING: this "
             "overwrites all existing actions — if you only want to add one action without "
-            "losing the others, use vm_append_container_action instead. "
+            "losing the others, use container_append_action instead. "
             "Action schema: {label: string, blueprint: string (name of a saved blueprint), "
             "context?: object (extra variables merged with auto-injected container name)}. "
             "The container name is always injected automatically when the action is executed."
@@ -824,7 +824,7 @@ TOOL_SCHEMAS = [
                     "type": "string",
                     "description": (
                         "Name of the favorite container to update. "
-                        "Must already be in the favorites list (use vm_add_favorite first if needed)."
+                        "Must already be in the favorites list (use container_add_favorite first if needed)."
                     ),
                 },
                 "actions": {
@@ -848,7 +848,7 @@ TOOL_SCHEMAS = [
         },
     },
     {
-        "name": "vm_get_container_actions",
+        "name": "container_get_actions",
         "description": (
             "Get the actions array for a single favorite container. Returns a JSON array "
             "of blueprint-action objects ({label, blueprint, context?}). Errors if the "
@@ -871,12 +871,12 @@ TOOL_SCHEMAS = [
         },
     },
     {
-        "name": "vm_append_container_action",
+        "name": "container_append_action",
         "description": (
             "Add one action to a favorite container WITHOUT removing existing actions. "
             "This is an atomic read-modify-write: it fetches the current actions, appends "
             "the new one, and saves the updated list in a single operation. Prefer this over "
-            "vm_set_container_actions when you only need to add an action — it is safer "
+            "container_set_actions when you only need to add an action — it is safer "
             "because it never drops existing entries. Accepts either 'container' or 'name' "
             "as the parameter key. "
             "Action schema: {label: string, blueprint: string (name of a saved blueprint), "
@@ -912,9 +912,9 @@ TOOL_SCHEMAS = [
         },
     },
     {
-        "name": "vm_start_container",
+        "name": "container_start",
         "description": (
-            "Start a stopped Docker container. Use vm_discover_containers first to check "
+            "Start a stopped Docker container. Use container_discover first to check "
             "the container's current state. After starting, you can open a terminal in it "
             "with open_terminal. Accepts either 'name' or 'container' as the parameter key."
         ),
@@ -925,7 +925,7 @@ TOOL_SCHEMAS = [
                     "type": "string",
                     "description": (
                         "Name of the Docker container to start (also accepted as 'container'). "
-                        "Use the exact name from vm_discover_containers."
+                        "Use the exact name from container_discover."
                     ),
                 },
             },
@@ -933,9 +933,9 @@ TOOL_SCHEMAS = [
         },
     },
     {
-        "name": "vm_stop_container",
+        "name": "container_stop",
         "description": (
-            "Stop a running Docker container. Use vm_discover_containers first to confirm "
+            "Stop a running Docker container. Use container_discover first to confirm "
             "it is running. Optionally set a timeout (seconds) before the container is "
             "force-killed. Accepts either 'name' or 'container' as the parameter key."
         ),
@@ -946,7 +946,7 @@ TOOL_SCHEMAS = [
                     "type": "string",
                     "description": (
                         "Name of the Docker container to stop (also accepted as 'container'). "
-                        "Use the exact name from vm_discover_containers."
+                        "Use the exact name from container_discover."
                     ),
                 },
                 "timeout": {
@@ -962,13 +962,13 @@ TOOL_SCHEMAS = [
         },
     },
     {
-        "name": "vm_add_favorite",
+        "name": "container_add_favorite",
         "description": (
-            "Add a Docker container to the VM Manager favorites list so it appears in "
+            "Add a Docker container to the Container Manager favorites list so it appears in "
             "the sidebar for quick access. If the container is already a favorite, returns "
             "a message and does nothing. Optionally provide custom blueprint-actions; "
             "default is an empty actions array (no actions configured). Use "
-            "vm_append_container_action or vm_set_container_actions to add actions after."
+            "container_append_action or container_set_actions to add actions after."
         ),
         "inputSchema": {
             "type": "object",
@@ -976,8 +976,7 @@ TOOL_SCHEMAS = [
                 "name": {
                     "type": "string",
                     "description": (
-                        "Name of the Docker container to add to favorites. "
-                        "Use the exact name from vm_discover_containers."
+                        "Name of the Docker container to add to favorites. Use the exact name from container_discover."
                     ),
                 },
                 "actions": {

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -144,13 +144,13 @@ async def widget_system_info_handler(request: web.Request) -> web.Response:
 _DOCKER_CMD = "docker"
 
 
-# ── VM Manager API ───────────────────────────────────────────────────────────
+# ── Container Manager API ────────────────────────────────────────────────────
 
 
-async def vm_discover_handler(request: web.Request) -> web.Response:
+async def container_discover_handler(request: web.Request) -> web.Response:
     """Discover all Docker containers (running + stopped) with status."""
     # In test mode, return injected mock data if available
-    test_containers = request.app.get("_test_vm_containers")
+    test_containers = request.app.get("_test_containers")
     if test_containers is not None:
         return web.json_response(sorted(test_containers, key=lambda c: c["name"]))
 
@@ -167,7 +167,7 @@ async def vm_discover_handler(request: web.Request) -> web.Response:
 
     if proc.returncode != 0:
         err = stderr.decode().strip() if stderr else "docker ps failed"
-        logger.warning("vm_discover: docker ps failed: {}", err)
+        logger.warning("container_discover: docker ps failed: {}", err)
         return web.json_response({"error": err}, status=500)
 
     containers = []
@@ -199,39 +199,39 @@ async def vm_discover_handler(request: web.Request) -> web.Response:
     return web.json_response(containers)
 
 
-async def vm_favorites_get_handler(request: web.Request) -> web.Response:
-    """Read the VM Manager favorites list from config."""
+async def container_favorites_get_handler(request: web.Request) -> web.Response:
+    """Read the Container Manager favorites list from config."""
     app_config: AppConfig = request.app["app_config"]
     config = read_config(app_config)
-    vm_config = config.get("vm_manager", {})
-    favorites = vm_config.get("favorites", [])
+    cm_config = config.get("container_manager", {})
+    favorites = cm_config.get("favorites", [])
     return web.json_response(favorites)
 
 
-async def vm_favorites_put_handler(request: web.Request) -> web.Response:
-    """Write the VM Manager favorites list to config."""
+async def container_favorites_put_handler(request: web.Request) -> web.Response:
+    """Write the Container Manager favorites list to config."""
     app_config: AppConfig = request.app["app_config"]
     body = await request.json()
     favorites = body if isinstance(body, list) else body.get("favorites", [])
     config = read_config(app_config)
-    if "vm_manager" not in config:
-        config["vm_manager"] = {}
-    config["vm_manager"]["favorites"] = favorites
+    if "container_manager" not in config:
+        config["container_manager"] = {}
+    config["container_manager"]["favorites"] = favorites
     write_config(app_config, config)
     return web.json_response(favorites)
 
 
-async def vm_start_handler(request: web.Request) -> web.Response:
+async def container_start_handler(request: web.Request) -> web.Response:
     """Start a stopped Docker container by name."""
     name = request.match_info["name"]
 
     # In test mode, flip mock container state instead of calling Docker
-    test_containers = request.app.get("_test_vm_containers")
+    test_containers = request.app.get("_test_containers")
     if test_containers is not None:
         for c in test_containers:
             if c["name"] == name:
                 c["state"] = "online"
-                logger.info("vm_start (test): flipped '{}' to online", name)
+                logger.info("container_start (test): flipped '{}' to online", name)
                 return web.json_response({"name": name, "state": "online"})
         return web.json_response({"error": f"No such container: {name}"}, status=500)
 
@@ -247,10 +247,10 @@ async def vm_start_handler(request: web.Request) -> web.Response:
 
     if proc.returncode != 0:
         err = stderr.decode().strip() if stderr else "docker start failed"
-        logger.warning("vm_start: failed to start container '{}': {}", name, err)
+        logger.warning("container_start: failed to start container '{}': {}", name, err)
         return web.json_response({"error": err}, status=500)
 
-    logger.info("vm_start: started container '{}'", name)
+    logger.info("container_start: started container '{}'", name)
     return web.json_response({"name": name, "state": "online"})
 
 
@@ -270,7 +270,7 @@ async def _require_canvas_claude_owned(request: web.Request, name: str) -> web.R
         return None
 
     # Test-mode hook: label lookup table keyed by container name
-    test_labels = request.app.get("_test_vm_labels")
+    test_labels = request.app.get("_test_container_labels")
     if test_labels is not None:
         label = test_labels.get(name, {}).get("created_by")
         if label != "canvas-claude":
@@ -322,7 +322,7 @@ async def _require_canvas_claude_owned(request: web.Request, name: str) -> web.R
     return None
 
 
-async def vm_stop_handler(request: web.Request) -> web.Response:
+async def container_stop_handler(request: web.Request) -> web.Response:
     """Stop a running Docker container by name."""
     name = request.match_info["name"]
 
@@ -334,12 +334,12 @@ async def vm_stop_handler(request: web.Request) -> web.Response:
         return guard_resp
 
     # In test mode, flip mock container state instead of calling Docker
-    test_containers = request.app.get("_test_vm_containers")
+    test_containers = request.app.get("_test_containers")
     if test_containers is not None:
         for c in test_containers:
             if c["name"] == name:
                 c["state"] = "offline"
-                logger.info("vm_stop (test): flipped '{}' to offline", name)
+                logger.info("container_stop (test): flipped '{}' to offline", name)
                 return web.json_response({"name": name, "state": "offline"})
         return web.json_response({"error": f"No such container: {name}"}, status=500)
 
@@ -363,20 +363,20 @@ async def vm_stop_handler(request: web.Request) -> web.Response:
 
     if proc.returncode != 0:
         err = stderr.decode().strip() if stderr else "docker stop failed"
-        logger.warning("vm_stop: failed to stop container '{}': {}", name, err)
+        logger.warning("container_stop: failed to stop container '{}': {}", name, err)
         return web.json_response({"error": err}, status=500)
 
-    logger.info("vm_stop: stopped container '{}'", name)
+    logger.info("container_stop: stopped container '{}'", name)
     return web.json_response({"name": name, "state": "offline"})
 
 
-async def vm_favorites_actions_put_handler(request: web.Request) -> web.Response:
+async def container_favorites_actions_put_handler(request: web.Request) -> web.Response:
     """Update actions for a specific favorite container by name."""
     name = request.match_info["name"]
     app_config: AppConfig = request.app["app_config"]
     cfg = read_config(app_config)
-    vm_config = cfg.get("vm_manager", {})
-    favorites = vm_config.get("favorites", [])
+    cm_config = cfg.get("container_manager", {})
+    favorites = cm_config.get("favorites", [])
 
     # Find the target favorite
     target = None
@@ -397,9 +397,9 @@ async def vm_favorites_actions_put_handler(request: web.Request) -> web.Response
     target["actions"] = actions
 
     # Persist
-    if "vm_manager" not in cfg:
-        cfg["vm_manager"] = {}
-    cfg["vm_manager"]["favorites"] = favorites
+    if "container_manager" not in cfg:
+        cfg["container_manager"] = {}
+    cfg["container_manager"]["favorites"] = favorites
     write_config(app_config, cfg)
 
     return web.json_response(actions)
@@ -675,17 +675,17 @@ async def test_sessions_list(request: web.Request) -> web.Response:
     return web.json_response(mgr.list_sessions())
 
 
-async def test_vm_containers_put(request: web.Request) -> web.Response:
-    """PUT /api/test/vm-containers — inject fake container list for E2E tests."""
+async def test_containers_put(request: web.Request) -> web.Response:
+    """PUT /api/test/containers — inject fake container list for E2E tests."""
     data = await request.json()
     containers = data if isinstance(data, list) else data.get("containers", [])
-    request.app["_test_vm_containers"] = containers
+    request.app["_test_containers"] = containers
     return web.json_response(containers)
 
 
-async def test_vm_containers_get(request: web.Request) -> web.Response:
-    """GET /api/test/vm-containers — read back fake container list."""
-    containers = request.app.get("_test_vm_containers", [])
+async def test_containers_get(request: web.Request) -> web.Response:
+    """GET /api/test/containers — read back fake container list."""
+    containers = request.app.get("_test_containers", [])
     return web.json_response(containers)
 
 
@@ -1736,13 +1736,13 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
     app.router.add_delete("/api/canvases/{name}", canvas_delete_handler)
     app.router.add_get("/api/widgets/system-info", widget_system_info_handler)
 
-    # VM Manager API
-    app.router.add_get("/api/vms/discover", vm_discover_handler)
-    app.router.add_get("/api/vms/favorites", vm_favorites_get_handler)
-    app.router.add_put("/api/vms/favorites", vm_favorites_put_handler)
-    app.router.add_post("/api/vms/{name}/start", vm_start_handler)
-    app.router.add_post("/api/vms/{name}/stop", vm_stop_handler)
-    app.router.add_put("/api/vms/favorites/{name}/actions", vm_favorites_actions_put_handler)
+    # Container Manager API
+    app.router.add_get("/api/containers/discover", container_discover_handler)
+    app.router.add_get("/api/containers/favorites", container_favorites_get_handler)
+    app.router.add_put("/api/containers/favorites", container_favorites_put_handler)
+    app.router.add_post("/api/containers/{name}/start", container_start_handler)
+    app.router.add_post("/api/containers/{name}/stop", container_stop_handler)
+    app.router.add_put("/api/containers/favorites/{name}/actions", container_favorites_actions_put_handler)
 
     app.router.add_get("/api/profiles", profiles_list_handler)
     app.router.add_get("/api/profiles/discover", profiles_discover_handler)
@@ -1791,8 +1791,8 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
         app.router.add_get("/api/test/session/{id}/status", test_session_status)
         app.router.add_delete("/api/test/session/{id}", test_session_delete)
         app.router.add_get("/api/test/sessions", test_sessions_list)
-        app.router.add_put("/api/test/vm-containers", test_vm_containers_put)
-        app.router.add_get("/api/test/vm-containers", test_vm_containers_get)
+        app.router.add_put("/api/test/containers", test_containers_put)
+        app.router.add_get("/api/test/containers", test_containers_get)
 
     # Lifecycle hooks
     async def on_startup(app: web.Application) -> None:

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -2439,8 +2439,8 @@ const WIDGET_REGISTRY = {
       }
     },
   },
-  'vm-manager': {
-    label: 'VM Manager',
+  'container-manager': {
+    label: 'Container Manager',
     defaultRefreshInterval: 15000,
     async render(body, card) {
       try {
@@ -2450,8 +2450,8 @@ const WIDGET_REGISTRY = {
         // (A third /api/config fetch was dropped in #163 review — it was
         // only used for the removed priority_profile lookup.)
         const [favsResp, discoverResp] = await Promise.all([
-          fetch('/api/vms/favorites'),
-          fetch('/api/vms/discover'),
+          fetch('/api/containers/favorites'),
+          fetch('/api/containers/discover'),
         ]);
         if (!favsResp.ok) throw new Error(`Favorites: HTTP ${favsResp.status}`);
         if (!discoverResp.ok) throw new Error(`Discover: HTTP ${discoverResp.status}`);
@@ -2476,9 +2476,9 @@ const WIDGET_REGISTRY = {
         html += '<div style="padding:4px 6px;border-bottom:1px solid #313244">';
         html += '<div style="display:flex;gap:4px;align-items:center">';
         html += '<span style="color:#6c7086;font-size:11px">＋ Add:</span>';
-        html += '<input type="text" data-vm-search placeholder="Search containers…" style="flex:1;background:#1e1e2e;border:1px solid #45475a;color:#cdd6f4;border-radius:4px;padding:3px 6px;font-size:11px;outline:none">';
+        html += '<input type="text" data-container-search placeholder="Search containers…" style="flex:1;background:#1e1e2e;border:1px solid #45475a;color:#cdd6f4;border-radius:4px;padding:3px 6px;font-size:11px;outline:none">';
         html += '</div>';
-        html += '<div data-vm-search-results style="max-height:120px;overflow-y:auto;margin-top:4px;display:none"></div>';
+        html += '<div data-container-search-results style="max-height:120px;overflow-y:auto;margin-top:4px;display:none"></div>';
         html += '</div>';
 
         // ── Favorites list ──
@@ -2500,11 +2500,11 @@ const WIDGET_REGISTRY = {
             if (missing) {
               html += `<span style="color:#6c7086;font-size:10px;font-style:italic">not found</span>`;
             } else if (state === 'offline') {
-              html += `<button data-vm-start="${esc(fav.name)}" style="background:#1e1e2e;border:1px solid #45475a;color:#a6e3a1;border-radius:4px;padding:2px 8px;cursor:pointer;font-size:10px" title="Start container">Start</button>`;
+              html += `<button data-container-start="${esc(fav.name)}" style="background:#1e1e2e;border:1px solid #45475a;color:#a6e3a1;border-radius:4px;padding:2px 8px;cursor:pointer;font-size:10px" title="Start container">Start</button>`;
             } else if (state === 'online') {
-              html += `<button data-vm-stop="${esc(fav.name)}" style="background:#1e1e2e;border:1px solid #45475a;color:#f38ba8;border-radius:4px;padding:2px 8px;cursor:pointer;font-size:10px" title="Stop container">Stop</button>`;
+              html += `<button data-container-stop="${esc(fav.name)}" style="background:#1e1e2e;border:1px solid #45475a;color:#f38ba8;border-radius:4px;padding:2px 8px;cursor:pointer;font-size:10px" title="Stop container">Stop</button>`;
             }
-            html += `<button data-vm-remove="${esc(fav.name)}" style="background:none;border:1px solid #45475a;color:#f38ba8;border-radius:4px;padding:2px 6px;cursor:pointer;font-size:10px" title="Remove from favorites">✕</button>`;
+            html += `<button data-container-remove="${esc(fav.name)}" style="background:none;border:1px solid #45475a;color:#f38ba8;border-radius:4px;padding:2px 6px;cursor:pointer;font-size:10px" title="Remove from favorites">✕</button>`;
             html += '</div>';
             if (image) {
               html += `<div style="font-size:10px;color:#6c7086;margin-bottom:3px;padding-left:18px">${esc(image)}</div>`;
@@ -2514,10 +2514,10 @@ const WIDGET_REGISTRY = {
             for (let i = 0; i < actions.length; i++) {
               const act = actions[i];
               const disabled = state !== 'online' ? 'opacity:0.4;pointer-events:none;' : '';
-              html += `<button data-vm-action="${esc(fav.name)}" data-action-idx="${i}" style="${disabled}background:#1e1e2e;border:1px solid #45475a;color:#89b4fa;border-radius:4px;padding:2px 8px;cursor:pointer;font-size:10px">${esc(act.label)}</button>`;
+              html += `<button data-container-action="${esc(fav.name)}" data-action-idx="${i}" style="${disabled}background:#1e1e2e;border:1px solid #45475a;color:#89b4fa;border-radius:4px;padding:2px 8px;cursor:pointer;font-size:10px">${esc(act.label)}</button>`;
             }
             // Configure actions button
-            html += `<button data-vm-configure="${esc(fav.name)}" style="background:none;border:1px dashed #45475a;color:#6c7086;border-radius:4px;padding:2px 6px;cursor:pointer;font-size:10px" title="Configure actions">⚙</button>`;
+            html += `<button data-container-configure="${esc(fav.name)}" style="background:none;border:1px dashed #45475a;color:#6c7086;border-radius:4px;padding:2px 6px;cursor:pointer;font-size:10px" title="Configure actions">⚙</button>`;
             html += '</div>';
             html += '</div>';
           }
@@ -2527,8 +2527,8 @@ const WIDGET_REGISTRY = {
         body.innerHTML = html;
 
         // ── Search functionality ──
-        const searchInput = body.querySelector('[data-vm-search]');
-        const searchResults = body.querySelector('[data-vm-search-results]');
+        const searchInput = body.querySelector('[data-container-search]');
+        const searchResults = body.querySelector('[data-container-search-results]');
         if (searchInput && searchResults) {
           const truncate = (s, n) => s.length > n ? s.slice(0, n) + '…' : s;
           const renderSearchResults = (q) => {
@@ -2541,7 +2541,7 @@ const WIDGET_REGISTRY = {
               searchResults.innerHTML = '<div style="padding:4px 6px;color:#6c7086;font-size:11px">No matches</div>';
             } else {
               searchResults.innerHTML = matches.map(c =>
-                `<div style="display:flex;align-items:center;gap:6px;padding:3px 6px;cursor:pointer;font-size:11px" data-vm-add="${esc(c.name)}">
+                `<div style="display:flex;align-items:center;gap:6px;padding:3px 6px;cursor:pointer;font-size:11px" data-container-add="${esc(c.name)}">
                   ${stateIcon(c.state)} <span style="flex:1" title="${esc(c.name)}">${esc(truncate(c.name, 20))}</span>
                   <span style="color:#6c7086;font-size:10px">${esc(truncate(c.image, 20))}</span>
                   <span style="color:#585b70;font-size:9px">${esc(c.status || '')}</span>
@@ -2562,11 +2562,11 @@ const WIDGET_REGISTRY = {
 
           // Add to favorites
           searchResults.addEventListener('click', async (e) => {
-            const addBtn = e.target.closest('[data-vm-add]');
+            const addBtn = e.target.closest('[data-container-add]');
             if (!addBtn) return;
-            const name = addBtn.getAttribute('data-vm-add');
+            const name = addBtn.getAttribute('data-container-add');
             const newFavs = [...favorites, { name, type: 'docker', actions: [] }];
-            await fetch('/api/vms/favorites', {
+            await fetch('/api/containers/favorites', {
               method: 'PUT',
               headers: {'Content-Type': 'application/json'},
               body: JSON.stringify(newFavs),
@@ -2576,11 +2576,11 @@ const WIDGET_REGISTRY = {
         }
 
         // ── Remove from favorites ──
-        body.querySelectorAll('[data-vm-remove]').forEach(btn => {
+        body.querySelectorAll('[data-container-remove]').forEach(btn => {
           btn.addEventListener('click', async () => {
-            const name = btn.getAttribute('data-vm-remove');
+            const name = btn.getAttribute('data-container-remove');
             const newFavs = favorites.filter(f => f.name !== name);
-            await fetch('/api/vms/favorites', {
+            await fetch('/api/containers/favorites', {
               method: 'PUT',
               headers: {'Content-Type': 'application/json'},
               body: JSON.stringify(newFavs),
@@ -2590,14 +2590,14 @@ const WIDGET_REGISTRY = {
         });
 
         // ── Start container ──
-        body.querySelectorAll('[data-vm-start]').forEach(btn => {
+        body.querySelectorAll('[data-container-start]').forEach(btn => {
           btn.addEventListener('click', async () => {
-            const name = btn.getAttribute('data-vm-start');
+            const name = btn.getAttribute('data-container-start');
             btn.textContent = '⏳';
             btn.disabled = true;
             let failed = false;
             try {
-              const r = await fetch(`/api/vms/${encodeURIComponent(name)}/start`, { method: 'POST' });
+              const r = await fetch(`/api/containers/${encodeURIComponent(name)}/start`, { method: 'POST' });
               if (!r.ok) {
                 const err = await r.json().catch(() => ({ error: `HTTP ${r.status}` }));
                 console.error('Failed to start:', err);
@@ -2621,14 +2621,14 @@ const WIDGET_REGISTRY = {
         });
 
         // ── Stop container ──
-        body.querySelectorAll('[data-vm-stop]').forEach(btn => {
+        body.querySelectorAll('[data-container-stop]').forEach(btn => {
           btn.addEventListener('click', async () => {
-            const name = btn.getAttribute('data-vm-stop');
+            const name = btn.getAttribute('data-container-stop');
             btn.textContent = '⏳';
             btn.disabled = true;
             let failed = false;
             try {
-              const r = await fetch(`/api/vms/${encodeURIComponent(name)}/stop`, { method: 'POST' });
+              const r = await fetch(`/api/containers/${encodeURIComponent(name)}/stop`, { method: 'POST' });
               if (!r.ok) {
                 const err = await r.json().catch(() => ({ error: `HTTP ${r.status}` }));
                 console.error('Failed to stop:', err);
@@ -2652,9 +2652,9 @@ const WIDGET_REGISTRY = {
         });
 
         // ── Action buttons (blueprint-based) ──
-        body.querySelectorAll('[data-vm-action]').forEach(btn => {
+        body.querySelectorAll('[data-container-action]').forEach(btn => {
           btn.addEventListener('click', async () => {
-            const name = btn.getAttribute('data-vm-action');
+            const name = btn.getAttribute('data-container-action');
             const idx = parseInt(btn.getAttribute('data-action-idx'), 10);
             const fav = favorites.find(f => f.name === name);
             if (!fav) return;
@@ -2710,9 +2710,9 @@ const WIDGET_REGISTRY = {
         });
 
         // ── Configure actions ──
-        body.querySelectorAll('[data-vm-configure]').forEach(btn => {
+        body.querySelectorAll('[data-container-configure]').forEach(btn => {
           btn.addEventListener('click', () => {
-            const name = btn.getAttribute('data-vm-configure');
+            const name = btn.getAttribute('data-container-configure');
             const fav = favorites.find(f => f.name === name);
             if (!fav) return;
 
@@ -2740,7 +2740,7 @@ const WIDGET_REGISTRY = {
               try {
                 const actions = JSON.parse(box.querySelector('[data-actions-json]').value);
                 const newFavs = favorites.map(f => f.name === name ? { ...f, actions } : f);
-                await fetch('/api/vms/favorites', {
+                await fetch('/api/containers/favorites', {
                   method: 'PUT',
                   headers: {'Content-Type': 'application/json'},
                   body: JSON.stringify(newFavs),
@@ -2808,8 +2808,10 @@ class WidgetCard extends Card {
   }
 
   static fromSerialized(data) {
+    // Back-compat: legacy 'vm-manager' widget type renamed to 'container-manager' (#201).
+    const widgetType = data.widgetType === 'vm-manager' ? 'container-manager' : data.widgetType;
     const card = new WidgetCard({
-      widgetType: data.widgetType,
+      widgetType: widgetType,
       x: data.x || 0,
       y: data.y || 0,
       w: data.w || 360,

--- a/docs/adr-blueprint-execution-model.md
+++ b/docs/adr-blueprint-execution-model.md
@@ -6,21 +6,21 @@
 
 supreme-claudemander is an RTS-style terminal canvas where devcontainer shells appear as draggable, resizable cards on a 4K canvas. The system uses a Python/aiohttp backend (`server.py`), a single-file HTML frontend (`static/index.html`), WebSocket-based real-time PTY streaming, and an EventBus for cross-card pub/sub. Cards are Python objects managed server-side by `CardRegistry`. The frontend is a rendering layer that reacts to server-pushed events over `/ws/control`.
 
-Today, setting up a multi-card workspace is entirely manual. A user who wants three Claude Code terminals across two containers must: start each container, wait for it to come online, open terminals one at a time, and type the Claude startup commands into each. VM Manager actions partially automate per-container button clicks, but there is no way to orchestrate a full multi-card, multi-container workspace setup in a single operation.
+Today, setting up a multi-card workspace is entirely manual. A user who wants three Claude Code terminals across two containers must: start each container, wait for it to come online, open terminals one at a time, and type the Claude startup commands into each. Container Manager actions partially automate per-container button clicks, but there is no way to orchestrate a full multi-card, multi-container workspace setup in a single operation.
 
 The blueprint system solves this by providing a declarative, replayable artifact that can bring a canvas from empty to a fully populated workspace through a single trigger.
 
 ### What the current system can do
 
-- **Start/stop containers** via `POST /api/vms/{name}/start|stop`
-- **Discover containers** via `GET /api/vms/discover`
+- **Start/stop containers** via `POST /api/containers/{name}/start|stop`
+- **Discover containers** via `GET /api/containers/discover`
 - **Spawn terminal cards** via `POST /api/claude/terminal/create` with `cmd`, `hub`, `container`, layout params (cmd is passed through verbatim — no placeholder interpolation; reference `/profiles/<main_profile_name>` directly, resolve slot name via `GET /api/profiles/main`, defaults to `main`, see #163)
 - **Spawn Canvas Claude cards** via `POST /api/canvas-claude/create` with `profile`, `container`, layout params
 - **Read main profile slot** via `GET /api/profiles/main` (returns `{main_profile_name, exists}`; renamed from `/api/profiles/priority` in #163)
 - **EventBus** emits `card:registered` / `card:unregistered` events and fans out to `/ws/control` WebSocket clients
 - **CARD_TYPE_REGISTRY** on the frontend provides `spawn()`, `deserialize()`, and `_mount()` for typed card instantiation
 - **ServiceCard** base class supports cards that perform a job and emit results via EventBus
-- **MCP server** exposes `open_terminal`, `vm_start_container`, `vm_discover_containers`, etc. as JSON-RPC tools for Claude Code agents running inside the canvas
+- **MCP server** exposes `open_terminal`, `container_start`, `container_discover`, etc. as JSON-RPC tools for Claude Code agents running inside the canvas
 
 ### What the current system cannot do
 
@@ -95,7 +95,7 @@ This pattern:
 - Provides a visible card on canvas during the wait (user sees "starting hub3...")
 - Is extensible: any new waiting concern gets a new transient service card type
 
-**Readiness probe**: `docker exec <name> true` retried with exponential backoff. `state == "online"` from `GET /api/vms/discover` is not sufficient — it reflects Docker daemon state, not exec-readiness. The probe verifies exec-readiness directly.
+**Readiness probe**: `docker exec <name> true` retried with exponential backoff. `state == "online"` from `GET /api/containers/discover` is not sufficient — it reflects Docker daemon state, not exec-readiness. The probe verifies exec-readiness directly.
 
 ---
 
@@ -271,7 +271,7 @@ This keeps v1 minimal: the card does its job, logs what happened, and gets out o
 - Blueprint schema: `{ name, description, parameters: [{name, provenance, type, default?}], steps: [{action, ...}] }`
 - Execution trace (in-memory on BlueprintCard): `{ run_id, blueprint_name, started_at, steps: [{action, inputs, output, status, started_at, duration_ms}] }`
 
-### Existing VM Manager actions
+### Existing Container Manager actions
 - Unchanged and independent. Blueprints are a higher-level orchestration that may call the same underlying APIs.
 
 ### Tests

--- a/docs/e2e-qa-workflow.md
+++ b/docs/e2e-qa-workflow.md
@@ -233,7 +233,7 @@ Round 3: Agent 4 (Runner) — final, report only, no more fixes
 - The feature exercises a subprocess (`docker ps`, `docker start`) — run the real command
 - The external system has multiple outcomes that matter (success, failure, timeout, partial response)
 
-**Example:** VM Manager calls `docker start <name>`. The test should start a real stopped container and verify it transitions to running. It should also test starting a non-existent container and verify the error is surfaced to the user.
+**Example:** Container Manager calls `docker start <name>`. The test should start a real stopped container and verify it transitions to running. It should also test starting a non-existent container and verify the error is surfaced to the user.
 
 ### Use mock when
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,8 +11,8 @@ across e2e test files:
 
 - ``clear_canvas``          — destroy all cards + clear canvas DOM, condition-based
 - ``open_context_menu``     — right-click viewport and wait for menu
-- ``refresh_vm_card``       — re-render VM Manager widgets, condition-based
-- ``cleanup_non_vm_cards``  — remove non-VM cards, condition-based
+- ``refresh_container_card``       — re-render Container Manager widgets, condition-based
+- ``cleanup_non_container_cards``  — remove non-VM cards, condition-based
 
 Test files should import these helpers from conftest rather than
 redefining them locally (see issue #165).
@@ -253,15 +253,15 @@ def open_context_menu(page, x=500, y=500):
     ).first.wait_for(state="visible", timeout=5000)
 
 
-def refresh_vm_card(page):
-    """Force re-render of all VM Manager widget cards; wait until the DOM
-    reflects the current ``/api/vms/favorites`` response.
+def refresh_container_card(page):
+    """Force re-render of all Container Manager widget cards; wait until the DOM
+    reflects the current ``/api/containers/favorites`` response.
 
-    The VM Manager ``render()`` method is async (fetches favorites +
+    The Container Manager ``render()`` method is async (fetches favorites +
     discover + config before writing ``body.innerHTML``).  We read the
     expected favorite names from the API and poll until every favorite has
-    a ``[data-vm-remove="<name>"]`` button in the DOM (or favorites is
-    empty and ``[data-vm-search]`` is present).  This replaces fixed
+    a ``[data-container-remove="<name>"]`` button in the DOM (or favorites is
+    empty and ``[data-container-search]`` is present).  This replaces fixed
     ``wait_for_timeout`` delays that were 1.5 s in mock tests and 3 s in
     real-Docker tests — both readily slower than the slowest observed
     render and prone to flakes on busy CI.
@@ -270,7 +270,7 @@ def refresh_vm_card(page):
         """() => {
         if (typeof cards !== 'undefined') {
             for (const card of cards) {
-                if (card.widgetType === 'vm-manager' && typeof card.render === 'function') {
+                if (card.widgetType === 'container-manager' && typeof card.render === 'function') {
                     card.render();
                 }
             }
@@ -278,24 +278,24 @@ def refresh_vm_card(page):
     }"""
     )
     # Fetch expected favorite names, then wait for them to appear.  Using
-    # data-vm-remove (one per favorite, regardless of state) is the most
+    # data-container-remove (one per favorite, regardless of state) is the most
     # reliable observable for render completion.
     page.wait_for_function(
         """async () => {
-            const r = await fetch('/api/vms/favorites');
+            const r = await fetch('/api/containers/favorites');
             if (!r.ok) return false;
             const favs = await r.json();
-            // The VM Manager card must be present in the DOM.
-            const searchInputs = document.querySelectorAll('[data-vm-search]');
+            // The Container Manager card must be present in the DOM.
+            const searchInputs = document.querySelectorAll('[data-container-search]');
             if (searchInputs.length === 0) return false;
             if (favs.length === 0) {
                 // Empty favorites: confirm no remove buttons exist (clean render) and search input present
-                const removeBtns = document.querySelectorAll('[data-vm-remove]');
+                const removeBtns = document.querySelectorAll('[data-container-remove]');
                 return removeBtns.length === 0 && searchInputs.length > 0;
             }
             for (const fav of favs) {
                 const btn = document.querySelector(
-                    `[data-vm-remove="${CSS.escape(fav.name)}"]`
+                    `[data-container-remove="${CSS.escape(fav.name)}"]`
                 );
                 if (!btn) return false;
             }
@@ -305,20 +305,20 @@ def refresh_vm_card(page):
     )
 
 
-def cleanup_non_vm_cards(page):
-    """Remove all cards except VM Manager widgets.
+def cleanup_non_container_cards(page):
+    """Remove all cards except Container Manager widgets.
 
     Terminal cards spawned by earlier tests can intercept pointer events
-    on the VM Manager card.  This helper destroys them and waits until
-    every remaining ``[data-card-id]`` contains a ``[data-vm-search]``
-    descendant (i.e. only VM Manager cards remain) — no fixed sleep.
+    on the Container Manager card.  This helper destroys them and waits until
+    every remaining ``[data-card-id]`` contains a ``[data-container-search]``
+    descendant (i.e. only Container Manager cards remain) — no fixed sleep.
     """
     page.evaluate(
         """() => {
         if (typeof cards === 'undefined') return;
         const toRemove = [];
         for (let i = cards.length - 1; i >= 0; i--) {
-            if (cards[i].widgetType !== 'vm-manager') {
+            if (cards[i].widgetType !== 'container-manager') {
                 if (typeof cards[i].destroy === 'function') cards[i].destroy();
                 toRemove.push(i);
             }
@@ -330,7 +330,7 @@ def cleanup_non_vm_cards(page):
         """() => {
             const all = document.querySelectorAll('[data-card-id]');
             return Array.from(all).every(
-                c => c.querySelector('[data-vm-search]') !== null
+                c => c.querySelector('[data-container-search]') !== null
             );
         }""",
         timeout=3000,

--- a/tests/e2e/real/test_container_manager_real_e2e.py
+++ b/tests/e2e/real/test_container_manager_real_e2e.py
@@ -1,6 +1,6 @@
-"""Playwright E2E tests for the VM Manager card using REAL Docker containers.
+"""Playwright E2E tests for the Container Manager card using REAL Docker containers.
 
-These tests launch the real backend with --dev-config vm-manager and exercise
+These tests launch the real backend with --dev-config container-manager and exercise
 the actual docker code paths (no test puppeting API, no mock container
 data). Real containers are created/destroyed per test or per module.
 
@@ -10,10 +10,10 @@ is not available.
 Run:
     pip install pytest-playwright playwright
     python -m playwright install chromium
-    python -m pytest tests/e2e/real/test_vm_manager_real_e2e.py -v
+    python -m pytest tests/e2e/real/test_container_manager_real_e2e.py -v
 
 Headed mode (shows the browser window):
-    HEADED=1 python -m pytest tests/e2e/real/test_vm_manager_real_e2e.py -v
+    HEADED=1 python -m pytest tests/e2e/real/test_container_manager_real_e2e.py -v
 """
 
 import subprocess
@@ -25,7 +25,7 @@ import pytest
 pw = pytest.importorskip("playwright")
 
 # Shared helpers live in conftest (single source of truth — see issue #165).
-from tests.e2e.conftest import cleanup_non_vm_cards, refresh_vm_card  # noqa: E402
+from tests.e2e.conftest import cleanup_non_container_cards, refresh_container_card  # noqa: E402
 
 
 # ── Markers & skip logic ─────────────────────────────────────────────────────
@@ -55,8 +55,8 @@ if not _docker_available():
 
 @pytest.fixture(scope="module")
 def dev_config_preset():
-    """Use the vm-manager dev-config preset."""
-    return "vm-manager"
+    """Use the container-manager dev-config preset."""
+    return "container-manager"
 
 
 @pytest.fixture(scope="module")
@@ -155,7 +155,7 @@ def set_favorites(page, port, favorites):
     """PUT favorites to the API."""
     page.evaluate(
         """async ([port, favorites]) => {
-        await fetch(`http://localhost:${port}/api/vms/favorites`, {
+        await fetch(`http://localhost:${port}/api/containers/favorites`, {
             method: 'PUT',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify(favorites),
@@ -169,29 +169,29 @@ def get_favorites(page, port):
     """GET favorites from the API."""
     return page.evaluate(
         """async (port) => {
-        const r = await fetch(`http://localhost:${port}/api/vms/favorites`);
+        const r = await fetch(`http://localhost:${port}/api/containers/favorites`);
         return r.json();
     }""",
         port,
     )
 
 
-def ensure_vm_card_exists(page):
-    """Ensure at least one VM Manager card exists; spawn one if needed.
+def ensure_container_card_exists(page):
+    """Ensure at least one Container Manager card exists; spawn one if needed.
 
     Condition-based: after spawning, waits for the observable
-    ``[data-vm-search]`` input to appear in the DOM rather than a fixed
+    ``[data-container-search]`` input to appear in the DOM rather than a fixed
     sleep.  Removes a flaky 2-second ``wait_for_timeout`` from the critical
     path of every test in this module (see issue #167).
     """
-    vm_cards = page.locator("[data-card-id]").filter(has=page.locator("[data-vm-search]"))
-    if vm_cards.count() > 0:
+    container_cards = page.locator("[data-card-id]").filter(has=page.locator("[data-container-search]"))
+    if container_cards.count() > 0:
         return
     # Spawn via JS directly
-    page.evaluate("() => CARD_TYPE_REGISTRY.spawn('widget', {widgetType: 'vm-manager', x: 100, y: 100})")
-    # Wait for the VM Manager card's search input — the first observable
+    page.evaluate("() => CARD_TYPE_REGISTRY.spawn('widget', {widgetType: 'container-manager', x: 100, y: 100})")
+    # Wait for the Container Manager card's search input — the first observable
     # DOM element written by its async render() — instead of sleeping.
-    page.wait_for_selector("[data-vm-search]", timeout=5000)
+    page.wait_for_selector("[data-container-search]", timeout=5000)
 
 
 def docker_inspect_state(name: str) -> str:
@@ -230,9 +230,9 @@ class TestRealDiscovery:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Verify running container has Online indicator
         running_online = page.evaluate(
@@ -265,11 +265,11 @@ class TestRealDiscovery:
         assert stopped_offline, "Stopped container should have an Offline indicator"
 
         # Running container should NOT have a Start button
-        start_btn_running = page.locator(f'[data-vm-start="{running_container}"]')
+        start_btn_running = page.locator(f'[data-container-start="{running_container}"]')
         assert start_btn_running.count() == 0, "Running container should not have a Start button"
 
         # Stopped container SHOULD have a Start button
-        start_btn_stopped = page.locator(f'[data-vm-start="{stopped_container}"]')
+        start_btn_stopped = page.locator(f'[data-container-start="{stopped_container}"]')
         assert start_btn_stopped.count() > 0, "Stopped container should have a Start button"
 
 
@@ -294,12 +294,12 @@ class TestRealStartContainer:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Verify Start button exists
-        start_btn = page.locator(f'[data-vm-start="{startable_container}"]')
+        start_btn = page.locator(f'[data-container-start="{startable_container}"]')
         assert start_btn.count() > 0, "Start button should exist for exited container"
 
         # Click Start
@@ -309,7 +309,7 @@ class TestRealStartContainer:
         # once the frontend re-renders after the successful start response.  This
         # replaces a flat 4-second sleep with a condition-based wait (issue #172).
         page.wait_for_function(
-            f"() => document.querySelectorAll('[data-vm-start=\"{startable_container}\"]').length === 0",
+            f"() => document.querySelectorAll('[data-container-start=\"{startable_container}\"]').length === 0",
             timeout=10000,
         )
 
@@ -319,7 +319,7 @@ class TestRealStartContainer:
         assert state == "running", f"Container should be running after start, got: {state}"
 
         # Verify Start button is gone after re-render (already waited above)
-        start_btn_after = page.locator(f'[data-vm-start="{startable_container}"]')
+        start_btn_after = page.locator(f'[data-container-start="{startable_container}"]')
         assert start_btn_after.count() == 0, "Start button should disappear after container starts"
 
         # Verify Online indicator appeared
@@ -367,23 +367,23 @@ class TestRealStartNonExistent:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # The bogus container is not in Docker's list — UI renders it as "missing"
         # with a "not found" label, NOT a Start button.
-        start_btn = page.locator(f'[data-vm-start="{bogus_name}"]')
+        start_btn = page.locator(f'[data-container-start="{bogus_name}"]')
         assert start_btn.count() == 0, "Start button should NOT exist for a container Docker has never seen"
 
         # Remove button must still be present so the user can clean up the stale entry
-        remove_btn = page.locator(f'[data-vm-remove="{bogus_name}"]')
+        remove_btn = page.locator(f'[data-container-remove="{bogus_name}"]')
         assert remove_btn.count() > 0, "Remove button should exist for unknown favorite"
 
         # The row should display "not found" to distinguish it from a stopped container
         parent_text = page.evaluate(
             """(name) => {
-                const btn = document.querySelector(`[data-vm-remove="${name}"]`);
+                const btn = document.querySelector(`[data-container-remove="${name}"]`);
                 return btn ? btn.closest('div').innerText : '';
             }""",
             bogus_name,
@@ -404,12 +404,12 @@ class TestRealSearch:
         # Start with empty favorites
         set_favorites(page, backend_port, [])
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Type a substring of the running container's name in search
-        search_input = page.locator("[data-vm-search]").first
+        search_input = page.locator("[data-container-search]").first
         search_input.click()
         # Use the e2e-vm-running prefix to find our container
         search_input.fill("e2e-vm-running")
@@ -417,14 +417,14 @@ class TestRealSearch:
         # Wait for the search results container to become visible and the Add
         # button for our target container to render (condition-based in place of
         # a 1-second sleep — issue #172).
-        page.locator("[data-vm-search-results]").first.wait_for(state="visible", timeout=5000)
-        page.locator(f'[data-vm-add="{running_container}"]').first.wait_for(state="visible", timeout=5000)
+        page.locator("[data-container-search-results]").first.wait_for(state="visible", timeout=5000)
+        page.locator(f'[data-container-add="{running_container}"]').first.wait_for(state="visible", timeout=5000)
 
-        results = page.locator("[data-vm-search-results]").first
+        results = page.locator("[data-container-search-results]").first
         assert results.is_visible(), "Search results should be visible"
 
         # Verify our running container appears in results with an Add button
-        add_btn = page.locator(f'[data-vm-add="{running_container}"]')
+        add_btn = page.locator(f'[data-container-add="{running_container}"]')
         assert add_btn.count() > 0, f"Container {running_container} should appear in search results"
 
         # Click add
@@ -435,7 +435,7 @@ class TestRealSearch:
         # then re-renders — we wait on the server-side source of truth.
         page.wait_for_function(
             f"""async () => {{
-                const r = await fetch('http://localhost:{backend_port}/api/vms/favorites');
+                const r = await fetch('http://localhost:{backend_port}/api/containers/favorites');
                 const favs = await r.json();
                 return favs.some(f => f.name === {running_container!r});
             }}""",
@@ -484,15 +484,15 @@ class TestRealTerminalAction:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Count existing cards
         initial_count = page.locator("[data-card-id]").count()
 
         # Click Terminal action button
-        action_btn = page.locator(f'[data-vm-action="{bash_container}"][data-action-idx="0"]')
+        action_btn = page.locator(f'[data-container-action="{bash_container}"][data-action-idx="0"]')
         action_btn.wait_for(state="visible", timeout=5000)
         action_btn.click()
 
@@ -546,9 +546,9 @@ class TestRealStatusAccuracy:
                 ],
             )
 
-            cleanup_non_vm_cards(page)
-            ensure_vm_card_exists(page)
-            refresh_vm_card(page)
+            cleanup_non_container_cards(page)
+            ensure_container_card_exists(page)
+            refresh_container_card(page)
 
             # Verify initially Online
             online = page.evaluate(
@@ -566,7 +566,7 @@ class TestRealStatusAccuracy:
             assert online, "Container should initially show Online"
 
             # No Start button while running
-            start_btn = page.locator(f'[data-vm-start="{name}"]')
+            start_btn = page.locator(f'[data-container-start="{name}"]')
             assert start_btn.count() == 0, "No Start button while container is running"
 
             # Stop the container externally
@@ -578,7 +578,7 @@ class TestRealStatusAccuracy:
             )
 
             # Re-render to pick up the state change
-            refresh_vm_card(page)
+            refresh_container_card(page)
 
             # Verify now Offline
             offline = page.evaluate(
@@ -596,7 +596,7 @@ class TestRealStatusAccuracy:
             assert offline, "Container should show Offline after external stop"
 
             # Start button should now appear
-            start_btn_after = page.locator(f'[data-vm-start="{name}"]')
+            start_btn_after = page.locator(f'[data-container-start="{name}"]')
             assert start_btn_after.count() > 0, "Start button should appear after container is stopped"
 
         finally:

--- a/tests/e2e/test_container_manager_e2e.py
+++ b/tests/e2e/test_container_manager_e2e.py
@@ -1,15 +1,15 @@
-"""Playwright E2E tests for the VM Manager card.
+"""Playwright E2E tests for the Container Manager card.
 
-These tests launch the real backend with --dev-config vm-manager and
-verify VM Manager widget interactions via Playwright in a browser.
+These tests launch the real backend with --dev-config container-manager and
+verify Container Manager widget interactions via Playwright in a browser.
 
 Run:
     pip install pytest-playwright playwright
     python -m playwright install chromium
-    python -m pytest tests/e2e/test_vm_manager_e2e.py -v
+    python -m pytest tests/e2e/test_container_manager_e2e.py -v
 
 Headed mode (shows the browser window):
-    HEADED=1 python -m pytest tests/e2e/test_vm_manager_e2e.py -v
+    HEADED=1 python -m pytest tests/e2e/test_container_manager_e2e.py -v
 """
 
 import json
@@ -20,7 +20,7 @@ import pytest
 pw = pytest.importorskip("playwright")
 
 # Shared helpers live in conftest (single source of truth — see issue #165).
-from tests.e2e.conftest import cleanup_non_vm_cards, refresh_vm_card  # noqa: E402
+from tests.e2e.conftest import cleanup_non_container_cards, refresh_container_card  # noqa: E402
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -28,8 +28,8 @@ from tests.e2e.conftest import cleanup_non_vm_cards, refresh_vm_card  # noqa: E4
 
 @pytest.fixture(scope="module")
 def dev_config_preset():
-    """Use the vm-manager dev-config preset."""
-    return "vm-manager"
+    """Use the container-manager dev-config preset."""
+    return "container-manager"
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -39,7 +39,7 @@ def seed_containers(page, backend_port, containers):
     """PUT fake container data to the test puppeting API."""
     page.evaluate(
         """async ([port, containers]) => {
-        await fetch(`http://localhost:${port}/api/test/vm-containers`, {
+        await fetch(`http://localhost:${port}/api/test/containers`, {
             method: 'PUT',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify(containers),
@@ -53,7 +53,7 @@ def set_favorites(page, backend_port, favorites):
     """PUT favorites to the API."""
     page.evaluate(
         """async ([port, favorites]) => {
-        await fetch(`http://localhost:${port}/api/vms/favorites`, {
+        await fetch(`http://localhost:${port}/api/containers/favorites`, {
             method: 'PUT',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify(favorites),
@@ -67,18 +67,18 @@ def get_favorites(page, backend_port):
     """GET favorites from the API."""
     return page.evaluate(
         """async (port) => {
-        const r = await fetch(`http://localhost:${port}/api/vms/favorites`);
+        const r = await fetch(`http://localhost:${port}/api/containers/favorites`);
         return r.json();
     }""",
         backend_port,
     )
 
 
-def get_test_vm_containers(page, backend_port):
+def get_test_containers(page, backend_port):
     """GET test VM containers from the puppeting API."""
     return page.evaluate(
         """async (port) => {
-        const r = await fetch(`http://localhost:${port}/api/test/vm-containers`);
+        const r = await fetch(`http://localhost:${port}/api/test/containers`);
         return r.json();
     }""",
         backend_port,
@@ -99,45 +99,45 @@ def save_blueprint(page, backend_port, name, blueprint_def):
     )
 
 
-def ensure_vm_card_exists(page):
-    """Ensure at least one VM Manager card exists; spawn one if needed."""
-    vm_cards = page.locator("[data-card-id]").filter(has=page.locator("[data-vm-search]"))
-    if vm_cards.count() > 0:
+def ensure_container_card_exists(page):
+    """Ensure at least one Container Manager card exists; spawn one if needed."""
+    container_cards = page.locator("[data-card-id]").filter(has=page.locator("[data-container-search]"))
+    if container_cards.count() > 0:
         return
     # Spawn from context menu
     viewport = page.locator("#viewport")
     viewport.click(button="right", position={"x": 500, "y": 100})
     ctx_menu = page.locator("#context-menu")
     ctx_menu.wait_for(state="visible", timeout=3000)
-    widget_item = ctx_menu.locator('[data-widget="vm-manager"]')
+    widget_item = ctx_menu.locator('[data-widget="container-manager"]')
     if widget_item.count() > 0:
         widget_item.click()
-        # Wait for VM Manager card to appear in DOM (render complete => has search input).
+        # Wait for Container Manager card to appear in DOM (render complete => has search input).
         try:
             page.wait_for_function(
-                "() => document.querySelectorAll('[data-card-id] [data-vm-search]').length > 0",
+                "() => document.querySelectorAll('[data-card-id] [data-container-search]').length > 0",
                 timeout=5000,
             )
         except Exception:
             pass  # Fall through to JS-direct fallback below.
     # Fallback: if context menu approach didn't spawn a card, use JS directly
-    vm_cards_after = page.locator("[data-card-id]").filter(has=page.locator("[data-vm-search]"))
-    if vm_cards_after.count() == 0:
-        page.evaluate("() => CARD_TYPE_REGISTRY.spawn('widget', {widgetType: 'vm-manager', x: 100, y: 100})")
+    container_cards_after = page.locator("[data-card-id]").filter(has=page.locator("[data-container-search]"))
+    if container_cards_after.count() == 0:
+        page.evaluate("() => CARD_TYPE_REGISTRY.spawn('widget', {widgetType: 'container-manager', x: 100, y: 100})")
         page.wait_for_function(
-            "() => document.querySelectorAll('[data-card-id] [data-vm-search]').length > 0",
+            "() => document.querySelectorAll('[data-card-id] [data-container-search]').length > 0",
             timeout=5000,
         )
 
 
-# ── S1: VM Manager widget spawns from context menu ───────────────────────────
+# ── S1: Container Manager widget spawns from context menu ───────────────────────────
 
 
 class TestVmManagerSpawn:
-    """S1: VM Manager widget spawns from context menu."""
+    """S1: Container Manager widget spawns from context menu."""
 
-    def test_vm_manager_spawns_from_context_menu(self, page, backend_port):
-        """Right-click canvas, click vm-manager widget, verify card appears."""
+    def test_container_manager_spawns_from_context_menu(self, page, backend_port):
+        """Right-click canvas, click container-manager widget, verify card appears."""
         # Clear all cards first
         page.evaluate(
             """() => {
@@ -165,24 +165,24 @@ class TestVmManagerSpawn:
         ctx_menu = page.locator("#context-menu")
         ctx_menu.wait_for(state="visible", timeout=3000)
 
-        # Find and click vm-manager widget item
-        widget_item = ctx_menu.locator('[data-widget="vm-manager"]')
-        assert widget_item.count() > 0, "vm-manager should be in context menu"
+        # Find and click container-manager widget item
+        widget_item = ctx_menu.locator('[data-widget="container-manager"]')
+        assert widget_item.count() > 0, "container-manager should be in context menu"
         widget_item.click()
 
-        # Wait for the VM Manager card to be added and rendered (search input present).
+        # Wait for the Container Manager card to be added and rendered (search input present).
         page.wait_for_function(
-            "() => document.querySelectorAll('[data-card-id] [data-vm-search]').length > 0",
+            "() => document.querySelectorAll('[data-card-id] [data-container-search]').length > 0",
             timeout=5000,
         )
 
         # Verify card appeared
         new_cards = page.locator("[data-card-id]")
-        assert new_cards.count() > 0, "A card should appear after clicking vm-manager"
+        assert new_cards.count() > 0, "A card should appear after clicking container-manager"
 
         # Verify card contains the VM search input
-        search_input = page.locator("[data-vm-search]")
-        assert search_input.count() > 0, "Card should contain [data-vm-search]"
+        search_input = page.locator("[data-container-search]")
+        assert search_input.count() > 0, "Card should contain [data-container-search]"
 
 
 # ── S2: Favorites render with correct status indicators ──────────────────────
@@ -242,8 +242,8 @@ class TestVmFavoritesStatus:
             ],
         )
 
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Verify green dot for alpha (online)
         alpha_dot = page.evaluate(
@@ -260,17 +260,17 @@ class TestVmFavoritesStatus:
         assert alpha_dot is not None, "Alpha should have an Online indicator"
 
         # Verify beta has a Start button
-        start_btn = page.locator('[data-vm-start="beta"]')
+        start_btn = page.locator('[data-container-start="beta"]')
         assert start_btn.count() > 0, "Offline container beta should have Start button"
 
         # Verify alpha action buttons are NOT dimmed
-        alpha_action = page.locator('[data-vm-action="alpha"]').first
+        alpha_action = page.locator('[data-container-action="alpha"]').first
         if alpha_action.count() > 0:
             style = alpha_action.get_attribute("style") or ""
             assert "opacity:0.4" not in style, "Online container actions should not be dimmed"
 
         # Verify beta action buttons ARE dimmed
-        beta_action = page.locator('[data-vm-action="beta"]').first
+        beta_action = page.locator('[data-container-action="beta"]').first
         if beta_action.count() > 0:
             style = beta_action.get_attribute("style") or ""
             assert "opacity:0.4" in style or "pointer-events:none" in style, (
@@ -331,24 +331,24 @@ class TestVmSearch:
             ],
         )
 
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Click search input and type
-        search_input = page.locator("[data-vm-search]").first
+        search_input = page.locator("[data-container-search]").first
         search_input.click()
         search_input.fill("containerB")
 
         # Wait for search results to render the expected row.
         page.wait_for_function(
-            "() => document.querySelector('[data-vm-add=\"containerB\"]') !== null",
+            "() => document.querySelector('[data-container-add=\"containerB\"]') !== null",
             timeout=3000,
         )
-        results = page.locator("[data-vm-search-results]").first
+        results = page.locator("[data-container-search-results]").first
         assert results.is_visible(), "Search results should be visible"
 
         # Verify containerB appears in results
-        add_btn = page.locator('[data-vm-add="containerB"]')
+        add_btn = page.locator('[data-container-add="containerB"]')
         assert add_btn.count() > 0, "containerB should appear in search results"
 
         # Click add — readiness check first, then await DOM confirmation.
@@ -356,7 +356,7 @@ class TestVmSearch:
         add_btn.click()
         # Wait for the new favorite's remove button to appear (render complete).
         page.wait_for_function(
-            "() => document.querySelector('[data-vm-remove=\"containerB\"]') !== null",
+            "() => document.querySelector('[data-container-remove=\"containerB\"]') !== null",
             timeout=5000,
         )
 
@@ -411,17 +411,17 @@ class TestVmRemoveFavorite:
             ],
         )
 
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Click remove for web-app
-        remove_btn = page.locator('[data-vm-remove="web-app"]')
+        remove_btn = page.locator('[data-container-remove="web-app"]')
         assert remove_btn.count() > 0, "Remove button for web-app should exist"
         remove_btn.wait_for(state="visible", timeout=3000)
         remove_btn.click()
         # Wait for the row to leave the DOM (render reflects the removal).
         page.wait_for_function(
-            "() => document.querySelector('[data-vm-remove=\"web-app\"]') === null",
+            "() => document.querySelector('[data-container-remove=\"web-app\"]') === null",
             timeout=5000,
         )
 
@@ -432,7 +432,7 @@ class TestVmRemoveFavorite:
         assert "db-server" in fav_names, "db-server should remain"
 
         # Verify web-app row is gone from the card
-        remove_btn_after = page.locator('[data-vm-remove="web-app"]')
+        remove_btn_after = page.locator('[data-container-remove="web-app"]')
         assert remove_btn_after.count() == 0, "web-app row should be gone from card"
 
 
@@ -469,11 +469,11 @@ class TestVmStartContainer:
             ],
         )
 
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Verify Start button exists
-        start_btn = page.locator('[data-vm-start="my-db"]')
+        start_btn = page.locator('[data-container-start="my-db"]')
         assert start_btn.count() > 0, "Start button for my-db should exist"
 
         # Click Start
@@ -482,18 +482,18 @@ class TestVmStartContainer:
 
         # Wait for container state transition + VM card re-render (Start button gone).
         page.wait_for_function(
-            "() => document.querySelector('[data-vm-start=\"my-db\"]') === null",
+            "() => document.querySelector('[data-container-start=\"my-db\"]') === null",
             timeout=10000,
         )
 
         # Verify container is now online via API
-        containers = get_test_vm_containers(page, backend_port)
+        containers = get_test_containers(page, backend_port)
         my_db = next((c for c in containers if c["name"] == "my-db"), None)
         assert my_db is not None, "my-db should exist in test containers"
         assert my_db["state"] == "online", "my-db should be online after start"
 
         # Verify Start button is gone (online containers don't show it)
-        start_btn_after = page.locator('[data-vm-start="my-db"]')
+        start_btn_after = page.locator('[data-container-start="my-db"]')
         assert start_btn_after.count() == 0, "Start button should be gone for online container"
 
 
@@ -538,14 +538,14 @@ class TestVmTerminalAction:
             ],
         )
 
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Count existing cards
         initial_count = page.locator("[data-card-id]").count()
 
         # Click Terminal action
-        action_btn = page.locator('[data-vm-action="dev-web"][data-action-idx="0"]')
+        action_btn = page.locator('[data-container-action="dev-web"][data-action-idx="0"]')
         assert action_btn.count() > 0, "Terminal action button should exist"
         action_btn.click()
 
@@ -603,15 +603,15 @@ class TestVmBlueprintAction:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Count existing cards
         initial_count = page.locator("[data-card-id]").count()
 
         # Click second action (index 1)
-        action_btn = page.locator('[data-vm-action="claude-dev"][data-action-idx="1"]')
+        action_btn = page.locator('[data-container-action="claude-dev"][data-action-idx="1"]')
         assert action_btn.count() > 0, "Second blueprint action button should exist"
         action_btn.click()
 
@@ -665,11 +665,11 @@ class TestVmActionsDisabledOffline:
             ],
         )
 
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Verify action buttons are dimmed
-        action_btn = page.locator('[data-vm-action="stopped-svc"]').first
+        action_btn = page.locator('[data-container-action="stopped-svc"]').first
         assert action_btn.count() > 0, "Action button should exist for stopped-svc"
         style = action_btn.get_attribute("style") or ""
         assert "opacity:0.4" in style or "pointer-events:none" in style, (
@@ -725,12 +725,12 @@ class TestVmConfigureActions:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Click configure button
-        configure_btn = page.locator('[data-vm-configure="my-app"]')
+        configure_btn = page.locator('[data-container-configure="my-app"]')
         assert configure_btn.count() > 0, "Configure button should exist"
         configure_btn.wait_for(state="visible", timeout=3000)
         configure_btn.click()
@@ -817,12 +817,12 @@ class TestVmConfigureCancel:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Open configure dialog
-        configure_btn = page.locator('[data-vm-configure="cancel-test"]')
+        configure_btn = page.locator('[data-container-configure="cancel-test"]')
         configure_btn.wait_for(state="visible", timeout=3000)
         configure_btn.click()
         # Wait for the dialog overlay to appear.
@@ -886,12 +886,12 @@ class TestVmConfigureInvalidJson:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Open configure dialog
-        configure_btn = page.locator('[data-vm-configure="json-test"]')
+        configure_btn = page.locator('[data-container-configure="json-test"]')
         configure_btn.wait_for(state="visible", timeout=3000)
         configure_btn.click()
         # Wait for the dialog overlay to appear.
@@ -957,26 +957,26 @@ class TestVmSearchFilters:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Type search query
-        search_input = page.locator("[data-vm-search]").first
+        search_input = page.locator("[data-container-search]").first
         search_input.click()
         search_input.fill("aa")
         # Wait for the search results container to render with the expected rows
         # (aaa + aac; aab is filtered because it's a favorite).
         page.wait_for_function(
-            "() => document.querySelector('[data-vm-add=\"aaa\"]') !== null"
-            " && document.querySelector('[data-vm-add=\"aac\"]') !== null",
+            "() => document.querySelector('[data-container-add=\"aaa\"]') !== null"
+            " && document.querySelector('[data-container-add=\"aac\"]') !== null",
             timeout=3000,
         )
 
         # Verify search results
-        add_aaa = page.locator('[data-vm-add="aaa"]')
-        add_aab = page.locator('[data-vm-add="aab"]')
-        add_aac = page.locator('[data-vm-add="aac"]')
+        add_aaa = page.locator('[data-container-add="aaa"]')
+        add_aab = page.locator('[data-container-add="aab"]')
+        add_aac = page.locator('[data-container-add="aac"]')
 
         assert add_aaa.count() > 0, "aaa should be in search results"
         assert add_aab.count() == 0, "aab should NOT be in search results (already a favorite)"
@@ -994,15 +994,15 @@ class TestVmEmptyFavorites:
         seed_containers(page, backend_port, [])
         set_favorites(page, backend_port, [])
 
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Verify placeholder text
         body_text = page.evaluate(
             """() => {
             const cards = document.querySelectorAll('[data-card-id]');
             for (const card of cards) {
-                const search = card.querySelector('[data-vm-search]');
+                const search = card.querySelector('[data-container-search]');
                 if (search) return card.textContent;
             }
             return '';
@@ -1011,14 +1011,14 @@ class TestVmEmptyFavorites:
         assert "No favorites yet" in body_text, "Empty favorites should show placeholder message"
 
 
-# ── S14: VM Manager card persists across canvas save/reload ──────────────────
+# ── S14: Container Manager card persists across canvas save/reload ──────────────────
 
 
 class TestVmPersistence:
-    """S14: VM Manager card persists across canvas save/reload."""
+    """S14: Container Manager card persists across canvas save/reload."""
 
-    def test_vm_card_persists_reload(self, page, backend_port):
-        """Save canvas, reload, verify VM Manager card is still present."""
+    def test_container_card_persists_reload(self, page, backend_port):
+        """Save canvas, reload, verify Container Manager card is still present."""
         # Seed some data so the card has content
         seed_containers(
             page,
@@ -1044,20 +1044,20 @@ class TestVmPersistence:
             ],
         )
 
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
-        # Verify VM Manager card exists
-        vm_search = page.locator("[data-vm-search]")
-        assert vm_search.count() > 0, "VM Manager card should exist before save"
+        # Verify Container Manager card exists
+        container_search = page.locator("[data-container-search]")
+        assert container_search.count() > 0, "Container Manager card should exist before save"
 
         # Issue #194 flipped the card default to unstarred, and saveLayout()
-        # now excludes unstarred cards.  Star the VM Manager card explicitly
+        # now excludes unstarred cards.  Star the Container Manager card explicitly
         # so it persists across reload.
         page.evaluate(
             """() => {
-            const vmCard = cards.find(c => c.el && c.el.querySelector('[data-vm-search]'));
-            if (!vmCard) throw new Error('VM Manager card not found in cards[]');
+            const vmCard = cards.find(c => c.el && c.el.querySelector('[data-container-search]'));
+            if (!vmCard) throw new Error('Container Manager card not found in cards[]');
             if (!vmCard.starred) {
                 const btn = vmCard.el.querySelector(`[data-star="${vmCard.id}"]`);
                 if (btn) btn.click(); else vmCard.starred = true;
@@ -1076,20 +1076,20 @@ class TestVmPersistence:
         page.goto(f"http://localhost:{backend_port}")
         page.wait_for_load_state("networkidle")
         page.wait_for_selector("#canvas", timeout=10000)
-        # Wait for boot-complete signal and for the VM Manager card to be restored
+        # Wait for boot-complete signal and for the Container Manager card to be restored
         # (search input present), rather than a fixed 3-second sleep.
         page.wait_for_function(
             "() => window.__claudeRtsBootComplete === true",
             timeout=15000,
         )
         page.wait_for_function(
-            "() => document.querySelectorAll('[data-vm-search]').length > 0",
+            "() => document.querySelectorAll('[data-container-search]').length > 0",
             timeout=10000,
         )
 
-        # Verify VM Manager card is restored
-        vm_search_after = page.locator("[data-vm-search]")
-        assert vm_search_after.count() > 0, "VM Manager card should persist after reload"
+        # Verify Container Manager card is restored
+        container_search_after = page.locator("[data-container-search]")
+        assert container_search_after.count() > 0, "Container Manager card should persist after reload"
 
 
 # ── S15: Stop button stops running container ───────────────────────────────
@@ -1125,16 +1125,16 @@ class TestVmStopContainer:
             ],
         )
 
-        cleanup_non_vm_cards(page)
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        cleanup_non_container_cards(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Verify Stop button exists for running container
-        stop_btn = page.locator('[data-vm-stop="running-svc"]')
+        stop_btn = page.locator('[data-container-stop="running-svc"]')
         assert stop_btn.count() > 0, "Stop button for running-svc should exist"
 
         # Verify no Start button for running container
-        start_btn = page.locator('[data-vm-start="running-svc"]')
+        start_btn = page.locator('[data-container-start="running-svc"]')
         assert start_btn.count() == 0, "Start button should not exist for online container"
 
         # Click Stop
@@ -1144,22 +1144,22 @@ class TestVmStopContainer:
         # Wait for container state transition + VM card re-render: Stop button
         # should vanish and Start button should appear.
         page.wait_for_function(
-            "() => document.querySelector('[data-vm-stop=\"running-svc\"]') === null"
-            " && document.querySelector('[data-vm-start=\"running-svc\"]') !== null",
+            "() => document.querySelector('[data-container-stop=\"running-svc\"]') === null"
+            " && document.querySelector('[data-container-start=\"running-svc\"]') !== null",
             timeout=10000,
         )
 
         # Verify container is now offline via API
-        containers = get_test_vm_containers(page, backend_port)
+        containers = get_test_containers(page, backend_port)
         svc = next((c for c in containers if c["name"] == "running-svc"), None)
         assert svc is not None, "running-svc should exist in test containers"
         assert svc["state"] == "offline", "running-svc should be offline after stop"
 
         # Verify Stop button is gone and Start button appeared
-        stop_btn_after = page.locator('[data-vm-stop="running-svc"]')
+        stop_btn_after = page.locator('[data-container-stop="running-svc"]')
         assert stop_btn_after.count() == 0, "Stop button should be gone for offline container"
 
-        start_btn_after = page.locator('[data-vm-start="running-svc"]')
+        start_btn_after = page.locator('[data-container-start="running-svc"]')
         assert start_btn_after.count() > 0, "Start button should appear for offline container"
 
 
@@ -1199,34 +1199,34 @@ class TestVmSearchMetadata:
         # No favorites so all show in search
         set_favorites(page, backend_port, [])
 
-        ensure_vm_card_exists(page)
-        refresh_vm_card(page)
+        ensure_container_card_exists(page)
+        refresh_container_card(page)
 
         # Type search query
-        search_input = page.locator("[data-vm-search]").first
+        search_input = page.locator("[data-container-search]").first
         search_input.click()
         search_input.fill("svc-")
         # Wait for the search-results container to render all 3 expected rows.
         page.wait_for_function(
-            "() => document.querySelectorAll('[data-vm-search-results] [data-vm-add]').length === 3",
+            "() => document.querySelectorAll('[data-container-search-results] [data-container-add]').length === 3",
             timeout=3000,
         )
 
         # Get all search result rows
-        results = page.locator("[data-vm-search-results] [data-vm-add]")
+        results = page.locator("[data-container-search-results] [data-container-add]")
         count = results.count()
         assert count == 3, f"Should find 3 results, got {count}"
 
         # Verify online containers appear first (svc-beta and svc-gamma before svc-alpha)
-        first_name = results.nth(0).get_attribute("data-vm-add")
-        second_name = results.nth(1).get_attribute("data-vm-add")
-        third_name = results.nth(2).get_attribute("data-vm-add")
+        first_name = results.nth(0).get_attribute("data-container-add")
+        second_name = results.nth(1).get_attribute("data-container-add")
+        third_name = results.nth(2).get_attribute("data-container-add")
         assert first_name in ("svc-beta", "svc-gamma"), f"First result should be online, got {first_name}"
         assert second_name in ("svc-beta", "svc-gamma"), f"Second result should be online, got {second_name}"
         assert third_name == "svc-alpha", f"Third result should be offline svc-alpha, got {third_name}"
 
         # Verify search results contain image text
-        result_html = page.locator("[data-vm-search-results]").first.inner_html()
+        result_html = page.locator("[data-container-search-results]").first.inner_html()
         assert "node:18" in result_html, "Search results should show image name"
         assert "postgres:15" in result_html, "Search results should show image name"
 

--- a/tests/test_blueprint_card.py
+++ b/tests/test_blueprint_card.py
@@ -159,7 +159,7 @@ async def test_step_get_priority_profile_legacy_action_rejected(tmp_path, monkey
 
 async def test_step_discover_containers(tmp_path, monkeypatch):
     app, bus, mgr, reg = _make_app(tmp_path, monkeypatch)
-    app["_test_vm_containers"] = [
+    app["_test_containers"] = [
         {"name": "hub1", "state": "online"},
         {"name": "hub2", "state": "offline"},
     ]
@@ -184,7 +184,7 @@ async def test_step_discover_containers(tmp_path, monkeypatch):
 
 async def test_step_start_container(tmp_path, monkeypatch):
     app, bus, mgr, reg = _make_app(tmp_path, monkeypatch)
-    app["_test_vm_containers"] = [
+    app["_test_containers"] = [
         {"name": "hub1", "state": "offline"},
     ]
 
@@ -201,7 +201,7 @@ async def test_step_start_container(tmp_path, monkeypatch):
 
     assert card.variables.get("c") == "hub1"
     # Container should have been flipped to online
-    assert app["_test_vm_containers"][0]["state"] == "online"
+    assert app["_test_containers"][0]["state"] == "online"
     mgr.stop_all()
 
 
@@ -520,7 +520,7 @@ async def test_parameters_from_context(tmp_path, monkeypatch):
 
 async def test_for_each_step(tmp_path, monkeypatch):
     app, bus, mgr, reg = _make_app(tmp_path, monkeypatch)
-    app["_test_vm_containers"] = [
+    app["_test_containers"] = [
         {"name": "hub1", "state": "online"},
         {"name": "hub2", "state": "online"},
     ]

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -1,4 +1,4 @@
-"""Tests for VM Manager API endpoints."""
+"""Tests for Container Manager API endpoints."""
 
 from unittest.mock import patch, AsyncMock
 
@@ -30,7 +30,7 @@ def _mock_docker_ps(stdout_text, returncode=0):
     return mock_proc
 
 
-async def test_vm_discover_returns_containers(client):
+async def test_container_discover_returns_containers(client):
     docker_output = (
         "web-app|running|node:18|Up 2 hours\n"
         "db-server|exited|postgres:15|Exited (0) 3 hours ago\n"
@@ -38,7 +38,7 @@ async def test_vm_discover_returns_containers(client):
     )
     mock_proc = _mock_docker_ps(docker_output)
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
-        resp = await client.get("/api/vms/discover")
+        resp = await client.get("/api/containers/discover")
 
     assert resp.status == 200
     data = await resp.json()
@@ -52,28 +52,28 @@ async def test_vm_discover_returns_containers(client):
     assert data[2]["state"] == "online"
 
 
-async def test_vm_discover_empty(client):
+async def test_container_discover_empty(client):
     mock_proc = _mock_docker_ps("")
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
-        resp = await client.get("/api/vms/discover")
+        resp = await client.get("/api/containers/discover")
 
     assert resp.status == 200
     data = await resp.json()
     assert data == []
 
 
-async def test_vm_discover_docker_failure(client):
+async def test_container_discover_docker_failure(client):
     mock_proc = _mock_docker_ps("", returncode=1)
     mock_proc.communicate = AsyncMock(return_value=(b"", b"Cannot connect to Docker"))
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
-        resp = await client.get("/api/vms/discover")
+        resp = await client.get("/api/containers/discover")
 
     assert resp.status == 500
     data = await resp.json()
     assert "error" in data
 
 
-async def test_vm_discover_normalizes_states(client):
+async def test_container_discover_normalizes_states(client):
     docker_output = (
         "c1|running|img:1|Up 1h\n"
         "c2|created|img:2|Created\n"
@@ -83,7 +83,7 @@ async def test_vm_discover_normalizes_states(client):
     )
     mock_proc = _mock_docker_ps(docker_output)
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
-        resp = await client.get("/api/vms/discover")
+        resp = await client.get("/api/containers/discover")
 
     data = await resp.json()
     states = {c["name"]: c["state"] for c in data}
@@ -97,20 +97,20 @@ async def test_vm_discover_normalizes_states(client):
 # ── Favorites CRUD ───────────────────────────────────────────────────────────
 
 
-async def test_vm_favorites_empty_by_default(client):
-    resp = await client.get("/api/vms/favorites")
+async def test_container_favorites_empty_by_default(client):
+    resp = await client.get("/api/containers/favorites")
     assert resp.status == 200
     data = await resp.json()
     assert data == []
 
 
-async def test_vm_favorites_put_and_get(client):
+async def test_container_favorites_put_and_get(client):
     favorites = [
         {"name": "web-app", "type": "docker", "actions": [{"label": "Terminal", "type": "terminal"}]},
         {"name": "db-server", "type": "docker", "actions": []},
     ]
     resp = await client.put(
-        "/api/vms/favorites",
+        "/api/containers/favorites",
         json=favorites,
     )
     assert resp.status == 200
@@ -118,17 +118,17 @@ async def test_vm_favorites_put_and_get(client):
     assert len(data) == 2
 
     # Verify persistence
-    resp2 = await client.get("/api/vms/favorites")
+    resp2 = await client.get("/api/containers/favorites")
     data2 = await resp2.json()
     assert len(data2) == 2
     assert data2[0]["name"] == "web-app"
     assert data2[1]["name"] == "db-server"
 
 
-async def test_vm_favorites_put_with_wrapper(client):
+async def test_container_favorites_put_with_wrapper(client):
     """Accept favorites wrapped in {"favorites": [...]}."""
     resp = await client.put(
-        "/api/vms/favorites",
+        "/api/containers/favorites",
         json={"favorites": [{"name": "test-container", "type": "docker"}]},
     )
     assert resp.status == 200
@@ -137,18 +137,18 @@ async def test_vm_favorites_put_with_wrapper(client):
     assert data[0]["name"] == "test-container"
 
 
-async def test_vm_favorites_persists_in_config(client, app):
+async def test_container_favorites_persists_in_config(client, app):
     favorites = [{"name": "my-vm", "type": "docker"}]
-    await client.put("/api/vms/favorites", json=favorites)
+    await client.put("/api/containers/favorites", json=favorites)
 
-    # Read raw config to verify vm_manager section
+    # Read raw config to verify container_manager section
     app_config = app["app_config"]
     raw = config.read_config(app_config)
-    assert "vm_manager" in raw
-    assert raw["vm_manager"]["favorites"] == favorites
+    assert "container_manager" in raw
+    assert raw["container_manager"]["favorites"] == favorites
 
 
-async def test_vm_favorites_with_custom_actions(client):
+async def test_container_favorites_with_custom_actions(client):
     favorites = [
         {
             "name": "devcontainer-web",
@@ -164,10 +164,10 @@ async def test_vm_favorites_with_custom_actions(client):
             ],
         }
     ]
-    resp = await client.put("/api/vms/favorites", json=favorites)
+    resp = await client.put("/api/containers/favorites", json=favorites)
     assert resp.status == 200
 
-    resp2 = await client.get("/api/vms/favorites")
+    resp2 = await client.get("/api/containers/favorites")
     data = await resp2.json()
     assert len(data[0]["actions"]) == 2
     assert data[0]["actions"][1]["shell_prefix"].startswith("cd /workspace/web")
@@ -177,12 +177,12 @@ async def test_vm_favorites_with_custom_actions(client):
 # ── Start container ──────────────────────────────────────────────────────────
 
 
-async def test_vm_start_success(client):
+async def test_container_start_success(client):
     mock_proc = AsyncMock()
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"web-app\n", b""))
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
-        resp = await client.post("/api/vms/web-app/start")
+        resp = await client.post("/api/containers/web-app/start")
 
     assert resp.status == 200
     data = await resp.json()
@@ -190,12 +190,12 @@ async def test_vm_start_success(client):
     assert data["state"] == "online"
 
 
-async def test_vm_start_failure(client):
+async def test_container_start_failure(client):
     mock_proc = AsyncMock()
     mock_proc.returncode = 1
     mock_proc.communicate = AsyncMock(return_value=(b"", b"No such container"))
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
-        resp = await client.post("/api/vms/nonexistent/start")
+        resp = await client.post("/api/containers/nonexistent/start")
 
     assert resp.status == 500
     data = await resp.json()
@@ -208,12 +208,12 @@ async def test_vm_start_failure(client):
 # ── Stop container ──────────────────────────────────────────────────────────
 
 
-async def test_vm_stop_success(client):
+async def test_container_stop_success(client):
     mock_proc = AsyncMock()
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"web-app\n", b""))
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
-        resp = await client.post("/api/vms/web-app/stop")
+        resp = await client.post("/api/containers/web-app/stop")
 
     assert resp.status == 200
     data = await resp.json()
@@ -221,28 +221,28 @@ async def test_vm_stop_success(client):
     assert data["state"] == "offline"
 
 
-async def test_vm_stop_failure(client):
+async def test_container_stop_failure(client):
     mock_proc = AsyncMock()
     mock_proc.returncode = 1
     mock_proc.communicate = AsyncMock(return_value=(b"", b"No such container"))
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
-        resp = await client.post("/api/vms/nonexistent/stop")
+        resp = await client.post("/api/containers/nonexistent/stop")
 
     assert resp.status == 500
     data = await resp.json()
     assert "error" in data
 
 
-async def test_vm_stop_test_mode(client):
+async def test_container_stop_test_mode(client):
     """In test mode, stop flips container state to offline."""
     # Inject test containers via the app directly
     containers = [
         {"name": "web-app", "state": "online", "image": "node:18", "status": "Up 2h"},
     ]
     app = client.app
-    app["_test_vm_containers"] = containers
+    app["_test_containers"] = containers
 
-    resp = await client.post("/api/vms/web-app/stop")
+    resp = await client.post("/api/containers/web-app/stop")
     assert resp.status == 200
     data = await resp.json()
     assert data["name"] == "web-app"
@@ -252,27 +252,27 @@ async def test_vm_stop_test_mode(client):
     assert containers[0]["state"] == "offline"
 
 
-async def test_vm_stop_test_mode_not_found(client):
+async def test_container_stop_test_mode_not_found(client):
     """In test mode, stop returns 500 when container name doesn't exist in mock list."""
     containers = [
         {"name": "other-container", "state": "online", "image": "ubuntu:22.04", "status": "Up 1h"},
     ]
     app = client.app
-    app["_test_vm_containers"] = containers
+    app["_test_containers"] = containers
 
-    resp = await client.post("/api/vms/nonexistent-container/stop")
+    resp = await client.post("/api/containers/nonexistent-container/stop")
     assert resp.status == 500
     data = await resp.json()
     assert "error" in data
 
 
-async def test_vm_stop_with_timeout(client):
+async def test_container_stop_with_timeout(client):
     """Stop with optional timeout query param."""
     mock_proc = AsyncMock()
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"web-app\n", b""))
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
-        resp = await client.post("/api/vms/web-app/stop?timeout=30")
+        resp = await client.post("/api/containers/web-app/stop?timeout=30")
 
     assert resp.status == 200
     # Verify -t flag was passed
@@ -281,9 +281,9 @@ async def test_vm_stop_with_timeout(client):
     assert "30" in call_args
 
 
-async def test_vm_stop_invalid_timeout(client):
+async def test_container_stop_invalid_timeout(client):
     """Stop with invalid timeout returns 400."""
-    resp = await client.post("/api/vms/web-app/stop?timeout=invalid")
+    resp = await client.post("/api/containers/web-app/stop?timeout=invalid")
     assert resp.status == 400
     body = await resp.json()
     assert "timeout" in body["error"]
@@ -292,80 +292,80 @@ async def test_vm_stop_invalid_timeout(client):
 # ── created_by=canvas-claude guard (issue #200) ────────────────────────────
 
 
-async def test_vm_stop_guard_allows_when_label_matches(client):
+async def test_container_stop_guard_allows_when_label_matches(client):
     """MCP-origin stop (via=canvas-claude) succeeds when container carries
     created_by=canvas-claude label."""
     app = client.app
-    app["_test_vm_containers"] = [
+    app["_test_containers"] = [
         {"name": "cc-owned", "state": "online", "image": "ubuntu:24.04", "status": "Up 1m"},
     ]
-    app["_test_vm_labels"] = {"cc-owned": {"created_by": "canvas-claude"}}
+    app["_test_container_labels"] = {"cc-owned": {"created_by": "canvas-claude"}}
 
-    resp = await client.post("/api/vms/cc-owned/stop?via=canvas-claude")
+    resp = await client.post("/api/containers/cc-owned/stop?via=canvas-claude")
     assert resp.status == 200
     data = await resp.json()
     assert data["state"] == "offline"
 
 
-async def test_vm_stop_guard_rejects_when_label_missing(client):
+async def test_container_stop_guard_rejects_when_label_missing(client):
     """MCP-origin stop returns 403 not_canvas_claude_owned when the container
     has no created_by label."""
     app = client.app
-    app["_test_vm_containers"] = [
+    app["_test_containers"] = [
         {"name": "human-owned", "state": "online", "image": "ubuntu:24.04", "status": "Up 1h"},
     ]
-    app["_test_vm_labels"] = {"human-owned": {}}  # no created_by
+    app["_test_container_labels"] = {"human-owned": {}}  # no created_by
 
-    resp = await client.post("/api/vms/human-owned/stop?via=canvas-claude")
+    resp = await client.post("/api/containers/human-owned/stop?via=canvas-claude")
     assert resp.status == 403
     data = await resp.json()
     assert data["error"] == "not_canvas_claude_owned"
     assert data["container"] == "human-owned"
 
     # Guard must NOT have flipped state
-    assert app["_test_vm_containers"][0]["state"] == "online"
+    assert app["_test_containers"][0]["state"] == "online"
 
 
-async def test_vm_stop_guard_rejects_when_label_mismatched(client):
+async def test_container_stop_guard_rejects_when_label_mismatched(client):
     """MCP-origin stop is rejected when created_by is set to a different value."""
     app = client.app
-    app["_test_vm_containers"] = [
+    app["_test_containers"] = [
         {"name": "other", "state": "online", "image": "x", "status": "Up"},
     ]
-    app["_test_vm_labels"] = {"other": {"created_by": "someone-else"}}
+    app["_test_container_labels"] = {"other": {"created_by": "someone-else"}}
 
-    resp = await client.post("/api/vms/other/stop?via=canvas-claude")
+    resp = await client.post("/api/containers/other/stop?via=canvas-claude")
     assert resp.status == 403
     data = await resp.json()
     assert data["error"] == "not_canvas_claude_owned"
 
 
-async def test_vm_stop_human_ui_path_bypasses_guard(client):
+async def test_container_stop_human_ui_path_bypasses_guard(client):
     """UI requests (no via/header) are not guarded — humans may stop any
     container they own, including ones without the canvas-claude label."""
     app = client.app
-    app["_test_vm_containers"] = [
+    app["_test_containers"] = [
         {"name": "human-owned", "state": "online", "image": "x", "status": "Up"},
     ]
-    app["_test_vm_labels"] = {"human-owned": {}}  # no label
+    app["_test_container_labels"] = {"human-owned": {}}  # no label
 
-    resp = await client.post("/api/vms/human-owned/stop")
+    resp = await client.post("/api/containers/human-owned/stop")
     assert resp.status == 200
     data = await resp.json()
     assert data["state"] == "offline"
 
 
-async def test_vm_stop_guard_via_spawner_header(client):
+async def test_container_stop_guard_via_spawner_header(client):
     """The X-Canvas-Claude-Spawner header is an alternate origin signal
     equivalent to ?via=canvas-claude."""
     app = client.app
-    app["_test_vm_containers"] = [
+    app["_test_containers"] = [
         {"name": "human-owned", "state": "online", "image": "x", "status": "Up"},
     ]
-    app["_test_vm_labels"] = {"human-owned": {}}
+    app["_test_container_labels"] = {"human-owned": {}}
 
     resp = await client.post(
-        "/api/vms/human-owned/stop",
+        "/api/containers/human-owned/stop",
         headers={"X-Canvas-Claude-Spawner": "card-abc123"},
     )
     assert resp.status == 403
@@ -373,16 +373,16 @@ async def test_vm_stop_guard_via_spawner_header(client):
     assert data["error"] == "not_canvas_claude_owned"
 
 
-async def test_vm_stop_guard_docker_inspect_failure_maps_to_500(client):
+async def test_container_stop_guard_docker_inspect_failure_maps_to_500(client):
     """When docker inspect itself fails, guard returns 500 with a stable error
     key (docker_inspect_failed) rather than silently allowing or rejecting."""
-    # Not setting _test_vm_labels → real docker inspect path. Mock subprocess
+    # Not setting _test_container_labels → real docker inspect path. Mock subprocess
     # to simulate docker inspect returning non-zero.
     mock_proc = AsyncMock()
     mock_proc.returncode = 1
     mock_proc.communicate = AsyncMock(return_value=(b"", b"No such object: ghost"))
     with patch("claude_rts.server.asyncio.create_subprocess_exec", return_value=mock_proc):
-        resp = await client.post("/api/vms/ghost/stop?via=canvas-claude")
+        resp = await client.post("/api/containers/ghost/stop?via=canvas-claude")
 
     assert resp.status == 500
     data = await resp.json()
@@ -393,35 +393,35 @@ async def test_vm_stop_guard_docker_inspect_failure_maps_to_500(client):
 # ── Per-container actions endpoint ──────────────────────────────────────────
 
 
-async def test_vm_favorites_actions_put(client):
+async def test_container_favorites_actions_put(client):
     """PUT actions for a specific favorite container."""
     # First create a favorite
     favorites = [
         {"name": "devcontainer-web", "type": "docker", "actions": [{"label": "Terminal", "type": "terminal"}]},
     ]
-    await client.put("/api/vms/favorites", json=favorites)
+    await client.put("/api/containers/favorites", json=favorites)
 
     # Update actions
     new_actions = [
         {"label": "Terminal", "type": "terminal"},
         {"label": "Claude", "type": "terminal", "shell_prefix": "cd /workspace && claude"},
     ]
-    resp = await client.put("/api/vms/favorites/devcontainer-web/actions", json=new_actions)
+    resp = await client.put("/api/containers/favorites/devcontainer-web/actions", json=new_actions)
     assert resp.status == 200
     data = await resp.json()
     assert len(data) == 2
     assert data[1]["label"] == "Claude"
 
     # Verify persisted
-    resp2 = await client.get("/api/vms/favorites")
+    resp2 = await client.get("/api/containers/favorites")
     favs = await resp2.json()
     assert len(favs[0]["actions"]) == 2
 
 
-async def test_vm_favorites_actions_not_found(client):
+async def test_container_favorites_actions_not_found(client):
     """PUT actions for a nonexistent favorite returns 404."""
     resp = await client.put(
-        "/api/vms/favorites/nonexistent/actions",
+        "/api/containers/favorites/nonexistent/actions",
         json=[{"label": "Terminal", "type": "terminal"}],
     )
     assert resp.status == 404
@@ -433,10 +433,10 @@ async def test_vm_favorites_actions_not_found(client):
 # ── Route registration ───────────────────────────────────────────────────────
 
 
-async def test_vm_routes_registered(app):
+async def test_container_routes_registered(app):
     routes = [r.resource.canonical for r in app.router.routes() if hasattr(r, "resource")]
-    assert "/api/vms/discover" in routes
-    assert "/api/vms/favorites" in routes
-    assert "/api/vms/{name}/start" in routes
-    assert "/api/vms/{name}/stop" in routes
-    assert "/api/vms/favorites/{name}/actions" in routes
+    assert "/api/containers/discover" in routes
+    assert "/api/containers/favorites" in routes
+    assert "/api/containers/{name}/start" in routes
+    assert "/api/containers/{name}/stop" in routes
+    assert "/api/containers/favorites/{name}/actions" in routes

--- a/tests/test_container_starter_card.py
+++ b/tests/test_container_starter_card.py
@@ -39,7 +39,7 @@ def test_container_name():
 async def test_start_success_emits_ready():
     """ContainerStarterCard starts container and emits container:ready:{name}."""
     app, bus, reg = _make_app_dict()
-    app["_test_vm_containers"] = [{"name": "hub1", "state": "offline"}]
+    app["_test_containers"] = [{"name": "hub1", "state": "offline"}]
 
     events = []
 
@@ -61,13 +61,13 @@ async def test_start_success_emits_ready():
     assert ready_events[0][1]["container_name"] == "hub1"
 
     # Container state should be "online"
-    assert app["_test_vm_containers"][0]["state"] == "online"
+    assert app["_test_containers"][0]["state"] == "online"
 
 
 async def test_self_close_after_success():
     """Card unregisters from CardRegistry after successful start."""
     app, bus, reg = _make_app_dict()
-    app["_test_vm_containers"] = [{"name": "hub1", "state": "offline"}]
+    app["_test_containers"] = [{"name": "hub1", "state": "offline"}]
 
     card = ContainerStarterCard(container_name="hub1", app=app)
     card.bus = bus
@@ -89,7 +89,7 @@ async def test_self_close_after_success():
 async def test_start_failure_emits_failed():
     """Starting a nonexistent container emits container:failed:{name}."""
     app, bus, reg = _make_app_dict()
-    app["_test_vm_containers"] = []  # No containers
+    app["_test_containers"] = []  # No containers
 
     events = []
 
@@ -113,7 +113,7 @@ async def test_start_failure_emits_failed():
 async def test_self_close_after_failure():
     """Card unregisters from CardRegistry even after failure."""
     app, bus, reg = _make_app_dict()
-    app["_test_vm_containers"] = []
+    app["_test_containers"] = []
 
     card = ContainerStarterCard(container_name="nope", app=app)
     card.bus = bus
@@ -132,7 +132,7 @@ async def test_self_close_after_failure():
 async def test_stop_cancels_task():
     """stop() cancels the running task."""
     app, bus, reg = _make_app_dict()
-    app["_test_vm_containers"] = [{"name": "hub1", "state": "offline"}]
+    app["_test_containers"] = [{"name": "hub1", "state": "offline"}]
 
     card = ContainerStarterCard(container_name="hub1", app=app)
     card.bus = bus

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -22,14 +22,14 @@ from claude_rts.mcp_server import (
     tool_rename_terminal,
     tool_set_recovery_script,
     tool_get_recovery_script,
-    tool_vm_discover_containers,
-    tool_vm_get_favorites,
-    tool_vm_set_container_actions,
-    tool_vm_add_favorite,
-    tool_vm_get_container_actions,
-    tool_vm_append_container_action,
-    tool_vm_start_container,
-    tool_vm_stop_container,
+    tool_container_discover,
+    tool_container_get_favorites,
+    tool_container_set_actions,
+    tool_container_add_favorite,
+    tool_container_get_actions,
+    tool_container_append_action,
+    tool_container_start,
+    tool_container_stop,
     tool_blueprint_list,
     tool_blueprint_get,
     tool_blueprint_save,
@@ -198,14 +198,14 @@ def test_handle_request_tools_list():
         "rename_terminal",
         "set_recovery_script",
         "get_recovery_script",
-        "vm_discover_containers",
-        "vm_get_favorites",
-        "vm_set_container_actions",
-        "vm_get_container_actions",
-        "vm_append_container_action",
-        "vm_start_container",
-        "vm_stop_container",
-        "vm_add_favorite",
+        "container_discover",
+        "container_get_favorites",
+        "container_set_actions",
+        "container_get_actions",
+        "container_append_action",
+        "container_start",
+        "container_stop",
+        "container_add_favorite",
         "blueprint_list",
         "blueprint_get",
         "blueprint_save",
@@ -295,70 +295,70 @@ def test_handle_request_unknown_method_notification():
     assert resp is None
 
 
-# ── VM Manager MCP tool tests ──────────────────────────────────────────────
+# ── Container Manager MCP tool tests ──────────────────────────────────────────────
 
 
-def test_vm_discover_containers():
-    """vm_discover_containers GETs /api/vms/discover and formats result."""
+def test_container_discover():
+    """container_discover GETs /api/containers/discover and formats result."""
     containers = [
         {"name": "web-app", "state": "online", "image": "node:18", "status": "Up 2 hours"},
         {"name": "db-server", "state": "offline", "image": "postgres:15", "status": "Exited 3h ago"},
     ]
     mock_resp = make_mock_response(containers)
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
-        result = tool_vm_discover_containers({})
+        result = tool_container_discover({})
     assert "web-app" in result
     assert "online" in result
     assert "db-server" in result
     assert "node:18" in result
     call_args = mock_open.call_args
     req = call_args[0][0]
-    assert "/api/vms/discover" in req.full_url
+    assert "/api/containers/discover" in req.full_url
 
 
-def test_vm_discover_containers_empty():
-    """vm_discover_containers returns message when no containers."""
+def test_container_discover_empty():
+    """container_discover returns message when no containers."""
     mock_resp = make_mock_response([])
     with patch("urllib.request.urlopen", return_value=mock_resp):
-        result = tool_vm_discover_containers({})
+        result = tool_container_discover({})
     assert "no" in result.lower() or result == ""
 
 
-def test_vm_get_favorites():
-    """vm_get_favorites GETs /api/vms/favorites and returns JSON."""
+def test_container_get_favorites():
+    """container_get_favorites GETs /api/containers/favorites and returns JSON."""
     favorites = [
         {"name": "web-app", "type": "docker", "actions": [{"label": "Dev Shell", "blueprint": "dev-shell"}]},
     ]
     mock_resp = make_mock_response(favorites)
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
-        result = tool_vm_get_favorites({})
+        result = tool_container_get_favorites({})
     parsed = json.loads(result)
     assert len(parsed) == 1
     assert parsed[0]["name"] == "web-app"
     req = mock_open.call_args[0][0]
-    assert "/api/vms/favorites" in req.full_url
+    assert "/api/containers/favorites" in req.full_url
 
 
-def test_vm_set_container_actions():
-    """vm_set_container_actions PUTs to /api/vms/favorites/{name}/actions."""
+def test_container_set_actions():
+    """container_set_actions PUTs to /api/containers/favorites/{name}/actions."""
     actions = [{"label": "Dev Shell", "blueprint": "dev-shell"}, {"label": "Claude", "blueprint": "claude-session"}]
     mock_resp = make_mock_response(actions)
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
-        result = tool_vm_set_container_actions({"container": "web-app", "actions": actions})
+        result = tool_container_set_actions({"container": "web-app", "actions": actions})
     assert "web-app" in result
     req = mock_open.call_args[0][0]
-    assert "/api/vms/favorites/web-app/actions" in req.full_url
+    assert "/api/containers/favorites/web-app/actions" in req.full_url
     assert req.method == "PUT"
 
 
-def test_vm_set_container_actions_missing_container():
-    """vm_set_container_actions raises ValueError when container is missing."""
+def test_container_set_actions_missing_container():
+    """container_set_actions raises ValueError when container is missing."""
     with pytest.raises(ValueError):
-        tool_vm_set_container_actions({})
+        tool_container_set_actions({})
 
 
-def test_vm_add_favorite():
-    """vm_add_favorite GETs favorites, appends, PUTs back with empty default actions."""
+def test_container_add_favorite():
+    """container_add_favorite GETs favorites, appends, PUTs back with empty default actions."""
     existing = [{"name": "old-container", "type": "docker", "actions": []}]
     get_resp = make_mock_response(existing)
     put_resp = make_mock_response(existing + [{"name": "new-container", "type": "docker", "actions": []}])
@@ -371,7 +371,7 @@ def test_vm_add_favorite():
         return resp
 
     with patch("urllib.request.urlopen", side_effect=mock_urlopen) as mock_open:
-        result = tool_vm_add_favorite({"name": "new-container"})
+        result = tool_container_add_favorite({"name": "new-container"})
     assert "new-container" in result
     assert "Added" in result
     # Verify PUT was called with the new container and empty actions
@@ -382,35 +382,35 @@ def test_vm_add_favorite():
     assert put_body[1]["actions"] == []
 
 
-def test_vm_add_favorite_already_exists():
-    """vm_add_favorite returns message when container already a favorite."""
+def test_container_add_favorite_already_exists():
+    """container_add_favorite returns message when container already a favorite."""
     existing = [{"name": "web-app", "type": "docker", "actions": []}]
     mock_resp = make_mock_response(existing)
     with patch("urllib.request.urlopen", return_value=mock_resp):
-        result = tool_vm_add_favorite({"name": "web-app"})
+        result = tool_container_add_favorite({"name": "web-app"})
     assert "already" in result.lower()
 
 
-def test_vm_add_favorite_missing_name():
-    """vm_add_favorite raises ValueError when name is missing."""
+def test_container_add_favorite_missing_name():
+    """container_add_favorite raises ValueError when name is missing."""
     with pytest.raises(ValueError):
-        tool_vm_add_favorite({})
+        tool_container_add_favorite({})
 
 
-def test_tools_list_includes_vm_and_blueprint_tools():
+def test_tools_list_includes_container_and_blueprint_tools():
     """tools/list response includes all tools (8 terminal + 8 VM + 5 blueprint)."""
     msg = {"jsonrpc": "2.0", "id": 10, "method": "tools/list", "params": {}}
     resp = handle_request(msg)
     tools = resp["result"]["tools"]
     names = {t["name"] for t in tools}
-    assert "vm_discover_containers" in names
-    assert "vm_get_favorites" in names
-    assert "vm_set_container_actions" in names
-    assert "vm_get_container_actions" in names
-    assert "vm_append_container_action" in names
-    assert "vm_start_container" in names
-    assert "vm_stop_container" in names
-    assert "vm_add_favorite" in names
+    assert "container_discover" in names
+    assert "container_get_favorites" in names
+    assert "container_set_actions" in names
+    assert "container_get_actions" in names
+    assert "container_append_action" in names
+    assert "container_start" in names
+    assert "container_stop" in names
+    assert "container_add_favorite" in names
     assert "blueprint_list" in names
     assert "blueprint_get" in names
     assert "blueprint_save" in names
@@ -423,42 +423,42 @@ def test_tools_list_includes_vm_and_blueprint_tools():
     assert len(names) == 22
 
 
-# ── vm_get_container_actions ──────────────────────────────────────────────
+# ── container_get_actions ──────────────────────────────────────────────
 
 
-def test_vm_get_container_actions_returns_one():
-    """vm_get_container_actions filters favorites to one container's actions."""
+def test_container_get_actions_returns_one():
+    """container_get_actions filters favorites to one container's actions."""
     favorites = [
         {"name": "web-app", "type": "docker", "actions": [{"label": "Dev Shell", "blueprint": "dev-shell"}]},
         {"name": "db", "type": "docker", "actions": [{"label": "DB Admin", "blueprint": "db-admin"}]},
     ]
     mock_resp = make_mock_response(favorites)
     with patch("urllib.request.urlopen", return_value=mock_resp):
-        result = tool_vm_get_container_actions({"container": "web-app"})
+        result = tool_container_get_actions({"container": "web-app"})
     parsed = json.loads(result)
     assert parsed == [{"label": "Dev Shell", "blueprint": "dev-shell"}]
 
 
-def test_vm_get_container_actions_unknown_raises():
-    """vm_get_container_actions raises ValueError with 'Favorite not found' for unknown container."""
+def test_container_get_actions_unknown_raises():
+    """container_get_actions raises ValueError with 'Favorite not found' for unknown container."""
     favorites = [{"name": "web-app", "type": "docker", "actions": []}]
     mock_resp = make_mock_response(favorites)
     with patch("urllib.request.urlopen", return_value=mock_resp):
         with pytest.raises(ValueError, match="Favorite not found: nonexistent-xyz"):
-            tool_vm_get_container_actions({"container": "nonexistent-xyz"})
+            tool_container_get_actions({"container": "nonexistent-xyz"})
 
 
-def test_vm_get_container_actions_missing_container():
-    """vm_get_container_actions raises ValueError when container is missing."""
+def test_container_get_actions_missing_container():
+    """container_get_actions raises ValueError when container is missing."""
     with pytest.raises(ValueError, match="container is required"):
-        tool_vm_get_container_actions({})
+        tool_container_get_actions({})
 
 
-# ── vm_append_container_action ────────────────────────────────────────────
+# ── container_append_action ────────────────────────────────────────────
 
 
-def test_vm_append_container_action_preserves_existing():
-    """vm_append_container_action GETs current actions, appends, PUTs atomically."""
+def test_container_append_action_preserves_existing():
+    """container_append_action GETs current actions, appends, PUTs atomically."""
     existing_favs = [
         {
             "name": "web-app",
@@ -481,14 +481,14 @@ def test_vm_append_container_action_preserves_existing():
 
     new_action = {"label": "Claude", "blueprint": "claude-session"}
     with patch("urllib.request.urlopen", side_effect=mock_urlopen):
-        result = tool_vm_append_container_action({"container": "web-app", "action": new_action})
+        result = tool_container_append_action({"container": "web-app", "action": new_action})
 
     assert "web-app" in result
     # Verify GET then PUT
     assert calls[0].method == "GET"
-    assert "/api/vms/favorites" in calls[0].full_url
+    assert "/api/containers/favorites" in calls[0].full_url
     assert calls[1].method == "PUT"
-    assert "/api/vms/favorites/web-app/actions" in calls[1].full_url
+    assert "/api/containers/favorites/web-app/actions" in calls[1].full_url
     put_body = json.loads(calls[1].data.decode("utf-8"))
     assert len(put_body) == 2
     assert put_body[0]["label"] == "Dev Shell"
@@ -496,90 +496,90 @@ def test_vm_append_container_action_preserves_existing():
     assert put_body[1]["blueprint"] == "claude-session"
 
 
-def test_vm_append_container_action_unknown_container():
-    """vm_append_container_action raises ValueError for unknown container."""
+def test_container_append_action_unknown_container():
+    """container_append_action raises ValueError for unknown container."""
     favorites = [{"name": "web-app", "type": "docker", "actions": []}]
     mock_resp = make_mock_response(favorites)
     with patch("urllib.request.urlopen", return_value=mock_resp):
         with pytest.raises(ValueError, match="Favorite not found: nonexistent-xyz"):
-            tool_vm_append_container_action(
+            tool_container_append_action(
                 {"container": "nonexistent-xyz", "action": {"label": "X", "blueprint": "test"}}
             )
 
 
-def test_vm_append_container_action_missing_action():
-    """vm_append_container_action raises ValueError when action is missing."""
+def test_container_append_action_missing_action():
+    """container_append_action raises ValueError when action is missing."""
     with pytest.raises(ValueError, match="action"):
-        tool_vm_append_container_action({"container": "web-app"})
+        tool_container_append_action({"container": "web-app"})
 
 
-def test_vm_append_container_action_missing_container():
-    """vm_append_container_action raises ValueError when container is missing."""
+def test_container_append_action_missing_container():
+    """container_append_action raises ValueError when container is missing."""
     with pytest.raises(ValueError, match="container is required"):
-        tool_vm_append_container_action({"action": {"label": "X", "blueprint": "test"}})
+        tool_container_append_action({"action": {"label": "X", "blueprint": "test"}})
 
 
-# ── vm_start_container / vm_stop_container ────────────────────────────────
+# ── container_start / container_stop ────────────────────────────────
 
 
-def test_vm_start_container_calls_rest():
-    """vm_start_container POSTs to /api/vms/{name}/start."""
+def test_container_start_calls_rest():
+    """container_start POSTs to /api/containers/{name}/start."""
     mock_resp = make_mock_response({"name": "foo-dev", "state": "online"})
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
-        result = tool_vm_start_container({"name": "foo-dev"})
+        result = tool_container_start({"name": "foo-dev"})
     assert "foo-dev" in result
     req = mock_open.call_args[0][0]
     assert req.method == "POST"
-    assert "/api/vms/foo-dev/start" in req.full_url
+    assert "/api/containers/foo-dev/start" in req.full_url
 
 
-def test_vm_start_container_missing_name():
-    """vm_start_container raises ValueError when name is missing."""
+def test_container_start_missing_name():
+    """container_start raises ValueError when name is missing."""
     with pytest.raises(ValueError, match="name is required"):
-        tool_vm_start_container({})
+        tool_container_start({})
 
 
-def test_vm_stop_container_calls_rest():
-    """vm_stop_container POSTs to /api/vms/{name}/stop with via=canvas-claude."""
+def test_container_stop_calls_rest():
+    """container_stop POSTs to /api/containers/{name}/stop with via=canvas-claude."""
     mock_resp = make_mock_response({"name": "foo-dev", "state": "offline"})
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
-        result = tool_vm_stop_container({"name": "foo-dev"})
+        result = tool_container_stop({"name": "foo-dev"})
     assert "foo-dev" in result
     req = mock_open.call_args[0][0]
     assert req.method == "POST"
-    assert "/api/vms/foo-dev/stop" in req.full_url
+    assert "/api/containers/foo-dev/stop" in req.full_url
     # Guard origin signal must be present so server enforces created_by label
     assert "via=canvas-claude" in req.full_url
 
 
-def test_vm_stop_container_with_timeout():
-    """vm_stop_container passes timeout query param when provided."""
+def test_container_stop_with_timeout():
+    """container_stop passes timeout query param when provided."""
     mock_resp = make_mock_response({"name": "foo-dev", "state": "offline"})
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
-        tool_vm_stop_container({"name": "foo-dev", "timeout": 30})
+        tool_container_stop({"name": "foo-dev", "timeout": 30})
     req = mock_open.call_args[0][0]
     assert "timeout=30" in req.full_url
     assert "via=canvas-claude" in req.full_url
 
 
-def test_vm_stop_container_always_sends_origin_signal():
-    """vm_stop_container MUST carry via=canvas-claude so the server enforces
+def test_container_stop_always_sends_origin_signal():
+    """container_stop MUST carry via=canvas-claude so the server enforces
     the created_by=canvas-claude Docker-label guard. Regression guard for #200."""
     mock_resp = make_mock_response({"name": "foo", "state": "offline"})
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
-        tool_vm_stop_container({"name": "foo"})
+        tool_container_stop({"name": "foo"})
     req = mock_open.call_args[0][0]
     assert "via=canvas-claude" in req.full_url
 
 
-def test_vm_stop_container_propagates_403_guard_rejection():
+def test_container_stop_propagates_403_guard_rejection():
     """When the server returns 403 not_canvas_claude_owned, the MCP tool surfaces
     the error instead of reporting success."""
     import urllib.error
 
     err_body = json.dumps({"error": "not_canvas_claude_owned", "container": "foo"}).encode()
     http_err = urllib.error.HTTPError(
-        url="http://x/api/vms/foo/stop",
+        url="http://x/api/containers/foo/stop",
         code=403,
         msg="Forbidden",
         hdrs=None,
@@ -588,13 +588,13 @@ def test_vm_stop_container_propagates_403_guard_rejection():
     http_err.read = lambda: err_body  # type: ignore[assignment]
     with patch("urllib.request.urlopen", side_effect=http_err):
         with pytest.raises(RuntimeError, match="403"):
-            tool_vm_stop_container({"name": "foo"})
+            tool_container_stop({"name": "foo"})
 
 
-def test_vm_stop_container_missing_name():
-    """vm_stop_container raises ValueError when name is missing."""
+def test_container_stop_missing_name():
+    """container_stop raises ValueError when name is missing."""
     with pytest.raises(ValueError, match="name is required"):
-        tool_vm_stop_container({})
+        tool_container_stop({})
 
 
 # ── Blueprint MCP tool tests ─────────────────────────────────────────────
@@ -738,8 +738,8 @@ def test_blueprint_spawn_missing_name():
         tool_blueprint_spawn({})
 
 
-def test_vm_add_favorite_default_actions_empty():
-    """vm_add_favorite defaults to empty actions array (no terminal default)."""
+def test_container_add_favorite_default_actions_empty():
+    """container_add_favorite defaults to empty actions array (no terminal default)."""
     existing = []
     get_resp = make_mock_response(existing)
     put_resp = make_mock_response([{"name": "test-vm", "type": "docker", "actions": []}])
@@ -752,7 +752,7 @@ def test_vm_add_favorite_default_actions_empty():
         return resp
 
     with patch("urllib.request.urlopen", side_effect=mock_urlopen) as mock_open:
-        result = tool_vm_add_favorite({"name": "test-vm"})
+        result = tool_container_add_favorite({"name": "test-vm"})
     assert "test-vm" in result
     assert "0 action(s)" in result
     put_req = mock_open.call_args_list[1][0][0]


### PR DESCRIPTION
Closes #201

Part of epic #199 (epic/199-container-manager).

## Summary

Atomic rename of all vm_* identifiers to container_* throughout the codebase. Clean rename per epic intent, with one small back-compat shim in `WidgetCard.fromSerialized` for legacy saved canvas layouts.

## Changes
- `server.py`: `/api/vms/*` routes -> `/api/containers/*`, all handler functions renamed, test-mode endpoint `/api/test/vm-containers` -> `/api/test/containers`, app state keys `_test_vm_containers`/`_test_vm_labels` -> `_test_containers`/`_test_container_labels`.
- `mcp_server.py`: `vm_*` MCP tools renamed to `container_*` (`container_discover`, `container_get_favorites`, `container_get_actions`, `container_set_actions`, `container_append_action`, `container_start`, `container_stop`, `container_add_favorite`); tool handler functions and TOOL_HANDLERS dispatch updated; cross-references in schema descriptions updated.
- `config.py`: default config key `vm_manager` -> `container_manager`.
- `static/index.html`: `'vm-manager'` widget type -> `'container-manager'`, `'VM Manager'` label -> `'Container Manager'`, all `data-vm-*` DOM attributes -> `data-container-*`, all `fetch('/api/vms/...')` -> `/api/containers/`. Added back-compat alias in `WidgetCard.fromSerialized` so existing saved layouts with `vm-manager` still render.
- `claude_rts/cards/{blueprint_card.py, container_starter_card.py}`: updated app-state key refs and route URLs.
- `dev_presets/`: renamed `vm-manager/` -> `container-manager/`, `vm-actions-qa/` -> `container-actions-qa/`, inner canvas JSON files renamed, `vm_manager`/`vm-manager` strings updated.
- `tests/test_vm_manager.py` -> `tests/test_container_manager.py` (+ e2e variants); `test_mcp_server.py` updated for renamed MCP tools; helper functions in `tests/e2e/conftest.py` renamed.
- `CLAUDE.md`, `docs/adr-blueprint-execution-model.md`, `docs/e2e-qa-workflow.md`: string updates.

## Verification
- `ruff check` + `ruff format --check` clean
- `pytest tests/ --ignore=tests/e2e` -> 477 passed

Generated with [Claude Code](https://claude.com/claude-code)