### PR TITLE
chore: persist cpu-poller logs to workspace with timestamped files and 15-min rolling window

### DIFF
--- a/.devcontainer/cpu-poller.sh
+++ b/.devcontainer/cpu-poller.sh
@@ -3,23 +3,22 @@
 # Designed to survive when the aiohttp server is stuck — uses only docker CLI.
 set -u
 
-LOG="${CPU_POLLER_LOG:-/tmp/container-cpu.log}"
-INTERVAL="${CPU_POLLER_INTERVAL:-5}"
-MAX_BYTES="${CPU_POLLER_MAX_BYTES:-52428800}"  # 50 MB, then rotate once
+LOG="${CPU_POLLER_LOG:-/workspaces/claude-rts/.cpu-logs/container-cpu-$(date -u +%Y%m%d-%H%M).log}"
+INTERVAL="${CPU_POLLER_INTERVAL:-1}"
+RETAIN_SECONDS=900  # 15 minutes
 
 while true; do
-  if [ -f "$LOG" ]; then
-    size=$(stat -c%s "$LOG" 2>/dev/null || echo 0)
-    if [ "$size" -gt "$MAX_BYTES" ]; then
-      mv -f "$LOG" "$LOG.1"
-    fi
-  fi
-
   ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   docker stats --no-stream --format '{{.Name}},{{.CPUPerc}},{{.MemPerc}},{{.MemUsage}}' 2>/dev/null \
     | while IFS= read -r line; do
         printf '%s,%s\n' "$ts" "$line" >> "$LOG"
       done
+
+  # Trim entries older than 15 minutes (ISO 8601 sorts lexicographically)
+  if [ -f "$LOG" ]; then
+    cutoff=$(date -u -d "${RETAIN_SECONDS} seconds ago" +%Y-%m-%dT%H:%M:%SZ)
+    awk -v cutoff="$cutoff" -F',' '$1 >= cutoff' "$LOG" > "${LOG}.tmp" && mv "${LOG}.tmp" "$LOG"
+  fi
 
   sleep "$INTERVAL"
 done

--- a/.devcontainer/start-cpu-poller.sh
+++ b/.devcontainer/start-cpu-poller.sh
@@ -6,7 +6,11 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 POLLER="$SCRIPT_DIR/cpu-poller.sh"
 PIDFILE="/tmp/container-cpu.pid"
+LOG_DIR="/workspaces/claude-rts/.cpu-logs"
 
+mkdir -p "$LOG_DIR"
+
+# Kill prior poller instance
 if [ -f "$PIDFILE" ]; then
   old=$(cat "$PIDFILE" 2>/dev/null || echo "")
   if [ -n "$old" ] && [ -d "/proc/$old" ]; then
@@ -17,7 +21,13 @@ if [ -f "$PIDFILE" ]; then
   rm -f "$PIDFILE"
 fi
 
+# Prune oldest logs so that after this new one is created we have at most 5
+mapfile -t old_logs < <(ls -t "$LOG_DIR"/container-cpu-*.log 2>/dev/null | tail -n +5)
+[ "${#old_logs[@]}" -gt 0 ] && rm -f "${old_logs[@]}"
+
+LOG="$LOG_DIR/container-cpu-$(date -u +%Y%m%d-%H%M).log"
+
 chmod +x "$POLLER" 2>/dev/null || true
-nohup "$POLLER" >/dev/null 2>&1 &
+CPU_POLLER_LOG="$LOG" CPU_POLLER_INTERVAL=1 nohup "$POLLER" >/dev/null 2>&1 &
 echo $! > "$PIDFILE"
 disown 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ supreme-claudemander.*.log
 
 # local launch scripts (per-user, not checked in)
 scripts/launch-prod.sh
+
+# CPU poller logs (workspace-persistent, per-session)
+.cpu-logs/


### PR DESCRIPTION
## Summary

- Moves cpu-poller log output from `/tmp` (ephemeral) to `.cpu-logs/` inside the workspace, so logs survive container restarts
- Timestamps log filenames to the minute (`container-cpu-YYYYMMDD-HHMM.log`) so each container start gets its own file without overwriting
- Prunes oldest log files on startup, keeping at most 5 total
- Polls every 1s (down from 5s) and trims entries older than 15 minutes after each write via `awk` on ISO 8601 timestamps
- Gitignores `.cpu-logs/`

## Test plan

- [ ] Start/restart devcontainer — verify `.cpu-logs/container-cpu-YYYYMMDD-HHMM.log` is created
- [ ] Restart again — verify a new timestamped file is created, old one is preserved
- [ ] Restart 6+ times — verify only the 5 most recent log files remain
- [ ] Let poller run >15 minutes — verify log file doesn't grow beyond ~15 min of entries
- [ ] Confirm `.cpu-logs/` is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)