### PR TITLE
fix(#226): ci: add Tailscale connectivity test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,62 @@ jobs:
             tests/e2e/traces/
             tests/e2e/screenshots/
           retention-days: 7
+
+  tailscale:
+    # Skip on fork PRs — secrets are not available to forks, and we must
+    # not attempt Tailscale enrollment without credentials. Direct pushes
+    # (no pull_request payload) and same-repo PRs run the job.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[test]"
+      - name: Enroll ephemeral Tailscale node
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+      - name: Start server bound to 0.0.0.0
+        run: |
+          python -m claude_rts --host 0.0.0.0 --no-browser >/tmp/server.log 2>&1 &
+          echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+          # Wait for the server to start listening on port 3000.
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:3000/ >/dev/null; then
+              echo "Server is up after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+          curl -sf http://127.0.0.1:3000/ >/dev/null \
+            || { echo "Server failed to start within 30s"; cat /tmp/server.log; exit 1; }
+      - name: Verify reachability at Tailscale IP
+        run: |
+          TS_IP="$(tailscale ip -4 | head -n1)"
+          if [ -z "$TS_IP" ]; then
+            echo "Failed to resolve Tailscale IPv4 address" >&2
+            exit 1
+          fi
+          echo "Tailscale IP: $TS_IP"
+          # Fail loudly on non-2xx, and echo the headers for the CI log.
+          curl -fsS -D - "http://${TS_IP}:3000/" -o /dev/null
+      - name: Stop server
+        if: always()
+        run: |
+          if [ -n "${SERVER_PID:-}" ]; then
+            kill "$SERVER_PID" 2>/dev/null || true
+          fi
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tailscale-server-log
+          path: /tmp/server.log
+          retention-days: 7


### PR DESCRIPTION
Closes #226

Adds a new `tailscale` job to `.github/workflows/ci.yml` that enrolls the CI runner as an ephemeral Tailscale node, starts the server with `--host 0.0.0.0 --no-browser`, and verifies reachability at the Tailscale IP via HTTP.

## What changed

- **New `tailscale` job** in `ci.yml`, positioned after the existing `e2e` job.
- Gated by `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository` so fork PRs skip gracefully (no secret access) while direct pushes and same-repo PRs run.
- `needs: [lint, test]` so we don't enroll Tailscale for obviously-broken PRs. `e2e` is not in `needs` — the two jobs run in parallel after lint/test.
- Uses `tailscale/github-action@v3` with `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET` repo secrets and `tags: tag:ci`.
- Starts the server in background, waits up to 30s on `127.0.0.1:3000/` for readiness (dumps the server log and fails if not up), then resolves the Tailscale IPv4 with `tailscale ip -4` and curls `http://<ts-ip>:3000/` with `-fsS -D -` so any non-2xx fails the job.
- Server log uploaded as an artifact on failure for debugging.
- Always-run kill step terminates the backgrounded server at the end of the job; ephemeral Tailscale node teardown is handled by `tailscale/github-action@v3` itself.

## Open questions resolved

- **Q1 (teardown):** `tailscale/github-action@v3` handles ephemeral node teardown automatically at job end — no explicit teardown step added.
- **Q2 (dependency):** `needs: [lint, test]` — saves CI minutes and avoids enrolling bad PRs into Tailscale.
- **Q3 (IP format):** `tailscale ip -4` returns the 100.x.x.x IPv4 on stdout; we take `head -n1` and validate non-empty before curling.

## Tier / approach

Tier 1 — single file (`.github/workflows/ci.yml`), clear requirements, ~60-line diff.

## Acceptance criteria

- [x] Scenario 1: Non-fork push/PR — job runs; server reachable at Tailscale IP with HTTP 200.
- [x] Scenario 2: Fork PR — job skipped via `if:` condition; no secret access.
- [x] Scenario 3: Missing secrets — `tailscale/github-action@v3` fails loudly with a clear error (its own handling); no silent pass.
- [x] Scenario 4: Existing `lint`/`test`/`e2e` jobs unchanged; only an additive job was introduced.
- [x] Invariant: uses `--host 0.0.0.0` explicitly, never relies on a default bind change.

## Outstanding items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)