### PR TITLE
fix(#239): migrate starred to server via generic state endpoint

### DIFF
--- a/claude_rts/cards/base.py
+++ b/claude_rts/cards/base.py
@@ -31,6 +31,10 @@ class BaseCard(abc.ABC):
     def __init__(self, card_id: str | None = None, bus: EventBus | None = None):
         self._id = card_id or uuid.uuid4().hex[:8]
         self._bus = bus
+        # Server-owned state (epic #236). Every field listed here must appear
+        # in ``MUTABLE_FIELDS`` on the subclass that wants it mutable through
+        # ``PUT /api/cards/{id}/state`` (see docs/state-model.md).
+        self.starred: bool = False
 
     @property
     def id(self) -> str:

--- a/claude_rts/cards/card_registry.py
+++ b/claude_rts/cards/card_registry.py
@@ -62,9 +62,11 @@ class CardRegistry:
         here (see issue #238 / state-model.md).
 
         Each key in ``fields`` must appear in the card's
-        ``MUTABLE_FIELDS`` allowlist and its value must be a ``str`` (the
-        initial slice only covers string fields; Children 3/4 extend to
-        ``bool`` / ``int`` / ``float`` as needed).
+        ``MUTABLE_FIELDS`` allowlist. Allowed value types per field are
+        declared in ``MUTABLE_FIELD_TYPES`` on the card class (defaults to
+        ``str`` for any field not listed there). Child 3 extends this to
+        ``bool`` for ``starred``; Child 4 will extend to ``int`` / ``float``
+        for position / size.
 
         Returns the dict of fields that were actually applied.
 
@@ -79,14 +81,23 @@ class CardRegistry:
             raise LookupError(card_id)
 
         allowed = getattr(card, "MUTABLE_FIELDS", frozenset())
+        field_types: dict = getattr(card, "MUTABLE_FIELD_TYPES", {})
         applied: dict = {}
         for key, value in fields.items():
             if key not in allowed:
                 raise ValueError(f"field '{key}' is not mutable on card_type '{card.card_type}'")
-            # Initial allowlist (display_name, recovery_script) is str-only.
-            # When Children 3/4 add bool/int/float fields, extend this check.
-            if not isinstance(value, str):
-                raise ValueError(f"field '{key}' must be a string")
+            expected_type = field_types.get(key, str)
+            # ``bool`` is a subclass of ``int`` in Python — enforce exact type
+            # so a caller can't sneak a bool into an int field or vice-versa.
+            if expected_type is bool:
+                if not isinstance(value, bool):
+                    raise ValueError(f"field '{key}' must be a boolean")
+            elif expected_type is int:
+                if not isinstance(value, int) or isinstance(value, bool):
+                    raise ValueError(f"field '{key}' must be an integer")
+            elif not isinstance(value, expected_type):
+                type_name = getattr(expected_type, "__name__", str(expected_type))
+                raise ValueError(f"field '{key}' must be a {type_name}")
             setattr(card, key, value)
             applied[key] = value
 

--- a/claude_rts/cards/terminal_card.py
+++ b/claude_rts/cards/terminal_card.py
@@ -20,7 +20,10 @@ class TerminalCard(BaseCard):
 
     # Server-owned fields that ``PUT /api/cards/{id}/state`` may mutate.
     # See ``BaseCard.MUTABLE_FIELDS`` for the contract.
-    MUTABLE_FIELDS: frozenset[str] = frozenset({"display_name", "recovery_script"})
+    MUTABLE_FIELDS: frozenset[str] = frozenset({"display_name", "recovery_script", "starred"})
+    # Per-field expected type for ``CardRegistry.apply_state_patch`` validation.
+    # Fields not listed here default to ``str``. Child 3 adds ``starred: bool``.
+    MUTABLE_FIELD_TYPES: dict = {"starred": bool}
 
     def __init__(
         self,
@@ -32,6 +35,7 @@ class TerminalCard(BaseCard):
         layout: dict | None = None,
         display_name: str | None = None,
         recovery_script: str | None = None,
+        starred: bool = False,
     ):
         # card_id is set *after* start() when we know the session_id,
         # unless the caller supplies one (reconnect path).
@@ -44,6 +48,10 @@ class TerminalCard(BaseCard):
         self.layout = layout or {}  # optional {x, y, w, h} hints for frontend
         self.display_name = display_name or ""
         self.recovery_script = recovery_script or ""
+        # Epic #236 child 3: ``starred`` is server-owned (see docs/state-model.md).
+        # Mutated only through ``CardRegistry.apply_state_patch`` and broadcast
+        # via ``card_updated``; never assigned directly by the client.
+        self.starred = bool(starred)
 
     # ── Descriptor serialization ───────────────────────────────────────
 
@@ -56,6 +64,10 @@ class TerminalCard(BaseCard):
         desc: dict = {
             "type": self.card_type,
             "session_id": self.id,
+            # Epic #236 child 3: ``starred`` is always included — both True and
+            # False — so the client boot path can use it as the authoritative
+            # value without needing to fall back to a legacy default.
+            "starred": bool(self.starred),
         }
         if self.hub:
             desc["hub"] = self.hub

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -1165,11 +1165,12 @@ class Card {
     starBtn.style.cssText = 'background:none;border:none;cursor:pointer;font-size:14px;padding:0 4px;color:' + (this.starred ? '#f9e2af' : '#585b70');
     starBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      this.starred = !this.starred;
-      starBtn.textContent = this.starred ? '\u2605' : '\u2606';
-      starBtn.style.color = this.starred ? '#f9e2af' : '#585b70';
-      starBtn.title = this.starred ? 'Starred — will persist across reload' : 'Unstarred — will not persist across reload';
-      saveLayout();
+      // Epic #236 child 3: ``starred`` is server-owned. The click issues
+      // PUT /api/cards/{id}/state and does NOT mutate ``this.starred`` or
+      // the DOM synchronously — the server's ``card_updated`` broadcast
+      // (handled by applyStarredToCard) drives the re-render.
+      const next = !this.starred;
+      putCardState(this.id, { starred: next }).catch(err => console.error('star put failed:', err));
     });
     titlebar.appendChild(starBtn);
 
@@ -1387,8 +1388,11 @@ class Card {
     const data = { hub: this.hub, x: this.x, y: this.y, w: this.w, h: this.h, type: this.type, controlGroups: this.controlGroupNums.length > 0 ? [...this.controlGroupNums] : undefined };
     if (this.execCmd) data.exec = this.execCmd;
     if (this.sessionId) data.session_id = this.sessionId;
-    // Issue #151: persist starring, rename, recovery, stable identity
-    if (!this.starred) data.starred = false;
+    // Issue #151: persist rename, recovery, stable identity.
+    // Epic #236 child 3 (#239): ``starred`` is server-owned — it is NOT
+    // serialised into canvas JSON. The ``cards.filter(c => c.starred)`` in
+    // saveLayout() still filters correctly because ``c.starred`` now reads
+    // from server-pushed state.
     if (this.displayName) data.displayName = this.displayName;
     if (this.recoveryScript) data.recoveryScript = this.recoveryScript;
     if (this.cardUid) data.cardUid = this.cardUid;
@@ -1629,11 +1633,68 @@ class TerminalCard extends Card {
       this._renderDormant();
       return;
     }
+    this._activate();
+  }
+
+  // Live-terminal init path. Called from onInit() for starred cards and
+  // from _applyStarredBroadcast() when a dormant card is starred from
+  // another client. Idempotent guard via ``this.term``.
+  _activate() {
+    if (this.term) return; // already live
+    const body = this.el.querySelector(`[data-body="${this.id}"]`);
+    if (body) {
+      body.innerHTML = '';
+      body.style.cssText = '';
+    }
     this.initTerminal();
     this.connectWs();
     this.setupInput();
     this.setupResizeObserver();
     this.setupClaudeBtn();
+  }
+
+  // Apply a server-pushed ``starred`` update (from card_updated). Updates
+  // ``this.starred``, the star-glyph DOM, and drives the dormant↔live
+  // transition. This is the ONLY place outside the constructor /
+  // deserialiser where ``this.starred`` is assigned (epic #236 I-1).
+  _applyStarredBroadcast(next) {
+    const wasStarred = this.starred;
+    this.starred = !!next;
+
+    // Update star-button glyph / colour / tooltip.
+    const starBtn = this.el ? this.el.querySelector(`[data-star="${this.id}"]`) : null;
+    if (starBtn) {
+      starBtn.textContent = this.starred ? '\u2605' : '\u2606';
+      starBtn.style.color = this.starred ? '#f9e2af' : '#585b70';
+      starBtn.title = this.starred
+        ? 'Starred — will persist across reload'
+        : 'Unstarred — will not persist across reload';
+    }
+
+    // Drive dormant↔live transition.
+    if (this.starred && !wasStarred) {
+      this._activate();
+    } else if (!this.starred && wasStarred) {
+      this._deactivate();
+    }
+  }
+
+  // Live→dormant transition for remote un-star events.
+  _deactivate() {
+    // Tear down the live terminal, preserving the session on the server
+    // (kill_tmux=False default). The dormant placeholder is re-rendered
+    // so the card UI matches the fresh-load dormant look.
+    this._intentionalClose = true;
+    if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      try { this.ws.close(); } catch (e) { /* ignore */ }
+    }
+    this.ws = null;
+    if (this.ro) { try { this.ro.disconnect(); } catch (e) { /* ignore */ } this.ro = null; }
+    if (this.term) { try { this.term.dispose(); } catch (e) { /* ignore */ } this.term = null; }
+    this.fitAddon = null;
+    this._intentionalClose = false;
+    this._renderDormant();
   }
 
   _renderDormant() {
@@ -1648,19 +1709,11 @@ class TerminalCard extends Card {
     resumeBtn.style.cssText = 'background:#313244;color:#cdd6f4;border:1px solid #585b70;padding:6px 16px;border-radius:4px;cursor:pointer;font-size:13px;';
     resumeBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      this.starred = true;
-      // Update star button
-      const starBtn = this.el.querySelector(`[data-star="${this.id}"]`);
-      if (starBtn) { starBtn.textContent = '\u2605'; starBtn.style.color = '#f9e2af'; starBtn.title = 'Starred — will persist across reload'; }
-      // Clear dormant body and init live terminal
-      body.innerHTML = '';
-      body.style.cssText = '';
-      this.initTerminal();
-      this.connectWs();
-      this.setupInput();
-      this.setupResizeObserver();
-      this.setupClaudeBtn();
-      saveLayout();
+      // Epic #236 child 3: Resume is a ``starred = true`` mutation — it
+      // round-trips through the server. The dormant→live transition
+      // (clearing the body, initTerminal, connectWs, etc.) is performed in
+      // applyStarredToCard when the ``card_updated`` broadcast arrives.
+      putCardState(this.id, { starred: true }).catch(err => console.error('resume put failed:', err));
     });
     body.appendChild(resumeBtn);
     this.updateState('dead');
@@ -3795,7 +3848,10 @@ async function handleControlCardCreated(msg) {
       x, y,
       w: desc.w || CARD_W,
       h: desc.h || CARD_H,
-      starred: desc.starred != null ? desc.starred : true,
+      // Epic #236 child 3: ``to_descriptor()`` always includes ``starred``
+      // (both True and False). The ``!= null`` fallback remains only for
+      // pre-epic descriptors that may predate the server-side field.
+      starred: desc.starred != null ? desc.starred : false,
       displayName: desc.display_name || '',
       recoveryScript: desc.recovery_script || '',
       cardUid: desc.cardUid || '',
@@ -3854,8 +3910,18 @@ const CARD_UPDATED_FIELD_HANDLERS = {
     const recoveryBtn = card.el ? card.el.querySelector(`[data-recovery="${card.id}"]`) : null;
     if (recoveryBtn) recoveryBtn.style.display = value ? 'inline' : 'none';
   },
-  // To add a new field (e.g. `starred` in Child 3, `x`/`y`/`w`/`h`/`z_order`
-  // in Child 4): add another entry here — one line reference per field.
+  // Epic #236 child 3 (#239): ``starred`` is server-owned. The applier
+  // updates the star glyph and drives the dormant↔live terminal transition.
+  starred(card, value) {
+    if (typeof card._applyStarredBroadcast === 'function') {
+      card._applyStarredBroadcast(value);
+    } else {
+      // Non-terminal cards: just mirror the field; no transition logic.
+      card.starred = !!value;
+    }
+  },
+  // To add a new field (e.g. `x`/`y`/`w`/`h`/`z_order` in Child 4): add
+  // another entry here — one line reference per field.
 };
 
 function handleControlCardUpdated(msg) {

--- a/tests/e2e/test_pr152_starring_rename_recovery.py
+++ b/tests/e2e/test_pr152_starring_rename_recovery.py
@@ -403,7 +403,14 @@ class TestStarPersistence:
         assert text == "\u2605", "Star should be filled after resume"
 
     def test_star_state_in_canvas_json(self, page, backend_port):
-        """Canvas JSON correctly stores starred/unstarred state."""
+        """Canvas JSON no longer carries ``starred`` — it is server-owned.
+
+        Epic #236 child 3 (#239): ``saveLayout()`` filters to only starred
+        cards and does NOT serialise the ``starred`` key. Unstarred cards
+        are absent from the canvas JSON entirely; starred cards appear
+        without a ``starred`` field. The server's ``CardRegistry`` (and the
+        ``PUT /api/cards/{id}/state`` mutation path) is the sole authority.
+        """
         card_ids = get_terminal_card_ids(page)
         assert len(card_ids) >= 2
 
@@ -439,10 +446,13 @@ class TestStarPersistence:
         )
 
         terminal_cards = [c for c in canvas_json["cards"] if c.get("type") == "terminal"]
-        assert len(terminal_cards) > 0
-
-        has_unstarred = any(c.get("starred") is False for c in terminal_cards)
-        assert has_unstarred, "Expected at least one card with starred=false in canvas JSON"
+        # Only starred cards are persisted (unstarred ones are filtered by
+        # ``cards.filter(c => c.starred)`` in saveLayout()).
+        assert len(terminal_cards) > 0, "Expected at least one starred card in canvas JSON"
+        # ``starred`` is no longer client-serialised — none of the saved
+        # entries carry the key, in either truthy or falsy form.
+        for c in terminal_cards:
+            assert "starred" not in c, f"saveLayout() must not write 'starred' post-migration; got {c!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_claude_api.py
+++ b/tests/test_claude_api.py
@@ -698,7 +698,11 @@ async def test_cards_state_put_rejects_unknown_field(aiohttp_client, app_factory
 
 
 async def test_cards_state_put_rejects_non_string_value(aiohttp_client, app_factory):
-    """Allowlisted fields must be strings (initial slice); ints rejected with 400."""
+    """Allowlisted str fields (e.g. ``display_name``) reject non-string values with 400.
+
+    After child 3 (#239), per-field type validation is declared via
+    ``MUTABLE_FIELD_TYPES``; fields defaulting to ``str`` still reject ints.
+    """
     client = await aiohttp_client(app_factory())
     resp = await client.post("/api/claude/terminal/create?cmd=bash")
     sid = (await resp.json())["session_id"]
@@ -731,6 +735,54 @@ async def test_cards_state_put_rejects_non_object_body(aiohttp_client, app_facto
         data="[1, 2, 3]",
         headers={"Content-Type": "application/json"},
     )
+    assert resp.status == 400
+
+
+async def test_cards_state_put_patches_starred_and_broadcasts(aiohttp_client, app_factory):
+    """Epic #236 child 3 (#239): PUT /api/cards/{id}/state accepts bool ``starred``.
+
+    Mutates CardRegistry, broadcasts ``card_updated`` with the new starred
+    value, and surfaces it in ``to_descriptor`` for the boot path.
+    """
+    client = await aiohttp_client(app_factory())
+    async with client.ws_connect("/ws/control") as ws:
+        resp = await client.post("/api/claude/terminal/create?cmd=bash")
+        sid = (await resp.json())["session_id"]
+        await ws.receive_json(timeout=2)  # drain card_created
+
+        resp = await client.put(f"/api/cards/{sid}/state", json={"starred": True})
+        assert resp.status == 200
+        result = await resp.json()
+        assert result["status"] == "ok"
+        assert result["starred"] is True
+
+        card = client.app["card_registry"].get_terminal(sid)
+        assert card.starred is True
+        assert card.to_descriptor()["starred"] is True
+
+        msg = await ws.receive_json(timeout=2)
+        assert msg["type"] == "card_updated"
+        assert msg["card_id"] == sid
+        assert msg["starred"] is True
+
+        # Toggle back off.
+        resp = await client.put(f"/api/cards/{sid}/state", json={"starred": False})
+        assert resp.status == 200
+        assert client.app["card_registry"].get_terminal(sid).starred is False
+        msg = await ws.receive_json(timeout=2)
+        assert msg["starred"] is False
+
+
+async def test_cards_state_put_rejects_non_bool_starred(aiohttp_client, app_factory):
+    """``starred`` must be a ``bool`` — strings / ints are rejected with 400."""
+    client = await aiohttp_client(app_factory())
+    resp = await client.post("/api/claude/terminal/create?cmd=bash")
+    sid = (await resp.json())["session_id"]
+
+    resp = await client.put(f"/api/cards/{sid}/state", json={"starred": "yes"})
+    assert resp.status == 400
+
+    resp = await client.put(f"/api/cards/{sid}/state", json={"starred": 1})
     assert resp.status == 400
 
 

--- a/tests/test_terminal_card.py
+++ b/tests/test_terminal_card.py
@@ -344,8 +344,38 @@ async def test_terminal_card_descriptor_omits_empty_display_name(monkeypatch):
     desc = card.to_descriptor()
     assert "display_name" not in desc
     assert "recovery_script" not in desc
+    # Epic #236 child 3 (#239): ``starred`` is always present in the
+    # descriptor — both ``True`` and ``False`` — so the client boot path
+    # reads the server's authoritative value instead of defaulting.
+    assert desc["starred"] is False
 
     await card.stop()
+    mgr.stop_all()
+
+
+async def test_terminal_card_starred_descriptor_round_trip(monkeypatch):
+    """``starred`` round-trips through ``to_descriptor`` in both states."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+
+    # Default (unstarred)
+    card = TerminalCard(session_manager=mgr, cmd="bash")
+    await card.start()
+    desc = card.to_descriptor()
+    assert desc["starred"] is False
+
+    # Mutated to starred (simulating apply_state_patch)
+    card.starred = True
+    desc = card.to_descriptor()
+    assert desc["starred"] is True
+
+    # Constructed as starred
+    card2 = TerminalCard(session_manager=mgr, cmd="bash", starred=True)
+    await card2.start()
+    assert card2.to_descriptor()["starred"] is True
+
+    await card.stop()
+    await card2.stop()
     mgr.stop_all()
 
 


### PR DESCRIPTION
Closes #239

Part of epic #236 child 3. Makes `starred` server-owned, mutated only through `PUT /api/cards/{id}/state` (issue #238), and broadcast via `card_updated` — removing the last client-authored state path for this field.

## What changed

### Server
- `BaseCard` gains `starred: bool = False`; `TerminalCard` adds `starred` to `MUTABLE_FIELDS` and declares `bool` in a new `MUTABLE_FIELD_TYPES` dict.
- `CardRegistry.apply_state_patch` reads `MUTABLE_FIELD_TYPES` for per-field type validation, enforcing exact `bool` vs `int` so Python's `bool <: int` doesn't slip through.
- `TerminalCard.to_descriptor` always emits `starred` (both True and False) so the boot path reads the server's authoritative value.

### Frontend
- Star-button click and Resume-button click now call `putCardState(id, {starred: bool})` and never mutate `this.starred` synchronously. DOM updates are driven by `card_updated`.
- `CARD_UPDATED_FIELD_HANDLERS` gains a `starred` entry that calls `_applyStarredBroadcast` on the card. `TerminalCard` implements that method: updates the glyph, then drives the dormant↔live transition via new `_activate` / `_deactivate` helpers.
- `serialize()` no longer writes `starred` — unstarred cards remain filtered out by `saveLayout()`'s `c.starred` predicate, which now reads server-pushed state.
- `grep 'this.starred ='` in `index.html` returns exactly three sites: the constructor initialiser, the deserialiser, and the `card_updated` handler. **No user-action mutation remains** (I-1 satisfied).

### Tests
- `test_terminal_card.py`: `to_descriptor` always includes `starred`; new round-trip test covers True/False via constructor and post-start mutation.
- `test_claude_api.py`: `PUT /api/cards/{id}/state {starred}` patches the registry, broadcasts `card_updated`, and rejects non-bool values (strings, ints) with 400.
- `tests/e2e/test_pr152_starring_rename_recovery.py::test_star_state_in_canvas_json` now asserts `starred` is absent from the saved payload (no key at all), not present-but-false.

## Tier / approach

Tier 2 — single-session implementation (server + frontend + tests). No architecture decisions were open; the child-3 spec was fully load-bearing.

## Acceptance criteria

- [x] `TerminalCard` has `starred: bool` attribute, surfaced in `to_descriptor`.
- [x] `apply_state_patch` allowlist includes `starred` with `bool` type validation.
- [x] Star button calls `putCardState(id, {starred: bool})`, no synchronous mutation.
- [x] Resume button also calls `putCardState(id, {starred: true})` — second mutation site surfaced by intent-interview addressed.
- [x] `handleControlCardUpdated` merges `starred` and re-renders glyph + drives dormant↔live transition.
- [x] `saveLayout()` payload no longer contains `starred` (asserted by the e2e regression test).
- [x] Structural grep: `this.starred =` appears only in constructor, deserialiser, and `card_updated` handler.
- [x] Backward-compat: pre-epic canvas JSON carrying `"starred": true/false` still renders correctly via legacy deserialiser defaults.

## Outstanding items

None. Cross-browser 1s sync is covered by Child 6's e2e.

Co-Authored-By: Claude Code <noreply@anthropic.com>