### PR TITLE
feat(#206): container stats widget — live CPU/MEM per canvas-claude container

### DIFF
--- a/claude_rts/mcp_server.py
+++ b/claude_rts/mcp_server.py
@@ -373,6 +373,16 @@ def tool_container_stop(args):
     return f"Stopped {name}: {json.dumps(result)}"
 
 
+def tool_container_stats(args):
+    """Return live CPU/MEM stats for a single container via GET /api/containers/{name}/stats."""
+    name = args.get("name", "") or args.get("container", "")
+    if not name:
+        raise ValueError("name is required")
+    safe_name = urllib.parse.quote(name, safe="")
+    result = http_request("GET", f"/api/containers/{safe_name}/stats")
+    return json.dumps(result)
+
+
 def tool_container_add_favorite(args):
     name = args.get("name", "")
     if not name:
@@ -529,6 +539,7 @@ TOOL_HANDLERS = {
     "container_append_action": tool_container_append_action,
     "container_start": tool_container_start,
     "container_stop": tool_container_stop,
+    "container_stats": tool_container_stats,
     "container_add_favorite": tool_container_add_favorite,
     "container_create": tool_container_create,
     "container_rebuild": tool_container_rebuild,
@@ -1010,6 +1021,28 @@ TOOL_SCHEMAS = [
                         "Seconds to wait before force-killing the container (optional). "
                         "Default: Docker's default (usually 10s). Set higher for graceful "
                         "shutdown of services."
+                    ),
+                },
+            },
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "container_stats",
+        "description": (
+            "Return live CPU/MEM stats for a single container (snapshot from "
+            "`docker stats --no-stream`). Useful for observability — check whether "
+            "a container is using abnormal resources before stopping/rebuilding. "
+            "Accepts either 'name' or 'container' as the parameter key."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Name of the Docker container (also accepted as 'container'). "
+                        "Container must be running — stopped containers return 404."
                     ),
                 },
             },

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -145,6 +145,169 @@ async def widget_system_info_handler(request: web.Request) -> web.Response:
 _DOCKER_CMD = "docker"
 
 
+async def widget_container_stats_handler(request: web.Request) -> web.Response:
+    """Return live CPU/MEM stats for every Docker container (running + stopped).
+
+    Runs ``docker stats --no-stream --format '{{json .}}'`` for running containers
+    and ``docker ps -a`` to include stopped containers (zeroed stats). Each row
+    is augmented with the ``created_by`` label so the UI can flag canvas-claude
+    ownership.
+    """
+    # Test-mode injection: return mocked payload verbatim
+    test_stats = request.app.get("_test_container_stats")
+    if test_stats is not None:
+        return web.json_response({"containers": list(test_stats)})
+
+    # 1) docker ps -a to enumerate all containers + their created_by label
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            _DOCKER_CMD,
+            "ps",
+            "-a",
+            "--format",
+            '{{.Names}}|{{.State}}|{{.Label "created_by"}}',
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+    except FileNotFoundError:
+        return web.json_response({"error": "docker_unavailable"}, status=500)
+
+    if proc.returncode != 0:
+        err = stderr.decode().strip() if stderr else "docker ps failed"
+        logger.warning("widget_container_stats: docker ps failed: {}", err)
+        return web.json_response({"error": err}, status=500)
+
+    containers: list[dict] = []
+    for line in stdout.decode().strip().splitlines():
+        parts = line.split("|", 2)
+        if len(parts) < 2:
+            continue
+        name = parts[0].strip()
+        state = parts[1].strip().lower()
+        created_by = parts[2].strip() if len(parts) > 2 else ""
+        containers.append(
+            {
+                "name": name,
+                "status": "running" if state == "running" else "stopped",
+                "cpu_percent": "0.00%",
+                "mem_usage": "0B",
+                "mem_limit": "0B",
+                "mem_percent": "0.00%",
+                "net_io": "--",
+                "block_io": "--",
+                "pids": 0,
+                "created_by": created_by,
+            }
+        )
+
+    if not containers:
+        return web.json_response({"containers": []})
+
+    # 2) docker stats --no-stream on running containers
+    try:
+        stats_proc = await asyncio.create_subprocess_exec(
+            _DOCKER_CMD,
+            "stats",
+            "--no-stream",
+            "--format",
+            "{{json .}}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stats_out, stats_err = await stats_proc.communicate()
+    except FileNotFoundError:
+        return web.json_response({"containers": containers})
+
+    if stats_proc.returncode == 0:
+        by_name = {c["name"]: c for c in containers}
+        for line in stats_out.decode().strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                s = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            n = s.get("Name") or s.get("Container") or ""
+            if n not in by_name:
+                continue
+            c = by_name[n]
+            c["cpu_percent"] = s.get("CPUPerc", "0.00%")
+            mem_usage_raw = s.get("MemUsage", "0B / 0B")
+            # MemUsage format: "123MiB / 1.5GiB"
+            if " / " in mem_usage_raw:
+                used, limit = mem_usage_raw.split(" / ", 1)
+                c["mem_usage"] = used.strip()
+                c["mem_limit"] = limit.strip()
+            else:
+                c["mem_usage"] = mem_usage_raw
+            c["mem_percent"] = s.get("MemPerc", "0.00%")
+            c["net_io"] = s.get("NetIO", "--")
+            c["block_io"] = s.get("BlockIO", "--")
+            try:
+                c["pids"] = int(s.get("PIDs", 0))
+            except (TypeError, ValueError):
+                c["pids"] = 0
+
+    return web.json_response({"containers": containers})
+
+
+async def container_single_stats_handler(request: web.Request) -> web.Response:
+    """Return live stats for a single container via ``docker stats --no-stream``."""
+    name = request.match_info["name"]
+
+    test_stats = request.app.get("_test_container_stats")
+    if test_stats is not None:
+        for c in test_stats:
+            if c.get("name") == name:
+                return web.json_response(c)
+        return web.json_response({"error": f"No such container: {name}"}, status=404)
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            _DOCKER_CMD,
+            "stats",
+            "--no-stream",
+            "--format",
+            "{{json .}}",
+            "--",
+            name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+    except FileNotFoundError:
+        return web.json_response({"error": "docker_unavailable"}, status=500)
+
+    if proc.returncode != 0:
+        err = stderr.decode().strip() if stderr else "docker stats failed"
+        return web.json_response({"error": err}, status=500)
+
+    line = stdout.decode().strip().splitlines()
+    if not line:
+        return web.json_response({"error": f"No stats for: {name}"}, status=404)
+
+    try:
+        s = json.loads(line[0])
+    except json.JSONDecodeError:
+        return web.json_response({"error": "invalid stats output"}, status=500)
+
+    mem_usage_raw = s.get("MemUsage", "0B / 0B")
+    used, limit = (mem_usage_raw.split(" / ", 1) + [""])[:2] if " / " in mem_usage_raw else (mem_usage_raw, "")
+    return web.json_response(
+        {
+            "name": s.get("Name") or name,
+            "cpu_percent": s.get("CPUPerc", "0.00%"),
+            "mem_usage": used.strip(),
+            "mem_limit": limit.strip(),
+            "mem_percent": s.get("MemPerc", "0.00%"),
+            "net_io": s.get("NetIO", "--"),
+            "block_io": s.get("BlockIO", "--"),
+        }
+    )
+
+
 # ── Container Manager API ────────────────────────────────────────────────────
 
 
@@ -2163,9 +2326,11 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
     app.router.add_put("/api/canvases/{name}", canvas_put_handler)
     app.router.add_delete("/api/canvases/{name}", canvas_delete_handler)
     app.router.add_get("/api/widgets/system-info", widget_system_info_handler)
+    app.router.add_get("/api/widgets/container-stats", widget_container_stats_handler)
 
     # Container Manager API
     app.router.add_get("/api/containers/discover", container_discover_handler)
+    app.router.add_get("/api/containers/{name}/stats", container_single_stats_handler)
     app.router.add_get("/api/containers/favorites", container_favorites_get_handler)
     app.router.add_put("/api/containers/favorites", container_favorites_put_handler)
     app.router.add_post("/api/containers/{name}/start", container_start_handler)

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -2317,6 +2317,57 @@ CARD_TYPE_REGISTRY.register('loader', {
 // Widget registry
 // ════════════════════════════════════════════
 const WIDGET_REGISTRY = {
+  'container-stats': {
+    label: 'Container Stats',
+    defaultRefreshInterval: 5000,
+    async render(body, card) {
+      try {
+        const resp = await fetch('/api/widgets/container-stats');
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = await resp.json();
+        if (data.error) throw new Error(data.error);
+
+        const containers = data.containers || [];
+        if (containers.length === 0) {
+          body.innerHTML = '<div class="widget-row"><span class="widget-label" style="color:#a6adc8">No managed containers</span></div>';
+          card.updateState('idle');
+          return;
+        }
+
+        const esc = (s) => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+
+        let html = '<table style="width:100%;border-collapse:collapse;font-size:12px">';
+        html += '<tr style="color:#a6adc8;border-bottom:1px solid #313244">';
+        html += '<th style="text-align:left;padding:4px 6px">Name</th>';
+        html += '<th style="text-align:left;padding:4px 6px">Status</th>';
+        html += '<th style="text-align:right;padding:4px 6px">CPU%</th>';
+        html += '<th style="text-align:right;padding:4px 6px">Memory</th>';
+        html += '<th style="text-align:right;padding:4px 6px">Mem%</th>';
+        html += '</tr>';
+        for (const c of containers) {
+          const owned = c.created_by === 'canvas-claude';
+          const rowStyle = owned
+            ? 'border-bottom:1px solid #181825;background:rgba(137,180,250,0.08)'
+            : 'border-bottom:1px solid #181825';
+          const statusColor = c.status === 'running' ? '#a6e3a1' : '#6c7086';
+          html += `<tr style="${rowStyle}">`;
+          html += `<td style="padding:4px 6px">${esc(c.name)}${owned ? ' <span style="color:#89b4fa" title="canvas-claude owned">*</span>' : ''}</td>`;
+          html += `<td style="padding:4px 6px;color:${statusColor}">${esc(c.status)}</td>`;
+          html += `<td style="padding:4px 6px;text-align:right">${esc(c.cpu_percent)}</td>`;
+          html += `<td style="padding:4px 6px;text-align:right">${esc(c.mem_usage)}</td>`;
+          html += `<td style="padding:4px 6px;text-align:right">${esc(c.mem_percent)}</td>`;
+          html += '</tr>';
+        }
+        html += '</table>';
+        html += '<div style="font-size:10px;color:#6c7086;margin-top:4px">Snapshot, 5s refresh. * = canvas-claude-owned</div>';
+        body.innerHTML = html;
+        card.updateState('working');
+      } catch (err) {
+        body.innerHTML = `<div class="widget-row"><span class="widget-label" style="color:#f38ba8">Error: ${err.message}</span></div>`;
+        card.updateState('dead');
+      }
+    },
+  },
   'system-info': {
     label: 'System Info',
     defaultRefreshInterval: 10000,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -30,6 +30,7 @@ from claude_rts.mcp_server import (
     tool_container_append_action,
     tool_container_start,
     tool_container_stop,
+    tool_container_stats,
     tool_container_create,
     tool_container_rebuild,
     tool_blueprint_list,
@@ -207,6 +208,7 @@ def test_handle_request_tools_list():
         "container_append_action",
         "container_start",
         "container_stop",
+        "container_stats",
         "container_add_favorite",
         "container_create",
         "container_rebuild",
@@ -426,7 +428,8 @@ def test_tools_list_includes_container_and_blueprint_tools():
     assert "get_recovery_script" in names
     assert "run_task" in names
     assert "container_create" in names
-    assert len(names) == 24
+    assert "container_stats" in names
+    assert len(names) == 25
 
 
 # ── container_get_actions ──────────────────────────────────────────────
@@ -566,6 +569,28 @@ def test_container_stop_with_timeout():
     req = mock_open.call_args[0][0]
     assert "timeout=30" in req.full_url
     assert "via=canvas-claude" in req.full_url
+
+
+def test_container_stats_calls_rest():
+    """container_stats GETs /api/containers/{name}/stats."""
+    payload = {
+        "name": "foo-dev",
+        "cpu_percent": "1.23%",
+        "mem_usage": "100MiB",
+        "mem_limit": "1GiB",
+    }
+    mock_resp = make_mock_response(payload)
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+        result = tool_container_stats({"name": "foo-dev"})
+    assert "foo-dev" in result
+    req = mock_open.call_args[0][0]
+    assert req.method == "GET"
+    assert "/api/containers/foo-dev/stats" in req.full_url
+
+
+def test_container_stats_missing_name():
+    with pytest.raises(ValueError, match="name is required"):
+        tool_container_stats({})
 
 
 def test_container_stop_always_sends_origin_signal():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -91,4 +91,80 @@ async def test_app_has_all_routes(app):
     assert "/api/canvases/{name}" in routes
     assert "/api/startup" in routes
     assert "/api/widgets/system-info" in routes
+    assert "/api/widgets/container-stats" in routes
+    assert "/api/containers/{name}/stats" in routes
     assert "/ws/exec" in routes
+
+
+async def test_widget_container_stats_returns_containers(client, app):
+    # Use test-mode injection to avoid docker CLI dependency
+    app["_test_container_stats"] = [
+        {
+            "name": "cc-demo",
+            "status": "running",
+            "cpu_percent": "1.23%",
+            "mem_usage": "100MiB",
+            "mem_limit": "1GiB",
+            "mem_percent": "9.77%",
+            "net_io": "1kB / 2kB",
+            "block_io": "0B / 0B",
+            "pids": 5,
+            "created_by": "canvas-claude",
+        },
+        {
+            "name": "other",
+            "status": "stopped",
+            "cpu_percent": "0.00%",
+            "mem_usage": "0B",
+            "mem_limit": "0B",
+            "mem_percent": "0.00%",
+            "net_io": "--",
+            "block_io": "--",
+            "pids": 0,
+            "created_by": "",
+        },
+    ]
+    resp = await client.get("/api/widgets/container-stats")
+    assert resp.status == 200
+    data = await resp.json()
+    assert "containers" in data
+    names = [c["name"] for c in data["containers"]]
+    assert "cc-demo" in names
+    assert "other" in names
+    cc = next(c for c in data["containers"] if c["name"] == "cc-demo")
+    assert cc["created_by"] == "canvas-claude"
+    assert cc["status"] == "running"
+
+
+async def test_widget_container_stats_empty(client, app):
+    app["_test_container_stats"] = []
+    resp = await client.get("/api/widgets/container-stats")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["containers"] == []
+
+
+async def test_container_single_stats_returns_data(client, app):
+    app["_test_container_stats"] = [
+        {
+            "name": "cc-demo",
+            "status": "running",
+            "cpu_percent": "5.00%",
+            "mem_usage": "50MiB",
+            "mem_limit": "500MiB",
+            "mem_percent": "10.00%",
+            "created_by": "canvas-claude",
+        },
+    ]
+    resp = await client.get("/api/containers/cc-demo/stats")
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["name"] == "cc-demo"
+    assert data["cpu_percent"] == "5.00%"
+    assert data["mem_usage"] == "50MiB"
+
+
+async def test_container_single_stats_404(client, app):
+    app["_test_container_stats"] = []
+    resp = await client.get("/api/containers/nope/stats")
+    assert resp.status == 404


### PR DESCRIPTION
Closes #206

Part of epic #199 (epic/199-container-manager).

## Summary
- `GET /api/widgets/container-stats`: all containers with live CPU/MEM stats; canvas-claude-owned rows flagged via `created_by` label
- `GET /api/containers/{name}/stats`: single-container stats for MCP tool
- `container_stats` MCP tool
- Widget registered in WIDGET_REGISTRY with 5s auto-refresh
- Sidebar spawnable item auto-populated from WIDGET_REGISTRY

## Test plan
- [x] `python -m pytest tests/ --ignore=tests/e2e` — 521 passed
- [x] `ruff check` + `ruff format --check` clean
- [ ] Spawn widget via canvas context menu; verify 5s refresh and canvas-claude row highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)