### PR TITLE
fix(#256): flip TerminalCard.fromSerialized starred fallback true -> false

### DIFF
--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -2025,7 +2025,7 @@ class TerminalCard extends Card {
       symbol: (typeof hubSymbolMap !== 'undefined' && hubSymbolMap[data.hub]) || '?',
       exec: data.exec || null,
       sessionId: data.session_id || null,
-      starred: data.starred != null ? data.starred : true,
+      starred: data.starred != null ? data.starred : false,
       displayName: data.display_name || data.displayName || '',
       recoveryScript: data.recovery_script || data.recoveryScript || '',
       cardUid: data.card_uid || data.cardUid || '',


### PR DESCRIPTION
Closes #256. Part of epic #254.

## Summary

- Flips the `starred` fallback at `claude_rts/static/index.html:2028` from `true` to `false` in `TerminalCard.fromSerialized` so the client never invents an authoritative default for a server-owned field (DP-1).
- Matches the server's `BaseCard.__init__` default (`starred=False`).
- After this change, `grep -nE 'starred.*:\s*true' claude_rts/static/index.html` returns zero hits in boot, spawn, broadcast, or descriptor-construction paths. The remaining matches are the user-initiated resume-button `putCardState(...)` at line 1773 (a PUT, not a default) and a code comment at line 3210 — both explicitly exempt per the refined spec.

## Rationale (from epic #254 intent)

> The client never invents an authoritative default value for a server-owned field. The `starred: true` fallback at `static/index.html:2028` and every equivalent fallback is removed.

The residual line was currently-dead code (`CARD_TYPE_REGISTRY.deserialize()` has no callers today) but becomes live when Child #3 wires the descriptor-render path; fixing it now closes the DP-1 violation before the hydration foundation lands.

## Test plan

- [x] `grep -nE 'starred.*:\s*true' claude_rts/static/index.html` returns only the exempt resume-button line + comment line
- [x] `python -m pytest tests/ --ignore=tests/e2e` — 587 passed, 0 failed
- [x] `python -m pytest tests/e2e/test_pr152_starring_rename_recovery.py tests/e2e/test_spawn_registry_e2e.py tests/e2e/test_cross_browser_sync.py` — 68 passed, 1 xpassed, 0 failed (includes `test_state_persists_across_reload` — green on the baseline epic branch with this fix applied)
- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format --check .` — clean

## Refined spec note

The refined spec flagged `test_state_persists_across_reload` as a separate concern requiring investigation. On the current epic branch (`epic/254-server-authored-spawning` at commit 148914e) the test already passes after applying this single-line fix, so no additional server-side change is needed within this child's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)