### PR TITLE
feat(#265): resource limits, exec-form _run(), input validation, CI cap check

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,5 @@
     "3000": { "label": "supreme-claudemander", "onAutoForward": "openBrowser" }
   },
 
-  "runArgs": []
+  "runArgs": ["--cpus=2.0", "--cpu-shares=64", "--memory=8g", "--pids-limit=512"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - run: pip install ruff
       - run: ruff check .
       - run: ruff format --check .
+      - name: Check docker run calls carry resource caps
+        run: python scripts/check_docker_caps.py
 
   test:
     strategy:

--- a/claude_rts/config.py
+++ b/claude_rts/config.py
@@ -58,6 +58,10 @@ DEFAULT_CONFIG = {
         "auto_start": True,
         "auto_stop": False,
         "mounts": {},
+        "cpu_limit": 2.0,
+        "cpu_shares": 64,
+        "memory_limit": "8g",
+        "pids_limit": 512,
     },
     "sessions": {
         "orphan_timeout": 300,

--- a/claude_rts/util_container.py
+++ b/claude_rts/util_container.py
@@ -9,6 +9,7 @@ It stays alive via `sleep infinity` and commands are executed via `docker exec`.
 import asyncio
 import json
 import pathlib
+import re
 import time
 
 _DOCKER = "docker"
@@ -36,13 +37,17 @@ def _get_config(app_config: AppConfig) -> dict:
         "auto_stop": util.get("auto_stop", False),
         "mounts": util.get("mounts", {}),
         "volumes": util.get("volumes", {}),
+        "cpu_limit": util.get("cpu_limit", 2.0),
+        "cpu_shares": util.get("cpu_shares", 64),
+        "memory_limit": util.get("memory_limit", "8g"),
+        "pids_limit": util.get("pids_limit", 512),
     }
 
 
-async def _run(cmd: str, timeout: float = 30) -> tuple[int, str, str]:
-    """Run a shell command and return (returncode, stdout, stderr)."""
-    proc = await asyncio.create_subprocess_shell(
-        cmd,
+async def _run(cmd: list[str], timeout: float = 30) -> tuple[int, str, str]:
+    """Run a command (exec-form) and return (returncode, stdout, stderr)."""
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
@@ -57,7 +62,7 @@ async def _run(cmd: str, timeout: float = 30) -> tuple[int, str, str]:
 async def is_util_running(app_config: AppConfig) -> bool:
     """Check if the utility container is running."""
     cfg = _get_config(app_config)
-    rc, stdout, _ = await _run(f'{_DOCKER} ps --filter "name=^/{cfg["name"]}$" --format "{{{{.Status}}}}"')
+    rc, stdout, _ = await _run([_DOCKER, "ps", "--filter", f"name=^/{cfg['name']}$", "--format", "{{.Status}}"])
     return rc == 0 and "Up" in stdout
 
 
@@ -71,17 +76,17 @@ async def build_image(app_config: AppConfig) -> bool:
     """
     cfg = _get_config(app_config)
     # Check if image exists locally
-    rc, stdout, _ = await _run(f"{_DOCKER} images -q {cfg['image']}")
+    rc, stdout, _ = await _run([_DOCKER, "images", "-q", cfg["image"]])
     if rc == 0 and stdout.strip():
         logger.debug("Utility image {} already exists", cfg["image"])
         return True
 
     # Try pulling the prebuilt image from GHCR
     logger.info("Pulling prebuilt utility image from {}...", GHCR_IMAGE)
-    rc, _, stderr = await _run(f"{_DOCKER} pull {GHCR_IMAGE}", timeout=120)
+    rc, _, stderr = await _run([_DOCKER, "pull", GHCR_IMAGE], timeout=120)
     if rc == 0:
         # Tag as the local image name so subsequent checks find it
-        tag_rc, _, tag_err = await _run(f"{_DOCKER} tag {GHCR_IMAGE} {cfg['image']}")
+        tag_rc, _, tag_err = await _run([_DOCKER, "tag", GHCR_IMAGE, cfg["image"]])
         if tag_rc == 0:
             logger.info("Pulled and tagged prebuilt utility image as {}", cfg["image"])
             return True
@@ -92,7 +97,7 @@ async def build_image(app_config: AppConfig) -> bool:
     # Fall back to local build
     logger.info("Building utility container image {}...", cfg["image"])
     rc, stdout, stderr = await _run(
-        f'{_DOCKER} build -t {cfg["image"]} -f "{DOCKERFILE}" "{DOCKERFILE.parent}"',
+        [_DOCKER, "build", "-t", cfg["image"], "-f", str(DOCKERFILE), str(DOCKERFILE.parent)],
         timeout=300,
     )
     if rc != 0:
@@ -100,6 +105,9 @@ async def build_image(app_config: AppConfig) -> bool:
         return False
     logger.info("Utility image built successfully")
     return True
+
+
+_MEMORY_LIMIT_RE = re.compile(r"^\d+[kmgKMG]?$")
 
 
 async def start_container(app_config: AppConfig) -> bool:
@@ -114,11 +122,30 @@ async def start_container(app_config: AppConfig) -> bool:
     if not await build_image(app_config):
         return False
 
+    # Validate resource limit config values before interpolating into Docker flags.
+    try:
+        cpu_limit_f = float(cfg["cpu_limit"])
+    except (ValueError, TypeError):
+        logger.error("Invalid cpu_limit={!r} — must be a number; not starting util container", cfg["cpu_limit"])
+        return False
+    try:
+        pids_limit_i = int(cfg["pids_limit"])
+    except (ValueError, TypeError):
+        logger.error("Invalid pids_limit={!r} — must be an integer; not starting util container", cfg["pids_limit"])
+        return False
+    memory_limit_s = str(cfg["memory_limit"])
+    if not _MEMORY_LIMIT_RE.match(memory_limit_s):
+        logger.error(
+            "Invalid memory_limit={!r} — must match ^\\d+[kmgKMG]?$; not starting util container",
+            memory_limit_s,
+        )
+        return False
+
     # mcp_server.py is synced into the container via `docker cp` in
     # CanvasClaudeCard._sync_mcp_server on each card start — not bind-mounted.
     # A bind mount on a single file caused a WSL/Docker Desktop quirk where
     # docker cp against the mount point turned it into a directory.
-    mount_args = ""
+    mount_args: list[str] = []
 
     for host_path, container_path in cfg["mounts"].items():
         # Expand ~ in host path and normalize to forward slashes for Docker
@@ -126,21 +153,33 @@ async def start_container(app_config: AppConfig) -> bool:
         if expanded_path.exists():
             # Use POSIX-style path (forward slashes) — Docker rejects mixed-slash paths
             mount_src = expanded_path.as_posix()
-            mount_args += f' -v "{mount_src}:{container_path}"'
+            mount_args.extend(["-v", f"{mount_src}:{container_path}"])
             logger.info("Mounting {} -> {}", mount_src, container_path)
         else:
             logger.warning("Mount source does not exist, skipping: {}", expanded_path)
 
     for vol_name, container_path in cfg["volumes"].items():
-        mount_args += f" --mount type=volume,source={vol_name},target={container_path}"
+        mount_args.extend(["--mount", f"type=volume,source={vol_name},target={container_path}"])
         logger.info("Mounting volume {} -> {}", vol_name, container_path)
 
     # Remove old stopped container if exists
-    await _run(f"{_DOCKER} rm -f {cfg['name']}")
+    await _run([_DOCKER, "rm", "-f", cfg["name"]])
 
     # Start container
-    cmd = f"{_DOCKER} run -d --name {cfg['name']}{mount_args} {cfg['image']}"
-    logger.info("Starting utility container: {}", cmd)
+    cmd = [
+        _DOCKER,
+        "run",
+        "-d",
+        "--name",
+        cfg["name"],
+        f"--cpus={cpu_limit_f}",
+        f"--cpu-shares={cfg['cpu_shares']}",
+        f"--memory={memory_limit_s}",
+        f"--pids-limit={pids_limit_i}",
+        *mount_args,
+        cfg["image"],
+    ]
+    logger.info("Starting utility container: {}", " ".join(cmd))
     rc, stdout, stderr = await _run(cmd, timeout=60)
     if rc != 0:
         logger.error("Failed to start utility container: {}", stderr)
@@ -153,11 +192,11 @@ async def start_container(app_config: AppConfig) -> bool:
 async def stop_container(app_config: AppConfig) -> bool:
     """Stop the utility container."""
     cfg = _get_config(app_config)
-    rc, _, stderr = await _run(f"{_DOCKER} stop {cfg['name']}")
+    rc, _, stderr = await _run([_DOCKER, "stop", cfg["name"]])
     if rc != 0:
         logger.warning("Failed to stop utility container: {}", stderr)
         return False
-    await _run(f"{_DOCKER} rm {cfg['name']}")
+    await _run([_DOCKER, "rm", cfg["name"]])
     logger.info("Utility container '{}' stopped", cfg["name"])
     return True
 
@@ -172,7 +211,7 @@ async def exec_in_util(app_config: AppConfig, cmd: str, timeout: float = 60) -> 
     if not await is_util_running(app_config):
         raise RuntimeError(f"Utility container '{cfg['name']}' is not running")
 
-    full_cmd = f"{_DOCKER} exec {cfg['name']} {cmd}"
+    full_cmd = [_DOCKER, "exec", cfg["name"], "sh", "-c", cmd]
     logger.debug("exec_in_util: {}", cmd)
     rc, stdout, stderr = await _run(full_cmd, timeout=timeout)
     if rc != 0:
@@ -265,7 +304,7 @@ async def discover_profiles(app_config: AppConfig) -> list[str]:
         )
     excluded = _METADATA_DIRS | {main_name}
     try:
-        cmd = f"{_DOCKER} exec {cfg['name']} find /profiles -mindepth 1 -maxdepth 1 -type d"
+        cmd = [_DOCKER, "exec", cfg["name"], "find", "/profiles", "-mindepth", "1", "-maxdepth", "1", "-type", "d"]
         rc, stdout, _ = await _run(cmd, timeout=10)
         if rc != 0:
             logger.warning("discover_profiles: failed to list /profiles (rc={})", rc)
@@ -286,7 +325,7 @@ async def discover_profiles(app_config: AppConfig) -> list[str]:
 async def _mounts_match(app_config: AppConfig) -> bool:
     """Return True if the running container's bind mounts match the configured mounts."""
     cfg = _get_config(app_config)
-    rc, stdout, _ = await _run(f'{_DOCKER} inspect {cfg["name"]} --format "{{{{json .Mounts}}}}"')
+    rc, stdout, _ = await _run([_DOCKER, "inspect", cfg["name"], "--format", "{{json .Mounts}}"])
     if rc != 0:
         return False
     mounts = json.loads(stdout or "[]")
@@ -345,6 +384,6 @@ async def ensure_util_container(app_config: AppConfig) -> bool:
             logger.info("Utility container '{}' already running", cfg["name"])
             return True
         logger.warning("Utility container '{}' running with stale mounts, recreating", cfg["name"])
-        await _run(f"{_DOCKER} rm -f {cfg['name']}")
+        await _run([_DOCKER, "rm", "-f", cfg["name"]])
 
     return await start_container(app_config)

--- a/scripts/check_docker_caps.py
+++ b/scripts/check_docker_caps.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Fail if any uncapped 'docker run' call exists in claude_rts/ or tests/.
+
+Looks for list-form docker run patterns like ["docker", "run", ...] or
+'docker', 'run' that don't carry --cpus within the same call block.
+The docker_run() wrapper in tests/conftest.py is excluded because it
+defines the caps themselves.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+# Matches a line containing the literal tokens "docker" and "run" in sequence
+# (exec-form list syntax). Catches `["docker", "run", ...]` style.
+DOCKER_RUN_LINE = re.compile(r"""["']docker["'][^"']*["']run["']""")
+
+
+def check_file(path: Path) -> list[str]:
+    violations = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for lineno, line in enumerate(lines, 1):
+        stripped = line.strip()
+        # Skip blank lines and pure comments
+        if not stripped or stripped.startswith("#"):
+            continue
+        # Skip the docker_run wrapper definition and its internal list
+        # construction — that function IS the safe wrapper with caps.
+        if "docker_run" in line:
+            continue
+        if not DOCKER_RUN_LINE.search(line):
+            continue
+        # Found a docker run pattern — check for --cpus within ±15 lines
+        start = max(0, lineno - 5)
+        end = min(len(lines), lineno + 15)
+        context = "\n".join(lines[start:end])
+        if "--cpus" not in context:
+            rel = path.relative_to(ROOT)
+            violations.append(f"{rel}:{lineno}: {stripped!r}")
+    return violations
+
+
+def main() -> int:
+    targets = [*ROOT.glob("claude_rts/**/*.py"), *ROOT.glob("tests/**/*.py")]
+    all_violations: list[str] = []
+    for path in sorted(targets):
+        if path.name == "check_docker_caps.py":
+            continue
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("FAIL: uncapped docker run calls found in claude_rts/ or tests/:")
+        for v in all_violations:
+            print(f"  {v}")
+        return 1
+
+    print("OK: all docker run calls carry resource caps")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,10 @@
 Plain classes (not fixtures) so that test files can import them directly:
 
     from tests.conftest import ProbeCard, MockScrollback, MockSession, MockSessionManager
+    from tests.conftest import docker_run
 """
 
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -24,6 +26,31 @@ def _clear_probe_cooldowns():
     ServiceCard._probe_cooldowns.clear()
     yield
     ServiceCard._probe_cooldowns.clear()
+
+
+# ── Docker test helper ──────────────────────────────────────────────────────
+
+
+def docker_run(
+    name: str,
+    image: str,
+    cmd_args: list[str],
+    *,
+    detach: bool = False,
+    check: bool = True,
+    capture_output: bool = True,
+    **kwargs,
+) -> subprocess.CompletedProcess:
+    """Run a docker container with conservative test-scoped resource caps.
+
+    Injects --cpus=0.5 --memory=512m --pids-limit=64 automatically so test
+    fixtures cannot accidentally create unbounded containers.
+    """
+    args = ["docker", "run", "--cpus=0.5", "--memory=512m", "--pids-limit=64", "--name", name]
+    if detach:
+        args.append("-d")
+    args.extend([image, *cmd_args])
+    return subprocess.run(args, check=check, capture_output=capture_output, **kwargs)
 
 
 # ── Concrete test subclass ───────────────────────────────────────────────────

--- a/tests/e2e/real/test_container_manager_real_e2e.py
+++ b/tests/e2e/real/test_container_manager_real_e2e.py
@@ -25,6 +25,7 @@ import pytest
 pw = pytest.importorskip("playwright")
 
 # Shared helpers live in conftest (single source of truth — see issue #165).
+from tests.conftest import docker_run  # noqa: E402
 from tests.e2e.conftest import cleanup_non_container_cards, refresh_container_card  # noqa: E402
 
 
@@ -63,11 +64,7 @@ def dev_config_preset():
 def running_container():
     """Create a real running Alpine container for the test module."""
     name = f"e2e-vm-running-{uuid.uuid4().hex[:8]}"
-    subprocess.run(
-        ["docker", "run", "-d", "--name", name, "alpine:latest", "sleep", "3600"],
-        check=True,
-        capture_output=True,
-    )
+    docker_run(name, "alpine:latest", ["sleep", "3600"], detach=True)
     yield name
     subprocess.run(
         ["docker", "rm", "-f", name],
@@ -83,11 +80,7 @@ def stopped_container():
     which normalizes to 'offline'.
     """
     name = f"e2e-vm-stopped-{uuid.uuid4().hex[:8]}"
-    subprocess.run(
-        ["docker", "run", "--name", name, "alpine:latest", "echo", "done"],
-        check=True,
-        capture_output=True,
-    )
+    docker_run(name, "alpine:latest", ["echo", "done"])
     yield name
     subprocess.run(
         ["docker", "rm", "-f", name],
@@ -111,11 +104,7 @@ def startable_container():
     After the test, the container is force-removed regardless of state.
     """
     name = f"e2e-vm-startable-{uuid.uuid4().hex[:8]}"
-    subprocess.run(
-        ["docker", "run", "-d", "--name", name, "alpine:latest", "sleep", "3600"],
-        check=True,
-        capture_output=True,
-    )
+    docker_run(name, "alpine:latest", ["sleep", "3600"], detach=True)
     subprocess.run(
         ["docker", "stop", name],
         check=True,
@@ -136,11 +125,7 @@ def bash_container():
     Uses the bash:latest image which includes bash.
     """
     name = f"e2e-vm-bash-{uuid.uuid4().hex[:8]}"
-    subprocess.run(
-        ["docker", "run", "-d", "--name", name, "bash:latest", "sleep", "3600"],
-        check=True,
-        capture_output=True,
-    )
+    docker_run(name, "bash:latest", ["sleep", "3600"], detach=True)
     yield name
     subprocess.run(
         ["docker", "rm", "-f", name],
@@ -517,20 +502,7 @@ class TestRealStatusAccuracy:
         """Stop a running container externally, re-render, verify status flips."""
         # We need a dedicated container for this test since we'll stop it
         name = f"e2e-vm-stoppable-{uuid.uuid4().hex[:8]}"
-        subprocess.run(
-            [
-                "docker",
-                "run",
-                "-d",
-                "--name",
-                name,
-                "alpine:latest",
-                "sleep",
-                "3600",
-            ],
-            check=True,
-            capture_output=True,
-        )
+        docker_run(name, "alpine:latest", ["sleep", "3600"], detach=True)
 
         try:
             # Add the container to favorites


### PR DESCRIPTION
## Summary
- **devcontainer.json**: `runArgs` now includes `--cpus=2.0 --cpu-shares=64 --memory=8g --pids-limit=512`
- **config.py**: `DEFAULT_CONFIG["util_container"]` gains `cpu_limit`, `cpu_shares`, `memory_limit`, `pids_limit` with the same defaults (mirrors `container_manager.defaults` naming)
- **util_container._run()**: converted from `create_subprocess_shell` to `create_subprocess_exec`; all ~10 call-sites updated from f-string commands to argv lists (eliminates shell injection risk)
- **util_container.start_container()**: validates `cpu_limit` via `float()`, `pids_limit` via `int()`, `memory_limit` via `^\d+[kmgKMG]?$` regex before interpolating into Docker flags; returns `False` with a clear log message on invalid config
- **tests/conftest.py**: new `docker_run()` helper that injects `--cpus=0.5 --memory=512m --pids-limit=64` automatically, so test authors cannot create unbounded containers
- **tests/e2e/real/test_container_manager_real_e2e.py**: all 5 bare `subprocess.run(["docker", "run", ...])` fixture calls replaced with `docker_run()`
- **scripts/check_docker_caps.py**: CI script that fails on any uncapped `docker run` pattern in `claude_rts/` or `tests/`
- **ci.yml lint job**: new `check-docker-run` step runs the script on every PR

Closes #265

## Test plan
- [ ] Rebuild devcontainer and verify `docker inspect <id> --format '{{.HostConfig.NanoCpus}} {{.HostConfig.Memory}} {{.HostConfig.PidsLimit}}'` returns three non-zero values
- [ ] Restart server (auto-starts util container), verify `docker inspect supreme-claudemander-util` shows all four resource flags
- [ ] Override `cpu_limit: "bad"` in `~/.supreme-claudemander/config.json`, restart server — verify util container does not start and logs `Invalid cpu_limit`
- [ ] Run `python scripts/check_docker_caps.py` — should print `OK`
- [ ] Add a bare `subprocess.run(["docker", "run", "--name", "x", "ubuntu"])` to any file in `tests/`, run the script — should fail
- [ ] CI lint passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)