### PR TITLE
fix(#238): generic PUT /api/cards/{id}/state endpoint

### DIFF
--- a/claude_rts/cards/base.py
+++ b/claude_rts/cards/base.py
@@ -16,6 +16,18 @@ class BaseCard(abc.ABC):
     card_type: str = "base"
     hidden: bool = False  # ServiceCard overrides to True
 
+    # Allowlist of attribute names that may be mutated through
+    # ``CardRegistry.apply_state_patch`` (the single server-owned mutation path
+    # defined by epic #236 / issue #238). Subclasses extend this set with any
+    # additional server-owned fields. Fields outside this set are rejected with
+    # HTTP 400 by ``PUT /api/cards/{id}/state``.
+    #
+    # To add a new server-owned field: add its name here (or on a subclass),
+    # ensure it is a plain ``str`` attribute on the card instance, and add a
+    # one-line dispatch entry in ``handleControlCardUpdated`` in
+    # ``static/index.html``.
+    MUTABLE_FIELDS: frozenset[str] = frozenset()
+
     def __init__(self, card_id: str | None = None, bus: EventBus | None = None):
         self._id = card_id or uuid.uuid4().hex[:8]
         self._bus = bus

--- a/claude_rts/cards/card_registry.py
+++ b/claude_rts/cards/card_registry.py
@@ -53,6 +53,47 @@ class CardRegistry:
         """Look up a card by id."""
         return self._cards.get(card_id)
 
+    def apply_state_patch(self, card_id: str, fields: dict) -> dict:
+        """Apply a partial state patch to the card with the given id.
+
+        This is the **sole** attribute-mutation path for server-owned card
+        fields — the generic ``PUT /api/cards/{id}/state`` handler and the
+        legacy ``/rename`` + ``/recovery-script`` aliases all funnel through
+        here (see issue #238 / state-model.md).
+
+        Each key in ``fields`` must appear in the card's
+        ``MUTABLE_FIELDS`` allowlist and its value must be a ``str`` (the
+        initial slice only covers string fields; Children 3/4 extend to
+        ``bool`` / ``int`` / ``float`` as needed).
+
+        Returns the dict of fields that were actually applied.
+
+        Raises:
+            LookupError: card_id is not in the registry.
+            ValueError: a field is not in the card's allowlist or has the
+                wrong type. The message identifies the offending field so
+                callers can surface a structured 400.
+        """
+        card = self._cards.get(card_id)
+        if card is None:
+            raise LookupError(card_id)
+
+        allowed = getattr(card, "MUTABLE_FIELDS", frozenset())
+        applied: dict = {}
+        for key, value in fields.items():
+            if key not in allowed:
+                raise ValueError(f"field '{key}' is not mutable on card_type '{card.card_type}'")
+            # Initial allowlist (display_name, recovery_script) is str-only.
+            # When Children 3/4 add bool/int/float fields, extend this check.
+            if not isinstance(value, str):
+                raise ValueError(f"field '{key}' must be a string")
+            setattr(card, key, value)
+            applied[key] = value
+
+        if applied:
+            logger.debug("CardRegistry: patched card '{}' fields={}", card_id, list(applied.keys()))
+        return applied
+
     def get_terminal(self, session_id: str) -> TerminalCard | None:
         """Look up a TerminalCard by session_id (convenience)."""
         card = self._cards.get(session_id)

--- a/claude_rts/cards/terminal_card.py
+++ b/claude_rts/cards/terminal_card.py
@@ -18,6 +18,10 @@ class TerminalCard(BaseCard):
     card_type: str = "terminal"
     hidden: bool = False
 
+    # Server-owned fields that ``PUT /api/cards/{id}/state`` may mutate.
+    # See ``BaseCard.MUTABLE_FIELDS`` for the contract.
+    MUTABLE_FIELDS: frozenset[str] = frozenset({"display_name", "recovery_script"})
+
     def __init__(
         self,
         session_manager,

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -1900,30 +1900,82 @@ async def claude_terminal_delete(request: web.Request) -> web.Response:
     return web.json_response({"status": "ok"})
 
 
-async def claude_terminal_rename(request: web.Request) -> web.Response:
-    """PUT /api/claude/terminal/{id}/rename — set a display name."""
-    card_id = request.match_info["id"]
-    card_registry: CardRegistry = request.app["card_registry"]
-    card = card_registry.get_terminal(card_id)
-    if not card:
-        raise web.HTTPNotFound(text="Terminal not found")
+async def _apply_card_state_patch(request: web.Request, card_id: str, fields: dict) -> dict:
+    """Shared body of the generic + legacy state-mutation handlers.
 
+    This is the single authoritative code path for mutating server-owned card
+    state (see ``docs/state-model.md`` and epic #236 / issue #238). Both the
+    generic ``PUT /api/cards/{id}/state`` handler and the legacy
+    ``/rename`` + ``/recovery-script`` aliases funnel through here so exactly
+    one implementation performs allowlist validation, attribute mutation via
+    ``CardRegistry.apply_state_patch``, and the ``card_updated`` broadcast.
+
+    Raises ``web.HTTPNotFound`` / ``web.HTTPBadRequest`` for the caller to
+    propagate. Returns the dict of applied fields.
+    """
+    card_registry: CardRegistry = request.app["card_registry"]
+    try:
+        applied = card_registry.apply_state_patch(card_id, fields)
+    except LookupError:
+        raise web.HTTPNotFound(text="Card not found")
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text=str(exc))
+
+    if applied:
+        await _broadcast_card_updated(request.app, card_id, applied)
+    return applied
+
+
+async def cards_state_put(request: web.Request) -> web.Response:
+    """PUT /api/cards/{id}/state — generic server-owned state mutation.
+
+    Accepts a partial JSON dict of card state fields. Each field is validated
+    against the target card's ``MUTABLE_FIELDS`` allowlist; unknown fields get
+    HTTP 400. On success the patched fields are broadcast to every
+    ``/ws/control`` client via ``card_updated``.
+
+    This endpoint is the structural embodiment of Decision Prior DP-2 from
+    epic #236 — a single generic mutation path, not per-field endpoints.
+    """
+    card_id = request.match_info["id"]
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        raise web.HTTPBadRequest(text="Invalid JSON")
+    if not isinstance(body, dict):
+        raise web.HTTPBadRequest(text="Body must be a JSON object")
+
+    applied = await _apply_card_state_patch(request, card_id, body)
+    logger.info("cards_state_put: {} patched fields={}", card_id, list(applied.keys()))
+    return web.json_response({"status": "ok", **applied})
+
+
+async def claude_terminal_rename(request: web.Request) -> web.Response:
+    """PUT /api/claude/terminal/{id}/rename — legacy alias for display_name.
+
+    Thin wrapper around the generic ``PUT /api/cards/{id}/state`` path.
+    Retained for one release per epic #236 invariant I-6 so MCP callers
+    (``mcp_server.py``) keep working. The body ``{"display_name": ...}`` is
+    translated into the generic patch shape and delegated to the shared
+    ``_apply_card_state_patch`` helper.
+    """
+    card_id = request.match_info["id"]
     try:
         body = await request.json()
     except json.JSONDecodeError:
         raise web.HTTPBadRequest(text="Invalid JSON")
 
     display_name = body.get("display_name", "")
-    if not isinstance(display_name, str):
-        raise web.HTTPBadRequest(text="'display_name' must be a string")
+    # Preserve the legacy 404-for-terminal-only semantics so existing tests
+    # keep passing: if the card exists but isn't a terminal, the legacy URL
+    # must still report "not found".
+    card_registry: CardRegistry = request.app["card_registry"]
+    if card_registry.get_terminal(card_id) is None:
+        raise web.HTTPNotFound(text="Terminal not found")
 
-    card.display_name = display_name
+    applied = await _apply_card_state_patch(request, card_id, {"display_name": display_name})
     logger.info("claude_terminal_rename: {} -> {!r}", card_id, display_name)
-
-    # Broadcast card_updated via control WS
-    await _broadcast_card_updated(request.app, card_id, {"display_name": display_name})
-
-    return web.json_response({"status": "ok", "display_name": display_name})
+    return web.json_response({"status": "ok", "display_name": applied.get("display_name", display_name)})
 
 
 async def claude_terminal_recovery_get(request: web.Request) -> web.Response:
@@ -1938,29 +1990,25 @@ async def claude_terminal_recovery_get(request: web.Request) -> web.Response:
 
 
 async def claude_terminal_recovery_put(request: web.Request) -> web.Response:
-    """PUT /api/claude/terminal/{id}/recovery-script — set recovery script."""
-    card_id = request.match_info["id"]
-    card_registry: CardRegistry = request.app["card_registry"]
-    card = card_registry.get_terminal(card_id)
-    if not card:
-        raise web.HTTPNotFound(text="Terminal not found")
+    """PUT /api/claude/terminal/{id}/recovery-script — legacy alias for recovery_script.
 
+    Thin wrapper around the generic ``PUT /api/cards/{id}/state`` path.
+    Retained for one release per epic #236 invariant I-6.
+    """
+    card_id = request.match_info["id"]
     try:
         body = await request.json()
     except json.JSONDecodeError:
         raise web.HTTPBadRequest(text="Invalid JSON")
 
     script = body.get("recovery_script", "")
-    if not isinstance(script, str):
-        raise web.HTTPBadRequest(text="'recovery_script' must be a string")
+    card_registry: CardRegistry = request.app["card_registry"]
+    if card_registry.get_terminal(card_id) is None:
+        raise web.HTTPNotFound(text="Terminal not found")
 
-    card.recovery_script = script
+    applied = await _apply_card_state_patch(request, card_id, {"recovery_script": script})
     logger.info("claude_terminal_recovery_put: {} -> {!r}", card_id, script[:80])
-
-    # Broadcast card_updated via control WS
-    await _broadcast_card_updated(request.app, card_id, {"recovery_script": script})
-
-    return web.json_response({"status": "ok", "recovery_script": script})
+    return web.json_response({"status": "ok", "recovery_script": applied.get("recovery_script", script)})
 
 
 async def claude_terminals_list(request: web.Request) -> web.Response:
@@ -2346,6 +2394,9 @@ def create_app(app_config: AppConfig, test_mode: bool = False) -> web.Applicatio
     app.router.add_get("/api/canvases/{name}", canvas_get_handler)
     app.router.add_put("/api/canvases/{name}", canvas_put_handler)
     app.router.add_delete("/api/canvases/{name}", canvas_delete_handler)
+
+    # Generic card state mutation (epic #236 / issue #238 — single mutation path)
+    app.router.add_put("/api/cards/{id}/state", cards_state_put)
     app.router.add_get("/api/widgets/system-info", widget_system_info_handler)
     app.router.add_get("/api/widgets/container-stats", widget_container_stats_handler)
 

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -3821,6 +3821,43 @@ function handleControlCardDeleted(msg) {
   updateHubCount();
 }
 
+// PUT /api/cards/{id}/state — the single server-owned-state mutation path
+// (epic #236 / issue #238). Every user action that mutates a server-owned
+// card field MUST round-trip through here; direct assignment to card
+// properties followed by local rendering is forbidden (see docs/state-model.md).
+async function putCardState(cardId, fields) {
+  const resp = await fetch(`/api/cards/${encodeURIComponent(cardId)}/state`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(fields),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new Error(`putCardState ${cardId} failed: ${resp.status} ${text}`);
+  }
+  return resp.json();
+}
+
+// Field-dispatch table for card_updated broadcasts.
+//
+// To add a new server-owned field: add one entry here mapping the field name
+// to a (card, value) => void applier. Keep each applier self-contained — the
+// dispatcher below iterates every known field in the incoming message.
+const CARD_UPDATED_FIELD_HANDLERS = {
+  display_name(card, value) {
+    card.displayName = value;
+    const nameSpan = card.el ? card.el.querySelector(`[data-display-name="${card.id}"]`) : null;
+    if (nameSpan) nameSpan.textContent = value || card.hub;
+  },
+  recovery_script(card, value) {
+    card.recoveryScript = value;
+    const recoveryBtn = card.el ? card.el.querySelector(`[data-recovery="${card.id}"]`) : null;
+    if (recoveryBtn) recoveryBtn.style.display = value ? 'inline' : 'none';
+  },
+  // To add a new field (e.g. `starred` in Child 3, `x`/`y`/`w`/`h`/`z_order`
+  // in Child 4): add another entry here — one line reference per field.
+};
+
 function handleControlCardUpdated(msg) {
   const cardId = msg.card_id;
   if (!cardId) return;
@@ -3829,21 +3866,15 @@ function handleControlCardUpdated(msg) {
   const card = cards.find(c => c.sessionId === cardId);
   if (!card) return;
 
-  // Update display_name if present
-  if ('display_name' in msg) {
-    card.displayName = msg.display_name;
-    const nameSpan = card.el ? card.el.querySelector(`[data-display-name="${card.id}"]`) : null;
-    if (nameSpan) nameSpan.textContent = msg.display_name || card.hub;
+  let changed = false;
+  for (const [field, applier] of Object.entries(CARD_UPDATED_FIELD_HANDLERS)) {
+    if (field in msg) {
+      applier(card, msg[field]);
+      changed = true;
+    }
   }
 
-  // Update recovery_script if present
-  if ('recovery_script' in msg) {
-    card.recoveryScript = msg.recovery_script;
-    const recoveryBtn = card.el ? card.el.querySelector(`[data-recovery="${card.id}"]`) : null;
-    if (recoveryBtn) recoveryBtn.style.display = msg.recovery_script ? 'inline' : 'none';
-  }
-
-  saveLayout();
+  if (changed) saveLayout();
 }
 
 // ════════════════════════════════════════════

--- a/tests/test_claude_api.py
+++ b/tests/test_claude_api.py
@@ -628,6 +628,168 @@ async def test_ws_control_receives_card_updated_on_rename(aiohttp_client, app_fa
         assert msg["display_name"] == "Renamed"
 
 
+# ── Issue #238: generic PUT /api/cards/{id}/state endpoint ────────────────
+
+
+async def test_cards_state_put_patches_display_name_and_broadcasts(aiohttp_client, app_factory):
+    """PUT /api/cards/{id}/state applies partial dict, updates registry, broadcasts card_updated."""
+    client = await aiohttp_client(app_factory())
+    async with client.ws_connect("/ws/control") as ws:
+        resp = await client.post("/api/claude/terminal/create?cmd=bash")
+        data = await resp.json()
+        sid = data["session_id"]
+
+        # Drain card_created
+        await ws.receive_json(timeout=2)
+
+        resp = await client.put(
+            f"/api/cards/{sid}/state",
+            json={"display_name": "Renamed via generic"},
+        )
+        assert resp.status == 200
+        result = await resp.json()
+        assert result["status"] == "ok"
+        assert result["display_name"] == "Renamed via generic"
+
+        # CardRegistry has been mutated
+        card = client.app["card_registry"].get_terminal(sid)
+        assert card.display_name == "Renamed via generic"
+
+        # card_updated was broadcast
+        msg = await ws.receive_json(timeout=2)
+        assert msg["type"] == "card_updated"
+        assert msg["card_id"] == sid
+        assert msg["display_name"] == "Renamed via generic"
+
+
+async def test_cards_state_put_multiple_fields(aiohttp_client, app_factory):
+    """PUT /api/cards/{id}/state accepts multiple fields in one patch."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=bash")
+    sid = (await resp.json())["session_id"]
+
+    resp = await client.put(
+        f"/api/cards/{sid}/state",
+        json={"display_name": "DN", "recovery_script": "echo hi"},
+    )
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["display_name"] == "DN"
+    assert result["recovery_script"] == "echo hi"
+
+    card = client.app["card_registry"].get_terminal(sid)
+    assert card.display_name == "DN"
+    assert card.recovery_script == "echo hi"
+
+
+async def test_cards_state_put_rejects_unknown_field(aiohttp_client, app_factory):
+    """PUT /api/cards/{id}/state returns 400 for fields outside the allowlist."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=bash")
+    sid = (await resp.json())["session_id"]
+
+    resp = await client.put(
+        f"/api/cards/{sid}/state",
+        json={"bogus_field": 1},
+    )
+    assert resp.status == 400
+    text = await resp.text()
+    assert "bogus_field" in text
+
+
+async def test_cards_state_put_rejects_non_string_value(aiohttp_client, app_factory):
+    """Allowlisted fields must be strings (initial slice); ints rejected with 400."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=bash")
+    sid = (await resp.json())["session_id"]
+
+    resp = await client.put(
+        f"/api/cards/{sid}/state",
+        json={"display_name": 123},
+    )
+    assert resp.status == 400
+
+
+async def test_cards_state_put_nonexistent_card(aiohttp_client, app_factory):
+    """PUT /api/cards/{id}/state on unknown card returns 404."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.put(
+        "/api/cards/nonexistent/state",
+        json={"display_name": "x"},
+    )
+    assert resp.status == 404
+
+
+async def test_cards_state_put_rejects_non_object_body(aiohttp_client, app_factory):
+    """PUT /api/cards/{id}/state with a non-object JSON body returns 400."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=bash")
+    sid = (await resp.json())["session_id"]
+
+    resp = await client.put(
+        f"/api/cards/{sid}/state",
+        data="[1, 2, 3]",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status == 400
+
+
+async def test_cards_state_put_empty_patch_is_noop(aiohttp_client, app_factory):
+    """Empty patch returns 200 and does not broadcast."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=bash")
+    sid = (await resp.json())["session_id"]
+
+    resp = await client.put(f"/api/cards/{sid}/state", json={})
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["status"] == "ok"
+
+
+async def test_legacy_rename_still_broadcasts_via_generic_path(aiohttp_client, app_factory):
+    """Legacy /rename URL continues to work and broadcasts card_updated identically."""
+    client = await aiohttp_client(app_factory())
+    async with client.ws_connect("/ws/control") as ws:
+        resp = await client.post("/api/claude/terminal/create?cmd=bash")
+        sid = (await resp.json())["session_id"]
+        await ws.receive_json(timeout=2)  # drain card_created
+
+        resp = await client.put(
+            f"/api/claude/terminal/{sid}/rename",
+            json={"display_name": "Legacy"},
+        )
+        assert resp.status == 200
+        result = await resp.json()
+        assert result["display_name"] == "Legacy"
+
+        msg = await ws.receive_json(timeout=2)
+        assert msg["type"] == "card_updated"
+        assert msg["card_id"] == sid
+        assert msg["display_name"] == "Legacy"
+
+
+async def test_legacy_recovery_script_still_broadcasts(aiohttp_client, app_factory):
+    """Legacy /recovery-script URL continues to work via the generic path."""
+    client = await aiohttp_client(app_factory())
+    async with client.ws_connect("/ws/control") as ws:
+        resp = await client.post("/api/claude/terminal/create?cmd=bash")
+        sid = (await resp.json())["session_id"]
+        await ws.receive_json(timeout=2)  # drain card_created
+
+        resp = await client.put(
+            f"/api/claude/terminal/{sid}/recovery-script",
+            json={"recovery_script": "echo recovered"},
+        )
+        assert resp.status == 200
+        result = await resp.json()
+        assert result["recovery_script"] == "echo recovered"
+
+        msg = await ws.receive_json(timeout=2)
+        assert msg["type"] == "card_updated"
+        assert msg["card_id"] == sid
+        assert msg["recovery_script"] == "echo recovered"
+
+
 # ── Ephemeral session tests (#193) ────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #238 — epic #236 child 2.

## What changed

Ships the single server-owned card-state mutation path specified by state-model.md. Adds `PUT /api/cards/{id}/state` that accepts a partial JSON dict of allowlisted fields (initial allowlist: `display_name`, `recovery_script`), applies via a new `CardRegistry.apply_state_patch()` helper, and broadcasts the patched fields via the existing `_broadcast_card_updated()` over `/ws/control`.

The legacy `PUT /api/claude/terminal/{id}/rename` and `/recovery-script` URLs are rewritten as thin aliases that delegate to the same `apply_state_patch` helper — MCP callers (`mcp_server.py`) continue to work unchanged per invariant I-6.

## Implementation

- `BaseCard.MUTABLE_FIELDS: frozenset[str]` — empty on the base class. Each subclass declares its server-owned allowlist.
- `TerminalCard.MUTABLE_FIELDS = {"display_name", "recovery_script"}` — extended by Children 3/4 when they migrate `starred`/`x`/`y`/`w`/`h`/`z_order`.
- `CardRegistry.apply_state_patch(card_id, fields)` — sole attribute-mutation path; raises `LookupError` (→ 404) and `ValueError` (→ 400) for the generic handler and legacy aliases to surface.
- `_apply_card_state_patch(request, card_id, fields)` in `server.py` — shared body used by both `cards_state_put` and the legacy rename/recovery handlers.
- Frontend `putCardState(cardId, fields)` helper in `static/index.html`.
- Frontend `CARD_UPDATED_FIELD_HANDLERS` dispatch table — adding a new field to `handleControlCardUpdated` is now a single-entry addition.

## Tier / approach

Tier 2 — direct implementation by a single agent (requirements fully specified in the epic child doc; no open architecture questions).

## Acceptance criteria

- [x] `PUT /api/cards/{id}/state` registered in `create_app()`
- [x] `CardRegistry.apply_state_patch(card_id, fields)` is the sole attribute-mutation path
- [x] Legacy `/rename` + `/recovery-script` URLs still work (existing tests unchanged)
- [x] `mcp_server.py` tool functions unchanged
- [x] `_broadcast_card_updated` remains the single broadcast point
- [x] New tests: partial dict, 400 on unknown field, non-string rejection, 404 on unknown card, non-object body, empty patch, broadcast, CardRegistry mutation
- [x] Frontend `handleControlCardUpdated` refactored to field-dispatch table with inline one-line-add comment
- [x] Ruff format + lint pass
- [x] Full test suite (543 tests) green

## Non-goals (deferred to later epic children)

- Not migrating `starred` / `x` / `y` / `w` / `h` / `z_order` — Children 3 / 4.
- Not modifying `PUT /api/canvases/{name}` — Child 5.
- Not removing the legacy aliases — separate follow-up post-epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)