### PR TITLE
feat(#265): resource limits for devcontainer and util container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,5 @@
     "3000": { "label": "supreme-claudemander", "onAutoForward": "openBrowser" }
   },
 
-  "runArgs": []
+  "runArgs": ["--cpus=2.0", "--cpu-shares=64", "--memory=8g", "--pids-limit=512"]
 }

--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -58,6 +58,10 @@ DEFAULT_CONFIG = {
         "auto_start": True,
         "auto_stop": False,
         "mounts": {},
+        "cpu_limit": 2.0,
+        "cpu_shares": 64,
+        "memory_limit": "8g",
+        "pids_limit": 512,
     },
     "sessions": {
         "orphan_timeout": 300,

--- a/claude_rts/util_container.py
+++ b/claude_rts/util_container.py
@@ -36,6 +36,10 @@ def _get_config(app_config: AppConfig) -> dict:
         "auto_stop": util.get("auto_stop", False),
         "mounts": util.get("mounts", {}),
         "volumes": util.get("volumes", {}),
+        "cpu_limit": util.get("cpu_limit", 2.0),
+        "cpu_shares": util.get("cpu_shares", 64),
+        "memory_limit": util.get("memory_limit", "8g"),
+        "pids_limit": util.get("pids_limit", 512),
     }
 
 
@@ -139,7 +143,14 @@ async def start_container(app_config: AppConfig) -> bool:
     await _run(f"{_DOCKER} rm -f {cfg['name']}")
 
     # Start container
-    cmd = f"{_DOCKER} run -d --name {cfg['name']}{mount_args} {cfg['image']}"
+    cmd = (
+        f"{_DOCKER} run -d --name {cfg['name']}"
+        f" --cpus={cfg['cpu_limit']}"
+        f" --cpu-shares={cfg['cpu_shares']}"
+        f" --memory={cfg['memory_limit']}"
+        f" --pids-limit={cfg['pids_limit']}"
+        f"{mount_args} {cfg['image']}"
+    )
     logger.info("Starting utility container: {}", cmd)
     rc, stdout, stderr = await _run(cmd, timeout=60)
     if rc != 0:


### PR DESCRIPTION
## Summary
- Adds `--cpus=2.0 --cpu-shares=64 --memory=8g --pids-limit=512` to `devcontainer.json` `runArgs`
- Adds matching defaults (`cpu_limit`, `cpu_shares`, `memory_limit`, `pids_limit`) to `DEFAULT_CONFIG["util_container"]` in `config.py`
- Reads those fields in `util_container._get_config()` and applies them as Docker flags in `start_container()`

Closes #265

## Test plan
- [ ] Rebuild devcontainer and verify `docker inspect <devcontainer-id>` shows the resource limits
- [ ] Restart the server (which starts the util container) and verify `docker inspect supreme-claudemander-util` shows `--cpus=2`, `--cpu-shares=64`, `--memory=8g`, `--pids-limit=512`
- [ ] Verify overriding values in `~/.supreme-claudemander/config.json` under `util_container` takes effect on next util container start

🤖 Generated with [Claude Code](https://claude.com/claude-code)