### PR TITLE
fix(#222): add --host CLI flag to override bind address

### DIFF
--- a/claude_rts/__main__.py
+++ b/claude_rts/__main__.py
@@ -55,6 +55,7 @@ def main():
     parser = argparse.ArgumentParser(description="supreme-claudemander terminal canvas")
     parser.add_argument("--version", action="version", version=f"supreme-claudemander {_get_version()}")
     parser.add_argument("--port", type=int, default=3000, help="Server port (default: 3000)")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
     parser.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
     parser.add_argument("--electron", action="store_true", help="Launch in Electron shell instead of browser")
     parser.add_argument("--test-mode", action="store_true", help="Enable test puppeting API")
@@ -98,7 +99,7 @@ def main():
         format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {name}:{function}:{line} - {message}",
     )
 
-    logger.info("supreme-claudemander starting on http://localhost:{}", args.port)
+    logger.info("supreme-claudemander starting on http://{}:{}", args.host, args.port)
 
     test_mode = args.test_mode or os.environ.get("CLAUDE_RTS_TEST_MODE", "").lower() in ("1", "true")
     app = create_app(app_config, test_mode=test_mode)
@@ -138,14 +139,17 @@ def main():
     elif not args.no_browser:
 
         async def open_browser(app):
-            url = f"http://localhost:{args.port}"
+            # Browser URL uses 'localhost' when binding to wildcard 0.0.0.0 (macOS
+            # cannot open http://0.0.0.0); otherwise use the explicit host.
+            browser_host = "localhost" if args.host == "0.0.0.0" else args.host
+            url = f"http://{browser_host}:{args.port}"
             logger.info("Opening browser: {}", url)
             webbrowser.open(url)
 
         app.on_startup.append(open_browser)
 
     logger.info("Press Ctrl+C to stop")
-    web.run_app(app, host="127.0.0.1", port=args.port, print=None)
+    web.run_app(app, host=args.host, port=args.port, print=None)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,6 +43,42 @@ def test_custom_port():
         assert call_kwargs.kwargs["port"] == 4000
 
 
+def test_custom_host():
+    """Verify --host 0.0.0.0 is passed through to web.run_app."""
+    with (
+        patch("sys.argv", ["supreme-claudemander", "--host", "0.0.0.0", "--no-browser"]),
+        patch("claude_rts.__main__.web") as mock_web,
+        patch("claude_rts.__main__.create_app") as mock_create,
+        patch("claude_rts.__main__.config") as mock_config,
+    ):
+        mock_config.load.return_value = MagicMock()
+        mock_create.return_value = MagicMock()
+        try:
+            main()
+        except SystemExit:
+            pass
+        call_kwargs = mock_web.run_app.call_args
+        assert call_kwargs.kwargs["host"] == "0.0.0.0"
+
+
+def test_custom_host_tailscale_ip():
+    """Verify --host accepts a Tailscale-range IP and passes it through verbatim."""
+    with (
+        patch("sys.argv", ["supreme-claudemander", "--host", "100.64.0.1", "--no-browser"]),
+        patch("claude_rts.__main__.web") as mock_web,
+        patch("claude_rts.__main__.create_app") as mock_create,
+        patch("claude_rts.__main__.config") as mock_config,
+    ):
+        mock_config.load.return_value = MagicMock()
+        mock_create.return_value = MagicMock()
+        try:
+            main()
+        except SystemExit:
+            pass
+        call_kwargs = mock_web.run_app.call_args
+        assert call_kwargs.kwargs["host"] == "100.64.0.1"
+
+
 def test_no_browser_flag():
     """Verify --no-browser skips browser open."""
     with (


### PR DESCRIPTION
Closes #222

## What changed

Adds a `--host` CLI argument to `python -m claude_rts` that overrides the previously hard-coded `127.0.0.1` bind address passed to `web.run_app`. The default remains `127.0.0.1`, so existing users see no behavior change. When `--host 0.0.0.0` (or any address, including a Tailscale IP like `100.64.0.1`) is passed, that value flows through to `web.run_app` verbatim — aiohttp validates the address, argparse does not. The startup log line now reflects `args.host` instead of the hard-coded string `localhost`.

## Implementation walkthrough

### Changes to `claude_rts/__main__.py`

- **`parser.add_argument("--host", ...)` (line 58)** — Registers `--host` with `default="127.0.0.1"`. No type coercion; any string is accepted and aiohttp rejects bad values at bind time.
- **Startup log line (line 102)** — Changed from `http://localhost:{port}` to `http://{args.host}:{port}` so the logged URL matches the actual bind address (Scenario 4).
- **Browser auto-open URL (lines 142–145)** — When `args.host` is `0.0.0.0`, the browser is opened at `http://localhost:{port}` rather than `http://0.0.0.0:{port}`, because macOS cannot open a wildcard address in a browser tab. For any other value of `args.host` the browser URL uses `args.host` directly.
- **`web.run_app` call (line 152)** — `host="127.0.0.1"` replaced with `host=args.host`.

### New tests in `tests/test_main.py`

- **`test_custom_host`** — passes `--host 0.0.0.0`, asserts `web.run_app` receives `host="0.0.0.0"` (Scenario 2).
- **`test_custom_host_tailscale_ip`** — passes `--host 100.64.0.1`, asserts the string is forwarded unchanged (Scenario 3).
- **`test_default_port`** (existing, unchanged) — still asserts `host == "127.0.0.1"` for the no-flag case (Scenario 1).

## Tier / approach

Tier 1 — Planner → Coder → Reviewer (single-file additive change, < 50 lines)

## Acceptance criteria

- [x] `python -m claude_rts` (no flags) still binds to `127.0.0.1`
- [x] `--host 0.0.0.0` passes `host="0.0.0.0"` to `web.run_app`
- [x] `--host 100.64.0.1` passes that string through verbatim
- [x] Startup log line reflects actual host (not hard-coded `localhost`)
- [x] `ruff check` and `ruff format --check` pass
- [x] All 10 `test_main.py` tests pass

## Outstanding items

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)