### PR TITLE
feat(#204): enforce CPU/RAM/PIDs resource caps at container creation

### DIFF
--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -70,6 +70,15 @@ DEFAULT_CONFIG = {
             "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
             "mcr.microsoft.com/devcontainers/python:3.12",
         ],
+        # Resource caps applied at creation time (#204). Human-tunable.
+        # ``disk_limit`` is advisory in v1 — Docker named volumes have no
+        # native size cap on overlay2/ext4; observe via Child 7 stats widget.
+        "defaults": {
+            "cpu_limit": 2.0,
+            "memory_limit": "8g",
+            "disk_limit": "10g",
+            "pids_limit": 1024,
+        },
     },
 }
 

--- a/claude_rts/container_spec.py
+++ b/claude_rts/container_spec.py
@@ -36,6 +36,13 @@ def generate_container_name() -> str:
     return f"cc-{ts}-{rand}"
 
 
+#: v1 target per epic #199 intent §8 — 2 vCPU / 8 GB RAM / 10 GB workspace.
+DEFAULT_CPU_LIMIT: float = 2.0
+DEFAULT_MEMORY_LIMIT: str = "8g"
+DEFAULT_DISK_LIMIT: str = "10g"
+DEFAULT_PIDS_LIMIT: int = 1024
+
+
 @dataclass
 class ContainerSpec:
     """Generic container specification.
@@ -43,6 +50,11 @@ class ContainerSpec:
     v1 only implements the ``devcontainer`` preset. The dataclass is kept
     intentionally thin — richer preset-specific fields belong on subclasses or
     preset-specific helpers so the abstraction can grow without breaking v1.
+
+    Resource caps (#204) are STRONG invariants: every container gets
+    ``--cpus``/``--memory``/``--pids-limit`` stamped into runArgs at creation
+    time. ``disk_limit`` is advisory for v1 — Docker named volumes have no
+    native size cap on overlay2/ext4. Visibility is Child 7's stats widget.
     """
 
     image: str
@@ -52,6 +64,12 @@ class ContainerSpec:
     mounts: list[str] = field(default_factory=list)
     workspace_volume: str | None = None
     workspace_hint: str | None = None
+    # Resource caps (#204). Defaults are the v1 targets; humans can override
+    # via ``container_manager.defaults`` in config.
+    cpu_limit: float = DEFAULT_CPU_LIMIT
+    memory_limit: str = DEFAULT_MEMORY_LIMIT
+    disk_limit: str = DEFAULT_DISK_LIMIT
+    pids_limit: int = DEFAULT_PIDS_LIMIT
 
     def __post_init__(self) -> None:
         if not self.name:
@@ -74,6 +92,12 @@ class ContainerSpec:
         run_args: list[str] = []
         for k, v in self.labels.items():
             run_args.extend(["--label", f"{k}={v}"])
+
+        # Resource caps (#204) — appended to runArgs as Docker flags. The
+        # devcontainer CLI forwards runArgs verbatim to ``docker run``.
+        run_args.append(f"--cpus={self.cpu_limit}")
+        run_args.append(f"--memory={self.memory_limit}")
+        run_args.append(f"--pids-limit={self.pids_limit}")
 
         mounts = list(self.mounts) or [
             f"source={self.workspace_volume},target=/workspace,type=volume",

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -442,10 +442,25 @@ async def container_create_handler(request: web.Request) -> web.Response:
     name = (body.get("name") or "").strip() or None
     preset = body.get("preset") or "devcontainer"
 
+    # Resource caps (#204): merge config-level defaults onto the spec so a
+    # human can tune without code changes. Missing keys fall back to the
+    # ContainerSpec class defaults (v1 targets from epic #199 intent §8).
+    cap_defaults = cfg.get("container_manager", {}).get("defaults", {}) or {}
+    cap_kwargs: dict = {}
+    if "cpu_limit" in cap_defaults:
+        cap_kwargs["cpu_limit"] = float(cap_defaults["cpu_limit"])
+    if "memory_limit" in cap_defaults:
+        cap_kwargs["memory_limit"] = str(cap_defaults["memory_limit"])
+    if "disk_limit" in cap_defaults:
+        cap_kwargs["disk_limit"] = str(cap_defaults["disk_limit"])
+    if "pids_limit" in cap_defaults:
+        cap_kwargs["pids_limit"] = int(cap_defaults["pids_limit"])
+
     spec = container_spec_mod.ContainerSpec(
         image=image,
         name=name,
         preset=preset,
+        **cap_kwargs,
     )
 
     # Test-mode hook: bypass the real subprocess call.

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -490,6 +490,51 @@ async def test_container_create_success_with_whitelisted_image(app, client):
     assert any(m.startswith("source=") and "type=volume" in m for m in dc["mounts"])
 
 
+async def test_container_create_applies_default_resource_caps(app, client):
+    """#204: with no config overrides, every created container inherits v1 caps."""
+    app["_test_container_create"] = {}
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "caps-default"},
+    )
+    assert resp.status == 200
+    dc = app["_test_container_create"]["calls"][0]["devcontainer_json"]
+    run_args = dc["runArgs"]
+    assert "--cpus=2.0" in run_args
+    assert "--memory=8g" in run_args
+    assert "--pids-limit=1024" in run_args
+
+
+async def test_container_create_applies_configured_resource_caps(app, client, tmp_path):
+    """#204: config-level defaults override ContainerSpec class defaults."""
+    app_config = app["app_config"]
+    config.write_config(
+        app_config,
+        {
+            "container_manager": {
+                "image_whitelist": ["ubuntu:24.04"],
+                "defaults": {
+                    "cpu_limit": 4,
+                    "memory_limit": "16g",
+                    "pids_limit": 2048,
+                    "disk_limit": "20g",
+                },
+            },
+        },
+    )
+    app["_test_container_create"] = {}
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "caps-custom"},
+    )
+    assert resp.status == 200
+    dc = app["_test_container_create"]["calls"][0]["devcontainer_json"]
+    run_args = dc["runArgs"]
+    assert "--cpus=4.0" in run_args
+    assert "--memory=16g" in run_args
+    assert "--pids-limit=2048" in run_args
+
+
 async def test_container_create_generates_name_when_omitted(app, client):
     app["_test_container_create"] = {}
     resp = await client.post("/api/containers/create", json={"image": "ubuntu:24.04"})

--- a/tests/test_container_spec.py
+++ b/tests/test_container_spec.py
@@ -84,6 +84,52 @@ async def test_create_raises_on_nonzero_return(monkeypatch):
         await cs.create(spec)
 
 
+# ── Resource caps (#204) ────────────────────────────────────────────
+
+
+def test_container_spec_has_default_resource_caps():
+    """#204 STRONG invariant: every spec carries v1 resource caps by default."""
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="foo")
+    assert spec.cpu_limit == 2.0
+    assert spec.memory_limit == "8g"
+    assert spec.disk_limit == "10g"
+    assert spec.pids_limit == 1024
+
+
+def test_devcontainer_preset_emits_resource_cap_runargs():
+    """#204 acceptance: --cpus / --memory / --pids-limit present in runArgs."""
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="foo")
+    dc = spec.devcontainer_preset()
+    assert "--cpus=2.0" in dc["runArgs"]
+    assert "--memory=8g" in dc["runArgs"]
+    assert "--pids-limit=1024" in dc["runArgs"]
+
+
+def test_devcontainer_preset_respects_custom_resource_caps():
+    """Overrides flow through to Docker flags verbatim."""
+    spec = cs.ContainerSpec(
+        image="ubuntu:24.04",
+        name="foo",
+        cpu_limit=4.0,
+        memory_limit="16g",
+        pids_limit=2048,
+    )
+    dc = spec.devcontainer_preset()
+    assert "--cpus=4.0" in dc["runArgs"]
+    assert "--memory=16g" in dc["runArgs"]
+    assert "--pids-limit=2048" in dc["runArgs"]
+
+
+def test_resource_caps_preserved_alongside_labels():
+    """Labels and resource caps coexist in runArgs without collision."""
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="foo")
+    args = spec.devcontainer_preset()["runArgs"]
+    label_pairs = [args[i + 1] for i, v in enumerate(args) if v == "--label"]
+    assert "created_by=canvas-claude" in label_pairs
+    assert any(a.startswith("--cpus=") for a in args)
+    assert any(a.startswith("--memory=") for a in args)
+
+
 def test_create_does_not_shell_out_synchronously():
     """Regression guard: ensure container_spec does not import subprocess.run."""
     import inspect


### PR DESCRIPTION
Closes #204

Part of epic #199 (epic/199-container-manager).

## Summary

Every Canvas-Claude-owned container now gets resource caps stamped into
its `devcontainer.json` runArgs at creation time — Docker forwards them
to `docker run` verbatim:

- CPU: `--cpus=2.0`
- RAM: `--memory=8g`
- PIDs: `--pids-limit=1024`
- Disk: advisory (`disk_limit="10g"`) — Docker named volumes have no
  native size cap on overlay2/ext4. Observability comes from Child 7's
  stats widget, not a hard cap, per intent §9 (no automated hard-kill).

## Surface area

- `claude_rts/container_spec.py`: extend `ContainerSpec` with
  `cpu_limit`, `memory_limit`, `disk_limit`, `pids_limit`; append
  resource flags to `devcontainer_preset()` runArgs.
- `claude_rts/config.py`: add
  `container_manager.defaults = {cpu_limit, memory_limit, disk_limit, pids_limit}`
  so humans can tune without code changes.
- `claude_rts/server.py`: `container_create_handler` reads config
  `container_manager.defaults` and forwards overrides into the
  `ContainerSpec` constructor.

## Tests

- `tests/test_container_spec.py` (+4): default caps, runArg emission,
  custom overrides, label+cap coexistence.
- `tests/test_container_manager.py` (+2): default caps flow through
  `POST /api/containers/create`; config-level overrides take effect.

All 510 non-e2e tests pass; ruff check + format clean.

## Acceptance (from child spec)

- [x] Every `ContainerSpec.create()` carries `--cpus` and `--memory` in
      runArgs.
- [x] Defaults live in `DEFAULT_CONFIG["container_manager"]["defaults"]`.
- [x] `ruff` + pytest clean.
- [ ] `docker inspect` post-create confirms limits via integration test —
      deferred to Child 10 (E2E slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)