### PR TITLE
feat(#205): 4-container global cap with atomic lock enforcement

### DIFF
--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -70,6 +70,9 @@ DEFAULT_CONFIG = {
             "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
             "mcr.microsoft.com/devcontainers/python:3.12",
         ],
+        # Global cap on canvas-claude-created containers (running + stopped).
+        # See epic #199 intent §8 and child #205. Human-tunable.
+        "max_containers": 4,
         # Resource caps applied at creation time (#204). Human-tunable.
         # ``disk_limit`` is advisory in v1 — Docker named volumes have no
         # native size cap on overlay2/ext4; observe via Child 7 stats widget.

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -463,56 +463,131 @@ async def container_create_handler(request: web.Request) -> web.Response:
         **cap_kwargs,
     )
 
-    # Test-mode hook: bypass the real subprocess call.
-    test_create = request.app.get("_test_container_create")
-    if test_create is not None:
-        # Record the spec for assertions.
-        test_create.setdefault("calls", []).append(
+    # ── 4-container global cap (#205) ─────────────────────────────────────
+    # Mirrors the 10-terminal cap pattern at ``claude_terminal_create``: the
+    # lock is held across the count-check + creation so concurrent requests
+    # cannot race past the cap. The cap counts only containers stamped with
+    # ``created_by=canvas-claude``; human-created containers are excluded.
+    max_containers = int(cfg.get("container_manager", {}).get("max_containers", 4))
+    create_lock: asyncio.Lock = request.app["container_create_lock"]
+    async with create_lock:
+        existing_names, count_err = await _count_canvas_claude_containers(request.app)
+        if count_err is not None:
+            return count_err
+        if len(existing_names) >= max_containers:
+            return web.json_response(
+                {
+                    "error": "container_cap_reached",
+                    "message": (
+                        f"Canvas Claude has reached the {max_containers}-container cap. "
+                        "Rebuild or remove one before creating another."
+                    ),
+                    "existing_container_ids": sorted(existing_names),
+                    "live_container_names": sorted(existing_names),
+                },
+                status=429,
+            )
+
+        # Test-mode hook: bypass the real subprocess call.
+        test_create = request.app.get("_test_container_create")
+        if test_create is not None:
+            # Record the spec for assertions.
+            test_create.setdefault("calls", []).append(
+                {
+                    "image": spec.image,
+                    "name": spec.name,
+                    "preset": spec.preset,
+                    "labels": dict(spec.labels),
+                    "devcontainer_json": spec.devcontainer_preset(),
+                }
+            )
+            if test_create.get("should_fail"):
+                return web.json_response(
+                    {"error": "creation_failed", "detail": test_create.get("error", "mock failure")},
+                    status=500,
+                )
+            # Register the new container in the test-labels map so subsequent
+            # count-checks (inside the same test) see it as canvas-claude-owned.
+            test_labels = request.app.get("_test_container_labels")
+            if test_labels is not None:
+                test_labels.setdefault(spec.name, {})["created_by"] = "canvas-claude"
+        else:
+            try:
+                await container_spec_mod.create(spec)
+            except RuntimeError as exc:
+                return web.json_response(
+                    {"error": "creation_failed", "detail": str(exc)},
+                    status=500,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("container_create: unexpected failure")
+                return web.json_response(
+                    {"error": "creation_failed", "detail": str(exc)},
+                    status=500,
+                )
+
+        # Auto-register as favorite (idempotent — skip if already present).
+        if "container_manager" not in cfg:
+            cfg["container_manager"] = {}
+        favorites = cfg["container_manager"].get("favorites", [])
+        if not any(f.get("name") == spec.name for f in favorites):
+            favorites.append({"name": spec.name, "type": "docker", "actions": []})
+            cfg["container_manager"]["favorites"] = favorites
+            write_config(app_config, cfg)
+
+        return web.json_response(
             {
-                "image": spec.image,
+                "container_id": spec.name,
                 "name": spec.name,
-                "preset": spec.preset,
-                "labels": dict(spec.labels),
-                "devcontainer_json": spec.devcontainer_preset(),
+                "image": spec.image,
+                "status": "created",
             }
         )
-        if test_create.get("should_fail"):
-            return web.json_response(
-                {"error": "creation_failed", "detail": test_create.get("error", "mock failure")},
-                status=500,
-            )
-    else:
-        try:
-            await container_spec_mod.create(spec)
-        except RuntimeError as exc:
-            return web.json_response(
-                {"error": "creation_failed", "detail": str(exc)},
-                status=500,
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("container_create: unexpected failure")
-            return web.json_response(
-                {"error": "creation_failed", "detail": str(exc)},
-                status=500,
-            )
 
-    # Auto-register as favorite (idempotent — skip if already present).
-    if "container_manager" not in cfg:
-        cfg["container_manager"] = {}
-    favorites = cfg["container_manager"].get("favorites", [])
-    if not any(f.get("name") == spec.name for f in favorites):
-        favorites.append({"name": spec.name, "type": "docker", "actions": []})
-        cfg["container_manager"]["favorites"] = favorites
-        write_config(app_config, cfg)
 
-    return web.json_response(
-        {
-            "container_id": spec.name,
-            "name": spec.name,
-            "image": spec.image,
-            "status": "created",
-        }
-    )
+async def _count_canvas_claude_containers(
+    app: web.Application,
+) -> tuple[list[str], web.Response | None]:
+    """Return (names, error_response). Names are containers (running + stopped)
+    with the ``created_by=canvas-claude`` label. On docker failure, returns
+    ([], 500 response) — callers fail closed.
+
+    Test-mode path: when ``_test_container_labels`` is populated, derive the
+    count from that map so tests don't need to mock docker.
+    """
+    test_labels = app.get("_test_container_labels")
+    if test_labels is not None:
+        names = [name for name, entry in test_labels.items() if (entry or {}).get("created_by") == "canvas-claude"]
+        return names, None
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            _DOCKER_CMD,
+            "ps",
+            "-a",
+            "--filter",
+            "label=created_by=canvas-claude",
+            "--format",
+            "{{.Names}}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("container_create: docker ps (cap count) failed: {}", exc)
+        return [], web.json_response(
+            {"error": "container_count_failed", "detail": str(exc)},
+            status=500,
+        )
+    if proc.returncode != 0:
+        err = stderr.decode().strip() if stderr else "docker ps failed"
+        logger.warning("container_create: docker ps (cap count) failed: {}", err)
+        return [], web.json_response(
+            {"error": "container_count_failed", "detail": err},
+            status=500,
+        )
+    names = [line.strip() for line in stdout.decode().splitlines() if line.strip()]
+    return names, None
 
 
 async def _inspect_container_for_rebuild(request: web.Request, name: str) -> tuple[dict | None, web.Response | None]:
@@ -2071,6 +2146,9 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
     app["canvas_claude_spawns"]: dict[str, set[str]] = {}
     # Per-spawner asyncio.Lock to make the cap-check+add atomic
     app["canvas_claude_spawn_locks"]: dict[str, asyncio.Lock] = {}
+    # Global lock for the 4-container cap (#205): serialises the count-check +
+    # create so concurrent requests can't race past the cap.
+    app["container_create_lock"] = asyncio.Lock()
     # Pending ephemeral timeout tasks keyed by session_id
     app["ephemeral_timers"]: dict[str, asyncio.Task] = {}
 

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -671,6 +671,135 @@ async def test_container_rebuild_route_registered(client):
     assert "/api/containers/{name}/rebuild" in all_paths
 
 
+# ── 4-container global cap (#205) ────────────────────────────────────────
+
+
+async def test_container_create_allowed_under_cap(app, client):
+    """Count only canvas-claude-owned containers; 3 existing → 4th succeeds."""
+    app["_test_container_create"] = {}
+    app["_test_container_labels"] = {
+        "cc-1": {"created_by": "canvas-claude"},
+        "cc-2": {"created_by": "canvas-claude"},
+        "cc-3": {"created_by": "canvas-claude"},
+    }
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "cc-4"},
+    )
+    assert resp.status == 200, await resp.text()
+    data = await resp.json()
+    assert data["status"] == "created"
+    assert data["name"] == "cc-4"
+
+
+async def test_container_create_rejects_fifth_with_429(app, client):
+    """At-cap (4 existing) → 5th creation returns 429 container_cap_reached."""
+    app["_test_container_create"] = {}
+    app["_test_container_labels"] = {
+        "cc-1": {"created_by": "canvas-claude"},
+        "cc-2": {"created_by": "canvas-claude"},
+        "cc-3": {"created_by": "canvas-claude"},
+        "cc-4": {"created_by": "canvas-claude"},
+    }
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "cc-5"},
+    )
+    assert resp.status == 429
+    data = await resp.json()
+    assert data["error"] == "container_cap_reached"
+    # Response must list the existing container names so the caller can act.
+    assert sorted(data["existing_container_ids"]) == ["cc-1", "cc-2", "cc-3", "cc-4"]
+    # No spec was recorded — the create was refused before the hook ran.
+    assert app["_test_container_create"].get("calls", []) == []
+
+
+async def test_container_create_excludes_human_containers_from_cap(app, client):
+    """Human-created containers (no created_by label or a different value) do
+    NOT count toward the 4-container cap.
+    """
+    app["_test_container_create"] = {}
+    app["_test_container_labels"] = {
+        "cc-1": {"created_by": "canvas-claude"},
+        "cc-2": {"created_by": "canvas-claude"},
+        "cc-3": {"created_by": "canvas-claude"},
+        # Humans — both shapes (missing label + different owner) must be ignored.
+        "human-a": {},
+        "human-b": {"created_by": "someone-else"},
+    }
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "cc-4"},
+    )
+    assert resp.status == 200, await resp.text()
+
+
+async def test_container_create_cap_is_atomic_under_concurrency(app, client):
+    """Fire 6 concurrent creates at an empty state; exactly 4 must succeed and
+    2 must receive 429 container_cap_reached. The lock+set pattern prevents a
+    TOCTOU race where all 6 observe count=0 before any mutation lands.
+    """
+    import asyncio as _asyncio
+
+    app["_test_container_create"] = {}
+    app["_test_container_labels"] = {}
+
+    async def _spawn(i):
+        return await client.post(
+            "/api/containers/create",
+            json={"image": "ubuntu:24.04", "name": f"cc-conc-{i}"},
+        )
+
+    responses = await _asyncio.gather(*[_spawn(i) for i in range(6)])
+    statuses = [r.status for r in responses]
+    assert statuses.count(200) == 4, f"expected 4 successes, got statuses={statuses}"
+    assert statuses.count(429) == 2, f"expected 2 rejections, got statuses={statuses}"
+
+    # All 429s must carry the structured error shape.
+    for r in responses:
+        if r.status == 429:
+            data = await r.json()
+            assert data["error"] == "container_cap_reached"
+            assert isinstance(data.get("existing_container_ids"), list)
+            assert len(data["existing_container_ids"]) == 4
+
+
+async def test_container_create_cap_uses_label_filter_not_total_count(app, client, monkeypatch):
+    """Cap check must invoke `docker ps -a --filter label=created_by=canvas-claude`
+    rather than counting every container on the host. Verified by asserting the
+    argv passed to asyncio.create_subprocess_exec includes the filter.
+    """
+    # Clear the test-labels shortcut so the real subprocess path runs.
+    app.pop("_test_container_labels", None)
+    app["_test_container_create"] = {}
+
+    recorded_argv: list[list[str]] = []
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return (b"", b"")
+
+    async def fake_exec(*argv, **kw):
+        recorded_argv.append(list(argv))
+        return FakeProc()
+
+    monkeypatch.setattr("claude_rts.server.asyncio.create_subprocess_exec", fake_exec)
+
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "cc-filter-check"},
+    )
+    assert resp.status == 200
+
+    # The cap-count subprocess call must carry the label filter.
+    cap_count_calls = [a for a in recorded_argv if "ps" in a and "--filter" in a]
+    assert cap_count_calls, f"no docker-ps cap-count call observed; argvs={recorded_argv}"
+    for argv in cap_count_calls:
+        assert "label=created_by=canvas-claude" in argv
+
+
 async def test_container_create_uses_asyncio_subprocess(monkeypatch):
     """Invariant: devcontainer up runs via asyncio.create_subprocess_exec
     (never blocking sync subprocess.run). Test mocks the async call directly.


### PR DESCRIPTION
Closes #205

Part of epic #199 (epic/199-container-manager).

## Summary
Enforces a hard cap of 4 canvas-claude-created containers (running + stopped). Counted via `docker ps -a --filter label=created_by=canvas-claude`. 5th creation attempt returns HTTP 429 `container_cap_reached`. Human containers excluded. Atomic enforcement via `asyncio.Lock` (same pattern as 10-terminal cap).

## Changes
- `claude_rts/config.py`: new `container_manager.max_containers = 4` default (human-tunable).
- `claude_rts/server.py`: new app-level `container_create_lock` (asyncio.Lock). `container_create_handler` wraps count-check + create in `async with lock:`. New `_count_canvas_claude_containers` helper runs `docker ps -a --filter label=created_by=canvas-claude --format {{.Names}}`; fails closed (500 `container_count_failed`) on docker failure. Over-cap returns 429 with `existing_container_ids` + `live_container_names`.
- Test hook: when `_test_container_labels` is set, count derives from that map; successful creates auto-register the new name with `created_by=canvas-claude` so the cap accumulates correctly across sequential creates in one test.
- `tests/test_container_manager.py`: 5 new tests — allowed-under-cap, 5th-rejected-429, human-containers-excluded, concurrency (6 parallel → 4 succeed / 2 429), label-filter-used-not-total-count.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] Full non-e2e suite: 515 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)