### PR TITLE
feat(#202): container_create — devcontainer CLI, ContainerSpec, image whitelist

### DIFF
--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -65,6 +65,11 @@ DEFAULT_CONFIG = {
     },
     "container_manager": {
         "favorites": [],
+        "image_whitelist": [
+            "ubuntu:24.04",
+            "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+            "mcr.microsoft.com/devcontainers/python:3.12",
+        ],
     },
 }
 

--- a/claude_rts/container_spec.py
+++ b/claude_rts/container_spec.py
@@ -1,0 +1,154 @@
+"""ContainerSpec abstraction + devcontainer-based container creation.
+
+v1 preset: "devcontainer" — runs `devcontainer up --override-config` with a
+temporary devcontainer.json that references a named Docker volume for workspace
+storage. No `--workspace-folder` flag is passed (the workspace lives inside a
+named volume managed by devcontainer; see OQ-1 resolution on epic #199).
+
+Every created container is stamped with `created_by=canvas-claude` via runArgs
+so that Child 1's guard recognises it as Canvas-Claude-owned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import random
+import string
+import tempfile
+import time
+from dataclasses import dataclass, field
+from typing import Literal
+
+from loguru import logger
+
+_DEVCONTAINER_CLI = os.environ.get(
+    "SUPREME_CLAUDEMANDER_DEVCONTAINER_CLI",
+    os.path.expanduser("~/.local/bin/devcontainer"),
+)
+
+
+def generate_container_name() -> str:
+    """Generate a short unique container name, e.g. ``cc-<ts>-<rand>``."""
+    ts = int(time.time())
+    rand = "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
+    return f"cc-{ts}-{rand}"
+
+
+@dataclass
+class ContainerSpec:
+    """Generic container specification.
+
+    v1 only implements the ``devcontainer`` preset. The dataclass is kept
+    intentionally thin — richer preset-specific fields belong on subclasses or
+    preset-specific helpers so the abstraction can grow without breaking v1.
+    """
+
+    image: str
+    name: str | None = None
+    preset: Literal["devcontainer", "image-only"] = "devcontainer"
+    labels: dict[str, str] = field(default_factory=dict)
+    mounts: list[str] = field(default_factory=list)
+    workspace_volume: str | None = None
+    workspace_hint: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            self.name = generate_container_name()
+        # Canvas-Claude stamp is an ABSOLUTE invariant — always present.
+        self.labels.setdefault("created_by", "canvas-claude")
+        self.labels.setdefault("supreme-claudemander.managed", "true")
+        if not self.workspace_volume:
+            self.workspace_volume = f"{self.name}-workspace"
+
+    # ── devcontainer.json generation ────────────────────────────────────
+
+    def devcontainer_preset(self) -> dict:
+        """Return the devcontainer.json dict for this spec.
+
+        Uses a named Docker volume for `/workspace` (not a bind mount) so that
+        devcontainer-in-devcontainer works inside the RTS devcontainer.
+        `runArgs` carries all labels through to `docker run` as ``--label k=v``.
+        """
+        run_args: list[str] = []
+        for k, v in self.labels.items():
+            run_args.extend(["--label", f"{k}={v}"])
+
+        mounts = list(self.mounts) or [
+            f"source={self.workspace_volume},target=/workspace,type=volume",
+        ]
+
+        return {
+            "image": self.image,
+            "mounts": mounts,
+            "containerEnv": {},
+            "runArgs": run_args,
+        }
+
+
+async def _run_devcontainer_up(spec: ContainerSpec) -> tuple[int, str, str]:
+    """Invoke ``devcontainer up --override-config <tmp>`` asynchronously.
+
+    Returns ``(returncode, stdout, stderr)``. The caller interprets the code.
+    The subprocess MUST run via ``asyncio.create_subprocess_exec`` so the
+    aiohttp event loop is not blocked (STRONG invariant).
+    """
+    cfg = spec.devcontainer_preset()
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".devcontainer.json",
+        delete=False,
+    ) as tmp:
+        json.dump(cfg, tmp)
+        tmp_path = tmp.name
+
+    try:
+        argv = [
+            _DEVCONTAINER_CLI,
+            "up",
+            "--id-label",
+            f"supreme-claudemander.container={spec.name}",
+            "--override-config",
+            tmp_path,
+        ]
+        logger.info("container_create: running {}", " ".join(argv))
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        return (
+            proc.returncode or 0,
+            stdout.decode("utf-8", errors="replace"),
+            stderr.decode("utf-8", errors="replace"),
+        )
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+async def create(spec: ContainerSpec) -> dict:
+    """Create a container per its spec. Returns a result dict on success.
+
+    Raises ``RuntimeError`` with the subprocess stderr on failure so the
+    handler can return a structured 500 response.
+    """
+    rc, stdout, stderr = await _run_devcontainer_up(spec)
+    if rc != 0:
+        logger.warning(
+            "container_create: devcontainer up failed (rc={}): {}",
+            rc,
+            stderr.strip(),
+        )
+        raise RuntimeError(stderr.strip() or f"devcontainer up exited {rc}")
+    logger.info("container_create: created '{}' (image={})", spec.name, spec.image)
+    return {
+        "name": spec.name,
+        "image": spec.image,
+        "labels": dict(spec.labels),
+        "state": "created",
+    }

--- a/claude_rts/mcp_server.py
+++ b/claude_rts/mcp_server.py
@@ -389,6 +389,41 @@ def tool_container_add_favorite(args):
     return f"Added {name} to favorites with {len(actions)} action(s)"
 
 
+def tool_container_create(args):
+    """Create a new container via POST /api/containers/create.
+
+    Validates against the server-side image whitelist; non-whitelisted images
+    are rejected 400 with a structured error. The server stamps the
+    ``created_by=canvas-claude`` Docker label so destructive tools recognise
+    the container as Canvas-Claude-owned.
+    """
+    image = (args.get("image") or "").strip()
+    if not image:
+        raise ValueError("image is required")
+    body = {"image": image}
+    name = (args.get("name") or "").strip()
+    if name:
+        body["name"] = name
+    preset = args.get("preset")
+    if preset:
+        body["preset"] = preset
+    try:
+        result = http_request("POST", "/api/containers/create", body=json.dumps(body))
+    except RuntimeError as e:
+        err_str = str(e)
+        if "image_not_whitelisted" in err_str:
+            try:
+                body_start = err_str.find("{")
+                if body_start != -1:
+                    err_body = json.loads(err_str[body_start:])
+                    allowed = err_body.get("allowed", [])
+                    return f"Error: image '{image}' is not whitelisted. Allowed images: {', '.join(allowed)}."
+            except Exception:  # noqa: BLE001
+                pass
+        raise
+    return f"Container created: {json.dumps(result)}"
+
+
 # ── Blueprint MCP tools ──────────────────────────────────────────────────
 
 
@@ -477,6 +512,7 @@ TOOL_HANDLERS = {
     "container_start": tool_container_start,
     "container_stop": tool_container_stop,
     "container_add_favorite": tool_container_add_favorite,
+    "container_create": tool_container_create,
     "blueprint_list": tool_blueprint_list,
     "blueprint_get": tool_blueprint_get,
     "blueprint_save": tool_blueprint_save,
@@ -999,6 +1035,48 @@ TOOL_SCHEMAS = [
                 },
             },
             "required": ["name"],
+        },
+    },
+    {
+        "name": "container_create",
+        "description": (
+            "Create a new Docker container via the devcontainer CLI. The image must be "
+            "in the server-side whitelist (container_manager.image_whitelist in config); "
+            "non-whitelisted images are rejected with a structured error. "
+            "The new container is stamped with the Docker label created_by=canvas-claude "
+            "so other Canvas Claude tools (e.g. container_stop) recognise it as "
+            "Canvas-Claude-owned and can operate on it. After creation the container is "
+            "auto-registered as a Container Manager favorite. If 'name' is omitted, the "
+            "server generates a unique name like cc-<timestamp>-<rand>."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "string",
+                    "description": (
+                        "Docker image reference (e.g. 'ubuntu:24.04'). Must appear in "
+                        "container_manager.image_whitelist. Unknown images return "
+                        "image_not_whitelisted with the allowed list."
+                    ),
+                },
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Optional container name. If omitted, the server generates a unique name (cc-<ts>-<rand>)."
+                    ),
+                },
+                "preset": {
+                    "type": "string",
+                    "description": (
+                        "Container-spec preset. Defaults to 'devcontainer' (runs "
+                        "`devcontainer up` with a generated devcontainer.json backed by "
+                        "a named Docker volume for /workspace). v1 only supports "
+                        "'devcontainer'."
+                    ),
+                },
+            },
+            "required": ["image"],
         },
     },
     {

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -23,6 +23,7 @@ from .cards import ServiceCardRegistry, ClaudeUsageCard, TerminalCard, CardRegis
 from .event_bus import EventBus  # noqa: E402
 from .ansi_strip import strip_ansi  # noqa: E402
 from . import blueprint as blueprint_mod  # noqa: E402
+from . import container_spec as container_spec_mod  # noqa: E402
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
@@ -403,6 +404,100 @@ async def container_favorites_actions_put_handler(request: web.Request) -> web.R
     write_config(app_config, cfg)
 
     return web.json_response(actions)
+
+
+async def container_create_handler(request: web.Request) -> web.Response:
+    """Create a new container via the devcontainer CLI.
+
+    Body (JSON): ``{"image": str, "name"?: str, "preset"?: str}``.
+    - Validates ``image`` against ``container_manager.image_whitelist`` config.
+    - Generates a temp devcontainer.json, invokes ``devcontainer up`` async,
+      stamps ``created_by=canvas-claude`` via runArgs.
+    - On success, auto-registers the container as a favorite and returns
+      ``{"container_id": name, "name": name, "status": "created"}``.
+    """
+    app_config: AppConfig = request.app["app_config"]
+    cfg = read_config(app_config)
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Request body must be valid JSON"}, status=400)
+    if not isinstance(body, dict):
+        return web.json_response({"error": "Request body must be a JSON object"}, status=400)
+
+    image = (body.get("image") or "").strip()
+    if not image:
+        return web.json_response({"error": "image is required"}, status=400)
+
+    whitelist = cfg.get("container_manager", {}).get(
+        "image_whitelist",
+        ["ubuntu:24.04"],
+    )
+    if image not in whitelist:
+        return web.json_response(
+            {"error": "image_not_whitelisted", "allowed": whitelist},
+            status=400,
+        )
+
+    name = (body.get("name") or "").strip() or None
+    preset = body.get("preset") or "devcontainer"
+
+    spec = container_spec_mod.ContainerSpec(
+        image=image,
+        name=name,
+        preset=preset,
+    )
+
+    # Test-mode hook: bypass the real subprocess call.
+    test_create = request.app.get("_test_container_create")
+    if test_create is not None:
+        # Record the spec for assertions.
+        test_create.setdefault("calls", []).append(
+            {
+                "image": spec.image,
+                "name": spec.name,
+                "preset": spec.preset,
+                "labels": dict(spec.labels),
+                "devcontainer_json": spec.devcontainer_preset(),
+            }
+        )
+        if test_create.get("should_fail"):
+            return web.json_response(
+                {"error": "creation_failed", "detail": test_create.get("error", "mock failure")},
+                status=500,
+            )
+    else:
+        try:
+            await container_spec_mod.create(spec)
+        except RuntimeError as exc:
+            return web.json_response(
+                {"error": "creation_failed", "detail": str(exc)},
+                status=500,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("container_create: unexpected failure")
+            return web.json_response(
+                {"error": "creation_failed", "detail": str(exc)},
+                status=500,
+            )
+
+    # Auto-register as favorite (idempotent — skip if already present).
+    if "container_manager" not in cfg:
+        cfg["container_manager"] = {}
+    favorites = cfg["container_manager"].get("favorites", [])
+    if not any(f.get("name") == spec.name for f in favorites):
+        favorites.append({"name": spec.name, "type": "docker", "actions": []})
+        cfg["container_manager"]["favorites"] = favorites
+        write_config(app_config, cfg)
+
+    return web.json_response(
+        {
+            "container_id": spec.name,
+            "name": spec.name,
+            "image": spec.image,
+            "status": "created",
+        }
+    )
 
 
 async def exec_websocket_handler(request: web.Request) -> web.WebSocketResponse:
@@ -1743,6 +1838,7 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
     app.router.add_post("/api/containers/{name}/start", container_start_handler)
     app.router.add_post("/api/containers/{name}/stop", container_stop_handler)
     app.router.add_put("/api/containers/favorites/{name}/actions", container_favorites_actions_put_handler)
+    app.router.add_post("/api/containers/create", container_create_handler)
 
     app.router.add_get("/api/profiles", profiles_list_handler)
     app.router.add_get("/api/profiles/discover", profiles_discover_handler)

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -440,3 +440,125 @@ async def test_container_routes_registered(app):
     assert "/api/containers/{name}/start" in routes
     assert "/api/containers/{name}/stop" in routes
     assert "/api/containers/favorites/{name}/actions" in routes
+    assert "/api/containers/create" in routes
+
+
+# ── container_create ─────────────────────────────────────────────────────
+
+
+async def test_container_create_rejects_non_whitelisted_image(client):
+    resp = await client.post("/api/containers/create", json={"image": "evil/image:latest"})
+    assert resp.status == 400
+    data = await resp.json()
+    assert data["error"] == "image_not_whitelisted"
+    assert "ubuntu:24.04" in data["allowed"]
+
+
+async def test_container_create_requires_image(client):
+    resp = await client.post("/api/containers/create", json={})
+    assert resp.status == 400
+    data = await resp.json()
+    assert "image" in data["error"]
+
+
+async def test_container_create_success_with_whitelisted_image(app, client):
+    # Install test-mode hook so no real devcontainer CLI is called.
+    app["_test_container_create"] = {}
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "my-dev-123"},
+    )
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["status"] == "created"
+    assert data["container_id"] == "my-dev-123"
+    assert data["name"] == "my-dev-123"
+
+    # Verify the spec is correctly stamped with the canvas-claude label.
+    calls = app["_test_container_create"]["calls"]
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["labels"]["created_by"] == "canvas-claude"
+    # Generated devcontainer.json must carry the label via runArgs and use a named volume.
+    dc = call["devcontainer_json"]
+    assert dc["image"] == "ubuntu:24.04"
+    assert "--label" in dc["runArgs"]
+    label_pairs = [
+        dc["runArgs"][i + 1] for i, v in enumerate(dc["runArgs"]) if v == "--label" and i + 1 < len(dc["runArgs"])
+    ]
+    assert "created_by=canvas-claude" in label_pairs
+    assert any(m.startswith("source=") and "type=volume" in m for m in dc["mounts"])
+
+
+async def test_container_create_generates_name_when_omitted(app, client):
+    app["_test_container_create"] = {}
+    resp = await client.post("/api/containers/create", json={"image": "ubuntu:24.04"})
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["container_id"].startswith("cc-")
+    assert data["name"] == data["container_id"]
+
+
+async def test_container_create_auto_registers_favorite(app, client):
+    app["_test_container_create"] = {}
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "auto-fav-1"},
+    )
+    assert resp.status == 200
+
+    # Favorite should now exist with an empty actions array.
+    resp_favs = await client.get("/api/containers/favorites")
+    favs = await resp_favs.json()
+    names = [f["name"] for f in favs]
+    assert "auto-fav-1" in names
+    fav = next(f for f in favs if f["name"] == "auto-fav-1")
+    assert fav["type"] == "docker"
+    assert fav["actions"] == []
+
+
+async def test_container_create_surfaces_failure_as_500(app, client):
+    app["_test_container_create"] = {
+        "should_fail": True,
+        "error": "devcontainer up failed: permission denied",
+    }
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "fail-dev"},
+    )
+    assert resp.status == 500
+    data = await resp.json()
+    assert data["error"] == "creation_failed"
+    assert "permission denied" in data["detail"]
+
+
+async def test_container_create_uses_asyncio_subprocess(monkeypatch):
+    """Invariant: devcontainer up runs via asyncio.create_subprocess_exec
+    (never blocking sync subprocess.run). Test mocks the async call directly.
+    """
+    from claude_rts import container_spec as cs
+
+    recorded = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return (b"ok", b"")
+
+    async def fake_create(*argv, **kw):
+        recorded["argv"] = list(argv)
+        return FakeProc()
+
+    monkeypatch.setattr(cs.asyncio, "create_subprocess_exec", fake_create)
+
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="inv-test")
+    result = await cs.create(spec)
+    assert result["name"] == "inv-test"
+    assert "created_by" in result["labels"]
+    # The id-label stamp is present so devcontainer up can target the container.
+    argv_str = " ".join(recorded["argv"])
+    assert "devcontainer" in argv_str
+    assert "up" in recorded["argv"]
+    assert "--override-config" in recorded["argv"]
+    assert "--id-label" in recorded["argv"]

--- a/tests/test_container_spec.py
+++ b/tests/test_container_spec.py
@@ -1,0 +1,95 @@
+"""Unit tests for ContainerSpec and devcontainer-preset generation."""
+
+import pytest
+
+from claude_rts import container_spec as cs
+
+
+def test_container_spec_auto_generates_name():
+    spec = cs.ContainerSpec(image="ubuntu:24.04")
+    assert spec.name
+    assert spec.name.startswith("cc-")
+
+
+def test_container_spec_stamps_canvas_claude_label():
+    """ABSOLUTE invariant: every created container carries created_by=canvas-claude."""
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="foo")
+    assert spec.labels["created_by"] == "canvas-claude"
+    assert spec.labels["supreme-claudemander.managed"] == "true"
+
+
+def test_devcontainer_preset_uses_named_volume_by_default():
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="foo")
+    dc = spec.devcontainer_preset()
+    assert dc["image"] == "ubuntu:24.04"
+    # Default mount uses a named volume (not a bind mount) → devcontainer-in-devcontainer safe.
+    assert any("type=volume" in m and "source=foo-workspace" in m for m in dc["mounts"])
+    # Every label flows through to runArgs as `--label k=v`.
+    args = dc["runArgs"]
+    label_pairs = [args[i + 1] for i, v in enumerate(args) if v == "--label"]
+    assert "created_by=canvas-claude" in label_pairs
+
+
+def test_devcontainer_preset_respects_custom_mounts():
+    spec = cs.ContainerSpec(
+        image="ubuntu:24.04",
+        name="foo",
+        mounts=["source=my-vol,target=/data,type=volume"],
+    )
+    dc = spec.devcontainer_preset()
+    assert dc["mounts"] == ["source=my-vol,target=/data,type=volume"]
+
+
+@pytest.mark.asyncio
+async def test_create_invokes_devcontainer_up_async(monkeypatch):
+    """STRONG invariant: creation uses asyncio.create_subprocess_exec only."""
+    recorded = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return (b"", b"")
+
+    async def fake_exec(*argv, **kw):
+        recorded["argv"] = list(argv)
+        return FakeProc()
+
+    monkeypatch.setattr(cs.asyncio, "create_subprocess_exec", fake_exec)
+
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="creation-test")
+    result = await cs.create(spec)
+    assert result["name"] == "creation-test"
+    assert "--override-config" in recorded["argv"]
+    assert "--id-label" in recorded["argv"]
+    # id-label value is immediately after the flag.
+    idx = recorded["argv"].index("--id-label")
+    assert recorded["argv"][idx + 1] == "supreme-claudemander.container=creation-test"
+
+
+@pytest.mark.asyncio
+async def test_create_raises_on_nonzero_return(monkeypatch):
+    class FakeProc:
+        returncode = 2
+
+        async def communicate(self):
+            return (b"", b"boom: permission denied")
+
+    async def fake_exec(*argv, **kw):
+        return FakeProc()
+
+    monkeypatch.setattr(cs.asyncio, "create_subprocess_exec", fake_exec)
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="fail-test")
+    with pytest.raises(RuntimeError, match="permission denied"):
+        await cs.create(spec)
+
+
+def test_create_does_not_shell_out_synchronously():
+    """Regression guard: ensure container_spec does not import subprocess.run."""
+    import inspect
+
+    src = inspect.getsource(cs)
+    # The module must not call subprocess.run / subprocess.check_call (would block loop).
+    assert "subprocess.run(" not in src
+    assert "subprocess.check_call(" not in src
+    assert "subprocess.check_output(" not in src

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -30,6 +30,7 @@ from claude_rts.mcp_server import (
     tool_container_append_action,
     tool_container_start,
     tool_container_stop,
+    tool_container_create,
     tool_blueprint_list,
     tool_blueprint_get,
     tool_blueprint_save,
@@ -206,6 +207,7 @@ def test_handle_request_tools_list():
         "container_start",
         "container_stop",
         "container_add_favorite",
+        "container_create",
         "blueprint_list",
         "blueprint_get",
         "blueprint_save",
@@ -420,7 +422,8 @@ def test_tools_list_includes_container_and_blueprint_tools():
     assert "set_recovery_script" in names
     assert "get_recovery_script" in names
     assert "run_task" in names
-    assert len(names) == 22
+    assert "container_create" in names
+    assert len(names) == 23
 
 
 # ── container_get_actions ──────────────────────────────────────────────
@@ -595,6 +598,57 @@ def test_container_stop_missing_name():
     """container_stop raises ValueError when name is missing."""
     with pytest.raises(ValueError, match="name is required"):
         tool_container_stop({})
+
+
+# ── container_create ─────────────────────────────────────────────────────
+
+
+def test_container_create_calls_rest():
+    """container_create POSTs to /api/containers/create with the JSON body."""
+    mock_resp = make_mock_response({"container_id": "cc-123-abc", "name": "cc-123-abc", "status": "created"})
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+        result = tool_container_create({"image": "ubuntu:24.04"})
+    assert "cc-123-abc" in result
+    req = mock_open.call_args[0][0]
+    assert req.method == "POST"
+    assert "/api/containers/create" in req.full_url
+    sent = json.loads(req.data.decode())
+    assert sent == {"image": "ubuntu:24.04"}
+
+
+def test_container_create_passes_name_and_preset():
+    """container_create forwards optional name and preset fields."""
+    mock_resp = make_mock_response({"container_id": "my-dev", "status": "created"})
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+        tool_container_create({"image": "ubuntu:24.04", "name": "my-dev", "preset": "devcontainer"})
+    req = mock_open.call_args[0][0]
+    sent = json.loads(req.data.decode())
+    assert sent["name"] == "my-dev"
+    assert sent["preset"] == "devcontainer"
+
+
+def test_container_create_missing_image_raises():
+    """container_create raises ValueError when image is missing."""
+    with pytest.raises(ValueError, match="image is required"):
+        tool_container_create({})
+
+
+def test_container_create_surfaces_whitelist_error():
+    """A 400 image_not_whitelisted response surfaces a readable error string."""
+    import urllib.error
+
+    err = urllib.error.HTTPError(
+        url="http://localhost/api/containers/create",
+        code=400,
+        msg="Bad Request",
+        hdrs=None,
+        fp=None,
+    )
+    err.read = lambda: json.dumps({"error": "image_not_whitelisted", "allowed": ["ubuntu:24.04"]}).encode()
+    with patch("urllib.request.urlopen", side_effect=err):
+        result = tool_container_create({"image": "evil/image:latest"})
+    assert "not whitelisted" in result
+    assert "ubuntu:24.04" in result
 
 
 # ── Blueprint MCP tool tests ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #202

Part of epic #199 (`epic/199-container-manager`).

## Summary
- `POST /api/containers/create` endpoint: validates image whitelist, generates `devcontainer.json`, runs `devcontainer up --override-config` asynchronously via `asyncio.create_subprocess_exec` (non-blocking invariant).
- `container_create` MCP tool wrapping the endpoint (surfaces whitelist rejection as a readable error).
- `ContainerSpec` dataclass + `create()` helper in `claude_rts/container_spec.py`; devcontainer-preset generates a named-volume mount for `/workspace` and stamps `created_by=canvas-claude` (+ `supreme-claudemander.managed=true`) via `runArgs` so Child 1's guard recognises Canvas-Claude-owned containers.
- Image whitelist from `container_manager.image_whitelist` config (default: `ubuntu:24.04`, `mcr.microsoft.com/devcontainers/base:ubuntu-24.04`, `mcr.microsoft.com/devcontainers/python:3.12`).
- Auto-registers successful creations as Container Manager favorites (idempotent).

## OQ-1 resolution (documented in spec)
Use `devcontainer up --id-label "supreme-claudemander.container=<name>" --override-config <path>` with a named Docker volume for `/workspace`. No `--workspace-folder` flag — the workspace lives inside a named volume managed by devcontainer, which sidesteps the devcontainer-in-devcontainer bind-mount problem.

## Test plan
- [x] `python -m ruff check .` clean
- [x] `python -m ruff format --check .` clean
- [x] Full unit suite green (`pytest tests/ --ignore=tests/e2e` → 495 passed)
- [x] Tests cover: whitelist rejection (400), missing image (400), successful creation (labels + volume mount asserted), auto-generated name, auto-favorite registration, subprocess-failure propagation (500), asyncio-only invariant, regression guard against sync subprocess imports.
- [ ] Manual: hit `POST /api/containers/create` with `{"image": "ubuntu:24.04"}` inside the devcontainer to confirm `devcontainer up` actually succeeds end-to-end (the spike result was positive; this PR's CI does not exercise the real CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)