### PR TITLE
feat(#207): mount claude-profiles volume in managed containers

### DIFF
--- a/claude_rts/container_spec.py
+++ b/claude_rts/container_spec.py
@@ -42,6 +42,12 @@ DEFAULT_MEMORY_LIMIT: str = "8g"
 DEFAULT_DISK_LIMIT: str = "10g"
 DEFAULT_PIDS_LIMIT: int = 1024
 
+#: Name of the named Docker volume holding Claude credentials. Same volume
+#: used by the util container and the ``start-claude`` dev preset so managed
+#: containers see the same ``/profiles/<profile>/.credentials.json`` layout.
+#: Auto-created by Docker on first use if it does not already exist.
+DEFAULT_PROFILES_VOLUME: str = "claude-profiles"
+
 
 @dataclass
 class ContainerSpec:
@@ -70,6 +76,13 @@ class ContainerSpec:
     memory_limit: str = DEFAULT_MEMORY_LIMIT
     disk_limit: str = DEFAULT_DISK_LIMIT
     pids_limit: int = DEFAULT_PIDS_LIMIT
+    # Profiles volume mount (#207). Default on — managed containers need
+    # access to ``/profiles/<profile>/.credentials.json`` so Canvas Claude can
+    # start Claude sessions inside them using the same credentials the util
+    # container and ``start-claude`` preset already use. Opt-out via
+    # ``mount_profiles=False`` for future flexibility.
+    mount_profiles: bool = True
+    profiles_volume: str = DEFAULT_PROFILES_VOLUME
 
     def __post_init__(self) -> None:
         if not self.name:
@@ -102,6 +115,16 @@ class ContainerSpec:
         mounts = list(self.mounts) or [
             f"source={self.workspace_volume},target=/workspace,type=volume",
         ]
+        # Profiles volume mount (#207). Always appended to the default mount
+        # list so managed containers see ``/profiles`` with the same layout as
+        # the util container. Custom ``mounts=[...]`` callers are respected
+        # verbatim (they can add the profiles mount themselves or set
+        # ``mount_profiles=False`` explicitly); we only auto-append when the
+        # caller did not supply custom mounts AND opted in.
+        if self.mount_profiles and not self.mounts:
+            profiles_mount = f"source={self.profiles_volume},target=/profiles,type=volume"
+            if profiles_mount not in mounts:
+                mounts.append(profiles_mount)
 
         return {
             "image": self.image,

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -619,6 +619,14 @@ async def container_create_handler(request: web.Request) -> web.Response:
     if "pids_limit" in cap_defaults:
         cap_kwargs["pids_limit"] = int(cap_defaults["pids_limit"])
 
+    # Profiles volume mount (#207). Volume name is configurable via the same
+    # ``util_container.mounts.profiles`` config key used by the util container
+    # so both point at the same named volume by default (``claude-profiles``).
+    profiles_volume = (
+        cfg.get("util_container", {}).get("mounts", {}).get("profiles") or container_spec_mod.DEFAULT_PROFILES_VOLUME
+    )
+    cap_kwargs["profiles_volume"] = profiles_volume
+
     spec = container_spec_mod.ContainerSpec(
         image=image,
         name=name,

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -535,6 +535,44 @@ async def test_container_create_applies_configured_resource_caps(app, client, tm
     assert "--pids-limit=2048" in run_args
 
 
+async def test_container_create_mounts_profiles_volume_by_default(app, client):
+    """#207: default creation mounts claude-profiles at /profiles."""
+    app["_test_container_create"] = {}
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "profiles-default"},
+    )
+    assert resp.status == 200
+    dc = app["_test_container_create"]["calls"][0]["devcontainer_json"]
+    mounts = dc["mounts"]
+    assert any("source=claude-profiles" in m and "target=/profiles" in m and "type=volume" in m for m in mounts), (
+        f"profiles mount missing: {mounts}"
+    )
+    # Workspace mount still present alongside profiles mount.
+    assert any("target=/workspace" in m for m in mounts)
+
+
+async def test_container_create_profiles_volume_name_configurable(app, client):
+    """#207: volume name honours ``util_container.mounts.profiles`` config."""
+    app_config = app["app_config"]
+    config.write_config(
+        app_config,
+        {
+            "container_manager": {"image_whitelist": ["ubuntu:24.04"]},
+            "util_container": {"mounts": {"profiles": "team-creds"}},
+        },
+    )
+    app["_test_container_create"] = {}
+    resp = await client.post(
+        "/api/containers/create",
+        json={"image": "ubuntu:24.04", "name": "profiles-custom"},
+    )
+    assert resp.status == 200
+    mounts = app["_test_container_create"]["calls"][0]["devcontainer_json"]["mounts"]
+    assert any("source=team-creds" in m and "target=/profiles" in m for m in mounts)
+    assert not any("source=claude-profiles" in m for m in mounts)
+
+
 async def test_container_create_generates_name_when_omitted(app, client):
     app["_test_container_create"] = {}
     resp = await client.post("/api/containers/create", json={"image": "ubuntu:24.04"})

--- a/tests/test_container_spec.py
+++ b/tests/test_container_spec.py
@@ -130,6 +130,58 @@ def test_resource_caps_preserved_alongside_labels():
     assert any(a.startswith("--memory=") for a in args)
 
 
+# ── Profiles volume mount (#207) ─────────────────────────────────────
+
+
+def test_devcontainer_preset_mounts_profiles_volume_by_default():
+    """#207 acceptance: default spec mounts claude-profiles at /profiles."""
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="foo")
+    dc = spec.devcontainer_preset()
+    assert any(
+        "source=claude-profiles" in m and "target=/profiles" in m and "type=volume" in m for m in dc["mounts"]
+    ), f"profiles mount missing: {dc['mounts']}"
+
+
+def test_devcontainer_preset_keeps_workspace_mount_alongside_profiles():
+    """Workspace mount and profiles mount coexist in the default mount list."""
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="foo")
+    dc = spec.devcontainer_preset()
+    assert any("source=foo-workspace" in m and "target=/workspace" in m for m in dc["mounts"])
+    assert any("source=claude-profiles" in m and "target=/profiles" in m for m in dc["mounts"])
+
+
+def test_devcontainer_preset_profiles_volume_name_is_configurable():
+    """Volume name flows through from the ``profiles_volume`` field."""
+    spec = cs.ContainerSpec(
+        image="ubuntu:24.04",
+        name="foo",
+        profiles_volume="my-creds-vol",
+    )
+    dc = spec.devcontainer_preset()
+    assert any("source=my-creds-vol" in m and "target=/profiles" in m for m in dc["mounts"])
+    assert not any("source=claude-profiles" in m for m in dc["mounts"])
+
+
+def test_devcontainer_preset_opt_out_of_profiles_mount():
+    """``mount_profiles=False`` drops the /profiles mount entirely."""
+    spec = cs.ContainerSpec(image="ubuntu:24.04", name="foo", mount_profiles=False)
+    dc = spec.devcontainer_preset()
+    assert not any("target=/profiles" in m for m in dc["mounts"])
+    # Workspace mount still there.
+    assert any("target=/workspace" in m for m in dc["mounts"])
+
+
+def test_custom_mounts_skip_auto_profiles_injection():
+    """Explicit ``mounts=[...]`` respected verbatim — no auto-injection."""
+    spec = cs.ContainerSpec(
+        image="ubuntu:24.04",
+        name="foo",
+        mounts=["source=my-vol,target=/data,type=volume"],
+    )
+    dc = spec.devcontainer_preset()
+    assert dc["mounts"] == ["source=my-vol,target=/data,type=volume"]
+
+
 def test_create_does_not_shell_out_synchronously():
     """Regression guard: ensure container_spec does not import subprocess.run."""
     import inspect


### PR DESCRIPTION
Closes #207

Part of epic #199 (epic/199-container-manager).

## Summary
All canvas-claude-created containers now mount the `claude-profiles` named volume at `/profiles`. This enables Claude credential access inside managed containers (same pattern as the util container). Volume name configurable via `util_container.mounts.profiles` config; opt-out via `ContainerSpec(mount_profiles=False)`.

## Changes
- `claude_rts/container_spec.py`: add `mount_profiles` (default True) and `profiles_volume` (default `claude-profiles`) fields; auto-append `/profiles` volume mount in `devcontainer_preset()` when using the default mount list.
- `claude_rts/server.py`: wire `util_container.mounts.profiles` config into the `ContainerSpec` at `POST /api/containers/create` so both the util container and managed containers share the same named volume.
- `tests/test_container_spec.py`: 5 new unit tests covering default mount, workspace coexistence, configurable name, opt-out, and custom-mounts respect-verbatim.
- `tests/test_container_manager.py`: 2 new integration tests covering default volume name and config override.

## Test plan
- [x] `python -m ruff check .` clean
- [x] `python -m ruff format --check .` clean
- [x] `python -m pytest tests/ --ignore=tests/e2e` — 528 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)