### PR TITLE
feat(#261): CanvasClaudeCard hydration via attach-only from_descriptor

### DIFF
--- a/claude_rts/cards/canvas_claude_card.py
+++ b/claude_rts/cards/canvas_claude_card.py
@@ -387,6 +387,120 @@ class CanvasClaudeCard(TerminalCard):
             )
             logger.info("CanvasClaudeCard: creating new tmux session {}", TMUX_SESSION_NAME)
 
+    # ── Hydration ──────────────────────────────────────────────────────
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        data: dict,
+        session_manager=None,
+        api_base_url: str = "http://host.docker.internal:3000",
+        **kwargs,
+    ) -> "CanvasClaudeCard":
+        """Reconstruct a CanvasClaudeCard from a canvas-JSON snapshot entry.
+
+        Epic #254 child 6 (#261): the hydration entry point for canvas_claude
+        card types. Reconstructs the card from the on-disk snapshot without
+        starting the PTY — the caller invokes ``attach()`` separately so the
+        attach-vs-new-session decision and error-state handling apply uniformly.
+
+        Unlike ``start()`` (the full-creation path used by
+        ``/api/canvas-claude/create``), the hydrated card is expected to
+        attach to the already-running tmux session seeded at initial spawn
+        time. ``attach()`` trusts the existing tmux session as-is and does
+        NOT re-seed MCP config or trust settings.
+        """
+        if session_manager is None:
+            raise TypeError("CanvasClaudeCard.from_descriptor requires session_manager=")
+        layout = {
+            k: data[k]
+            for k in ("x", "y", "w", "h", "z_order")
+            if isinstance(data.get(k), int) and not isinstance(data.get(k), bool)
+        }
+        card = cls(
+            session_manager=session_manager,
+            hub=data.get("hub") or None,
+            container=data.get("container") or None,
+            card_id=data.get("card_id") or data.get("session_id"),
+            layout=layout or None,
+            api_base_url=api_base_url,
+            profile=data.get("profile") or None,
+            canvas_name=data.get("canvas_name") or None,
+        )
+        # Seed server-owned state from the snapshot (matches TerminalCard.from_descriptor).
+        card.starred = bool(data.get("starred", False))
+        if data.get("display_name"):
+            card.display_name = data["display_name"]
+        if data.get("recovery_script"):
+            card.recovery_script = data["recovery_script"]
+        if data.get("card_uid"):
+            card.card_uid = data["card_uid"]
+        return card
+
+    async def attach(
+        self,
+        retry_delays: tuple[float, ...] | list[float] | None = None,
+        on_error_state: "object" = None,
+    ) -> None:
+        """Attach to an existing tmux session without creating a new one.
+
+        Epic #254 child 6 (#261): the hydration-only lifecycle. Verifies the
+        stable ``canvas-claude`` tmux session is alive inside the target
+        container; if so, sets ``self.cmd`` to the attach variant and invokes
+        ``super().start()`` to allocate a PTY bound to it. If the tmux session
+        is missing (e.g. the container was killed / pruned while the server
+        was down), sets ``self.error_state = {"kind": "tmux_session_missing",
+        ...}`` and marks the card ``starred=True`` so the user sees a visible
+        error with a retry button — it does NOT silently auto-recreate the
+        session (that is reserved for the explicit user-click retry path).
+
+        Notes on intentional omissions vs ``start()``:
+          - No ``_sync_mcp_server()`` call — the already-running claude
+            process inside tmux uses whatever config snapshot it booted with;
+            mutating files on disk would not retroactively fix it.
+          - No ``_seed_claude_settings()`` call — same reasoning.
+
+        ``retry_delays`` and ``on_error_state`` are accepted so this method
+        plugs into ``hydrate_canvas_into_registry``'s uniform ``start()``
+        call shape; only ``on_error_state`` is used today.
+        """
+        loop = _asyncio.get_running_loop()
+        alive = await loop.run_in_executor(None, self._has_tmux_session)
+        if not alive:
+            self.error_state = {
+                "kind": "tmux_session_missing",
+                "attempts": 1,
+                "last_error": (
+                    f"tmux session {TMUX_SESSION_NAME!r} not found in container {self._effective_container!r}"
+                ),
+            }
+            # Hydrate-as-starred: the user should see the card and manually
+            # retry, not have it silently disappear.
+            self.starred = True
+            logger.warning(
+                "CanvasClaudeCard.attach: tmux session {} missing in {} — landed in error_state",
+                TMUX_SESSION_NAME,
+                self._effective_container,
+            )
+            if on_error_state is not None:
+                try:
+                    result = on_error_state(self)
+                    if _asyncio.iscoroutine(result):
+                        await result
+                except Exception:
+                    logger.exception("CanvasClaudeCard on_error_state callback failed")
+            return
+
+        # Session is alive — bind PTY via the attach command.
+        docker_bin = _DOCKER
+        self.cmd = f"{docker_bin} exec -it {self._effective_container} tmux attach-session -t {TMUX_SESSION_NAME}"
+        logger.info(
+            "CanvasClaudeCard.attach: attaching to existing tmux session {} in {}",
+            TMUX_SESSION_NAME,
+            self._effective_container,
+        )
+        await super().start(retry_delays=retry_delays, on_error_state=on_error_state)
+
     async def start(self) -> None:
         """Sync mcp_server.py, write MCP config, resolve tmux state, then start the PTY.
 

--- a/claude_rts/dev_presets/canvas-claude/canvases/canvas-claude-qa.json
+++ b/claude_rts/dev_presets/canvas-claude/canvases/canvas-claude-qa.json
@@ -7,6 +7,7 @@
   "cards": [
     {
       "type": "canvas_claude",
+      "card_id": "canvas-claude-qa-001",
       "starred": true,
       "x": 100,
       "y": 100,

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -2540,8 +2540,16 @@ async def hydrate_canvas_into_registry(
         try:
             if card_type == "terminal":
                 card = TerminalCard.from_descriptor(entry, session_manager=session_manager)
+            elif card_type == "canvas_claude":
+                # Epic #254 child 6 (#261): hydrate canvas_claude cards by
+                # attaching to their already-running tmux session. The
+                # ``from_descriptor`` path does NOT call ``start()``; the
+                # background task below invokes ``attach()`` which verifies
+                # the tmux session and either attaches (success) or lands the
+                # card in ``error_state`` (``tmux_session_missing``).
+                card = CanvasClaudeCard.from_descriptor(entry, session_manager=session_manager)
             else:
-                # Children #5/#6 extend dispatch here for widget / canvas-claude.
+                # Child #5 extends dispatch here for widget.
                 logger.debug(
                     "hydrate_canvas_into_registry: canvas '{}' entry #{} type '{}' has no hydrator, skipping",
                     canvas_name,
@@ -2569,8 +2577,15 @@ async def hydrate_canvas_into_registry(
         def _on_error_state(c: BaseCard, _app=app) -> "object":
             return _broadcast_card_updated(_app, c.id, {"error_state": c.error_state})
 
-        async def _start_card_bg(_card=card, _idx=idx, _cn=canvas_name) -> None:
+        async def _start_card_bg(_card=card, _idx=idx, _cn=canvas_name, _ct=card_type) -> None:
             try:
+                # Epic #254 child 6 (#261): canvas_claude hydration uses
+                # ``attach()`` (verify + PTY-bind) rather than ``start()``
+                # (MCP seed + tmux new-session). ``attach()`` accepts the
+                # same retry / error-state kwargs as ``TerminalCard.start()``.
+                if _ct == "canvas_claude":
+                    await _card.attach(retry_delays=retry_delays, on_error_state=_on_error_state)
+                    return
                 await _card.start(retry_delays=retry_delays, on_error_state=_on_error_state)
             except TypeError:
                 # Cards whose ``start`` signature does not accept retry

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -3858,9 +3858,13 @@ async function handleControlCardCreated(msg) {
   const desc = msg.descriptor;
   if (!desc) return;
 
-  // canvas_claude cards always self-create via _createAndConnect() — never spawn from
-  // the control event, which would race with the in-flight fetch and create duplicate cards.
-  if (desc.type === 'canvas_claude') return;
+  // Epic #254 child 6 (#261): canvas_claude cards now flow through the
+  // server-authored hydration + broadcast path. The old early-exit here was
+  // the pre-hydration workaround (the client used to own canvas_claude
+  // existence via ``_createAndConnect``). Post-migration we render from the
+  // broadcast descriptor like terminals; the branch below dispatches the
+  // render with ``sessionId = desc.session_id`` so ``connectWs`` takes the
+  // reconnect path instead of hitting ``/api/canvas-claude/create``.
 
   // Blueprint cards are spawned directly from context menu — skip the control event
   // to avoid duplicates. Also skip container_starter (hidden cards).
@@ -3920,6 +3924,23 @@ async function handleControlCardCreated(msg) {
     });
     // Epic #236 child 5 (#241): server snapshot already reflects this card
     // (the broadcast is downstream of the server-side register).
+  } else if (desc.type === 'canvas_claude') {
+    // Epic #254 child 6 (#261): server is authoritative over canvas_claude
+    // card existence. Render the client-side card with
+    // ``sessionId = desc.session_id`` so ``connectWs`` uses the reconnect
+    // path (never ``/api/canvas-claude/create`` — the server already did that).
+    await CARD_TYPE_REGISTRY.spawn('canvas_claude', {
+      hub: desc.hub || 'canvas-claude',
+      container: desc.container || 'supreme-claudemander-util',
+      exec: desc.exec || null,
+      sessionId: desc.session_id,
+      x: desc.x, y: desc.y,
+      w: desc.w || 960,
+      h: desc.h || 640,
+      profile: desc.profile || null,
+      canvasName: desc.canvas_name || desc.canvasName || null,
+      starred: desc.starred != null ? desc.starred : false,
+    });
   }
 }
 

--- a/tests/test_canvas_claude_card.py
+++ b/tests/test_canvas_claude_card.py
@@ -479,3 +479,114 @@ def test_canvas_claude_card_mcp_args_include_spawner_id(monkeypatch):
     # The value must match the card's own id
     assert mcp_args[idx + 1] == card.id
     mgr.stop_all()
+    mgr.stop_all()
+
+
+# ── Epic #254 child 6 (#261): from_descriptor + attach hydration ──────────
+
+
+async def test_canvas_claude_from_descriptor_builds_card_without_starting(monkeypatch):
+    """from_descriptor() builds a CanvasClaudeCard with fields set and no PTY."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+    data = {
+        "type": "canvas_claude",
+        "card_id": "cc-stable-001",
+        "container": "test-container",
+        "profile": "test-profile",
+        "canvas_name": "canvas-claude-qa",
+        "starred": True,
+        "x": 100,
+        "y": 200,
+        "w": 960,
+        "h": 640,
+    }
+    card = CanvasClaudeCard.from_descriptor(data, session_manager=mgr)
+    assert card.session is None  # PTY not started yet
+    assert card.id == "cc-stable-001"
+    assert card._effective_container == "test-container"
+    assert card.profile == "test-profile"
+    assert card.canvas_name == "canvas-claude-qa"
+    assert card.starred is True
+    assert card.x == 100 and card.y == 200
+    mgr.stop_all()
+
+
+async def test_canvas_claude_from_descriptor_requires_session_manager():
+    """from_descriptor() without session_manager raises TypeError."""
+    with pytest.raises(TypeError):
+        CanvasClaudeCard.from_descriptor({"type": "canvas_claude"})
+
+
+async def test_canvas_claude_to_descriptor_emits_card_id(monkeypatch):
+    """to_descriptor() always emits card_id (inherited from TerminalCard)."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+    card = CanvasClaudeCard(
+        session_manager=mgr,
+        container="my-container",
+        card_id="fixed-id-xyz",
+    )
+    desc = card.to_descriptor()
+    assert desc["card_id"] == "fixed-id-xyz"
+    assert desc["card_id"] == card.id
+    mgr.stop_all()
+
+
+async def test_canvas_claude_attach_uses_attach_command_when_tmux_alive(monkeypatch):
+    """attach() verifies tmux session, sets cmd to attach variant, starts PTY."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+
+    # Track all subprocess.run calls so we can assert new-session was never invoked.
+    calls = []
+
+    def fake_run(args, *a, **kw):
+        calls.append(list(args))
+        # tmux has-session -> returncode 0 (alive)
+        if "has-session" in args:
+            return type("R", (), {"returncode": 0, "stderr": b""})()
+        return type("R", (), {"returncode": 0, "stderr": b""})()
+
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", fake_run)
+    mgr = SessionManager()
+    card = CanvasClaudeCard.from_descriptor(
+        {"type": "canvas_claude", "container": "test-container"},
+        session_manager=mgr,
+    )
+    await card.attach(retry_delays=[])
+    assert card.error_state is None
+    assert "tmux attach-session" in card.cmd
+    assert "tmux new-session" not in card.cmd
+    # No subprocess.run call should contain "new-session" (attach-only path).
+    for args in calls:
+        assert "new-session" not in args, f"new-session issued during attach: {args}"
+    await card.stop()
+    mgr.stop_all()
+
+
+async def test_canvas_claude_attach_missing_tmux_lands_in_error_state(monkeypatch):
+    """attach() on a dead tmux session lands the card in error_state with starred=True."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    # has-session returns non-zero -> tmux session missing
+    monkeypatch.setattr(
+        "claude_rts.cards.canvas_claude_card._subprocess.run",
+        _mock_subprocess_run_no_tmux,
+    )
+    mgr = SessionManager()
+    card = CanvasClaudeCard.from_descriptor(
+        {"type": "canvas_claude", "container": "test-container", "starred": False},
+        session_manager=mgr,
+    )
+    broadcasts = []
+
+    def _on_error(c):
+        broadcasts.append(c.error_state)
+
+    await card.attach(retry_delays=[], on_error_state=_on_error)
+    assert card.session is None  # no PTY created
+    assert card.error_state is not None
+    assert card.error_state["kind"] == "tmux_session_missing"
+    # Hydrate-as-starred so the user sees the error and can click retry.
+    assert card.starred is True
+    assert broadcasts == [card.error_state]
+    mgr.stop_all()

--- a/tests/test_hydration.py
+++ b/tests/test_hydration.py
@@ -323,3 +323,106 @@ class _running_app:
                 await hook(self.app)
             except Exception:
                 pass
+                pass
+
+
+# ── Epic #254 child 6 (#261): canvas_claude hydration dispatch ────────────
+
+
+async def test_hydrate_canvas_claude_attaches_without_new_session(tmp_path, monkeypatch):
+    """Canvas with a canvas_claude entry hydrates via attach() — no tmux new-session."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+
+    # Mock _subprocess.run to report tmux session alive and never allow new-session.
+    calls = []
+
+    def fake_run(args, *a, **kw):
+        calls.append(list(args))
+        if "has-session" in args:
+            return type("R", (), {"returncode": 0, "stderr": b""})()
+        return type("R", (), {"returncode": 0, "stderr": b""})()
+
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", fake_run)
+
+    app_config = config.load(tmp_path / ".sc")
+    app_config.canvases_dir.mkdir(parents=True, exist_ok=True)
+    snapshot = {
+        "name": "canvas-claude-qa",
+        "canvas_size": [3840, 2160],
+        "cards": [
+            {
+                "type": "canvas_claude",
+                "card_id": "cc-hyd-001",
+                "container": "test-container",
+                "starred": True,
+                "x": 100,
+                "y": 100,
+                "w": 960,
+                "h": 640,
+            },
+        ],
+    }
+    (app_config.canvases_dir / "canvas-claude-qa.json").write_text(json.dumps(snapshot))
+
+    app = create_app(app_config, test_mode=True, skip_canvas_schema_check=True)
+    app["_hydrate_retry_delays"] = [0]
+    async with _running_app(app):
+        await asyncio.sleep(0.1)
+        from claude_rts.cards.canvas_claude_card import CanvasClaudeCard
+
+        registry: CardRegistry = app["card_registry"]
+        cards = registry.cards_on_canvas("canvas-claude-qa")
+        assert len(cards) == 1
+        cc = cards[0]
+        assert isinstance(cc, CanvasClaudeCard)
+        assert cc.session_id is not None
+        assert cc.error_state is None
+        # Attach path set the attach cmd, not new-session.
+        assert "tmux attach-session" in cc.cmd
+        # No subprocess.run call should contain "new-session" during hydration.
+        for args in calls:
+            assert "new-session" not in args, f"new-session called during hydration: {args}"
+
+
+async def test_hydrate_canvas_claude_missing_tmux_error_state(tmp_path, monkeypatch):
+    """Canvas hydration with dead tmux session lands canvas_claude in error_state."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+
+    def fake_run_dead(args, *a, **kw):
+        if "has-session" in args:
+            return type("R", (), {"returncode": 1, "stderr": b"no session"})()
+        return type("R", (), {"returncode": 0, "stderr": b""})()
+
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", fake_run_dead)
+
+    app_config = config.load(tmp_path / ".sc")
+    app_config.canvases_dir.mkdir(parents=True, exist_ok=True)
+    snapshot = {
+        "name": "cc-dead",
+        "canvas_size": [3840, 2160],
+        "cards": [
+            {
+                "type": "canvas_claude",
+                "card_id": "cc-dead-001",
+                "container": "test-container",
+                "starred": False,  # explicitly false — attach() must flip to True
+            },
+        ],
+    }
+    (app_config.canvases_dir / "cc-dead.json").write_text(json.dumps(snapshot))
+
+    app = create_app(app_config, test_mode=True, skip_canvas_schema_check=True)
+    app["_hydrate_retry_delays"] = [0]
+    async with _running_app(app):
+        await asyncio.sleep(0.1)
+        from claude_rts.cards.canvas_claude_card import CanvasClaudeCard
+
+        registry: CardRegistry = app["card_registry"]
+        cards = registry.cards_on_canvas("cc-dead")
+        assert len(cards) == 1
+        cc = cards[0]
+        assert isinstance(cc, CanvasClaudeCard)
+        assert cc.error_state is not None
+        assert cc.error_state["kind"] == "tmux_session_missing"
+        # Hydrate-as-starred override kicks in.
+        assert cc.starred is True


### PR DESCRIPTION
## Summary

Closes #261 — canvas_claude DP-1 gap from epic #254.

A canvas JSON entry of type `canvas_claude` now causes a `CanvasClaudeCard` to appear in `CardRegistry` at server boot, attached to the existing tmux session — no new `tmux new-session` is issued during hydration. If the tmux session is missing, the card lands in a visible `error_state` with `starred=True` so the user must explicitly retry (no silent auto-recreation, per the `/ws/session/new` invariant).

- `CanvasClaudeCard.from_descriptor`: reconstructs from snapshot without calling `start()`.
- `CanvasClaudeCard.attach`: verify-and-bind half of `start()`; skips MCP seeding and trust-settings (the running claude process keeps its boot config). Reuses `TerminalCard.start()`'s retry/error_state contract.
- `hydrate_canvas_into_registry`: dispatches `type=canvas_claude` to `from_descriptor` + `attach` in the background start task.
- `index.html handleControlCardCreated`: drops the `canvas_claude` early-exit (line 3863) and renders hydrated cards via the broadcast descriptor.
- `canvas-claude-qa.json` preset: stable `card_id` added.

## Test plan

- [x] `tests/test_canvas_claude_card.py` — `from_descriptor` builds without starting; `attach` uses attach-cmd when tmux alive (no `new-session` invoked); `attach` lands in `error_state` with `starred=True` when tmux dead.
- [x] `tests/test_hydration.py` — canvas hydration with `canvas_claude` entry registers card with attach-cmd and never calls `new-session`; missing tmux landing in `error_state`.
- [x] `python -m ruff check . && python -m ruff format --check .` clean.
- [ ] Manual QA: boot with `--dev-config canvas-claude` and confirm card hydrates without browser-initiated spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)