### PR TITLE
feat(#261): CanvasClaudeCard hydration (attach-only from_descriptor)

### DIFF
--- a/claude_rts/cards/canvas_claude_card.py
+++ b/claude_rts/cards/canvas_claude_card.py
@@ -170,6 +170,12 @@ class CanvasClaudeCard(TerminalCard):
         self.api_base_url = api_base_url
         self.profile = profile
         self.canvas_name = canvas_name
+        # Epic #254 child 6 (#261): set by ``from_descriptor`` so ``start()``
+        # takes the attach-only path (no MCP seed, no tmux new-session) on
+        # boot hydration. Default ``False`` preserves the original
+        # create-and-seed behaviour for direct instantiations and the
+        # ``/api/canvas-claude/create`` endpoint.
+        self._hydrated: bool = False
 
         # Build the MCP config JSON after super().__init__ so self.id is
         # available (BaseCard generates a uuid if card_id was None).
@@ -387,7 +393,7 @@ class CanvasClaudeCard(TerminalCard):
             )
             logger.info("CanvasClaudeCard: creating new tmux session {}", TMUX_SESSION_NAME)
 
-    async def start(self) -> None:
+    async def start(self, **kwargs) -> None:
         """Sync mcp_server.py, write MCP config, resolve tmux state, then start the PTY.
 
         On the *new-session* path we also seed the claude settings file so the
@@ -397,7 +403,18 @@ class CanvasClaudeCard(TerminalCard):
         with — mutating the files on disk would not retroactively fix a broken
         subprocess and could mislead the next fresh-session boot if the file is
         later consulted.
+
+        Epic #254 child 6 (#261): when the card was reconstructed via
+        ``from_descriptor`` (``self._hydrated`` is True), this method delegates
+        to ``attach()`` — an attach-only path that requires the tmux session to
+        already exist and never seeds a new one. ``kwargs`` (``retry_delays``,
+        ``on_error_state``) are accepted for compatibility with
+        ``hydrate_canvas_into_registry`` and forwarded to ``attach``.
         """
+        if self._hydrated:
+            await self.attach(**kwargs)
+            return
+
         loop = _asyncio.get_running_loop()
         await loop.run_in_executor(None, self._sync_mcp_server)
         await loop.run_in_executor(None, self._ensure_tmux_session)
@@ -417,7 +434,71 @@ class CanvasClaudeCard(TerminalCard):
             self._effective_container,
         )
 
-        await super().start()
+        # Forward kwargs (retry_delays, on_error_state) so the
+        # hydrate_canvas_into_registry retry / error_state contract still
+        # applies if a fresh-create path is ever invoked through hydration.
+        await super().start(**kwargs)
+
+    async def attach(self, on_error_state: "object" = None, **_kwargs) -> None:
+        """Attach to an existing tmux session without creating a new one.
+
+        Epic #254 child 6 (#261): the boot-hydration entry point. The
+        invariants:
+
+        - **No MCP seed.** The already-running claude process inside the tmux
+          session has whatever config snapshot it booted with — re-seeding
+          would not retroactively fix it.
+        - **No ``tmux new-session``.** If the named tmux session does not exist
+          we land in ``error_state`` rather than silently spawning a new one;
+          the user investigates / clicks retry (which goes through the full
+          ``/api/canvas-claude/create`` create path).
+        - **No ``docker cp`` of mcp_server.py.** Skipped on attach for the same
+          reason as MCP seed: the running subprocess does not re-read the file.
+
+        ``on_error_state`` mirrors ``TerminalCard.start`` — invoked with
+        ``self`` once ``error_state`` is populated so the caller (the
+        ``hydrate_canvas_into_registry`` helper) can broadcast a
+        ``card_updated`` event. ``_kwargs`` swallows ``retry_delays`` (no
+        retries on attach — either the session exists or it doesn't).
+        """
+        loop = _asyncio.get_running_loop()
+        session_present = await loop.run_in_executor(None, self._has_tmux_session)
+        if not session_present:
+            # Session is gone — record error_state and signal the caller.
+            self.error_state = {
+                "kind": "tmux_session_missing",
+                "container": self._effective_container,
+                "tmux_session": TMUX_SESSION_NAME,
+            }
+            logger.warning(
+                "CanvasClaudeCard.attach: tmux session {} missing in container {} — landing in error_state",
+                TMUX_SESSION_NAME,
+                self._effective_container,
+            )
+            if on_error_state is not None:
+                try:
+                    result = on_error_state(self)
+                    if _asyncio.iscoroutine(result):
+                        await result
+                except Exception:
+                    logger.exception("CanvasClaudeCard.attach: on_error_state callback failed")
+            return
+
+        # Session is alive — set the cmd to the attach variant and run the
+        # PTY-allocation half of TerminalCard.start. We skip the
+        # TerminalCard.start retry loop on attach because there is no
+        # transient error class it would help with: docker exec attach to a
+        # tmux session is either immediately available or the session is gone.
+        docker_bin = _DOCKER
+        self.cmd = f"{docker_bin} exec -it {self._effective_container} tmux attach-session -t {TMUX_SESSION_NAME}"
+        logger.info(
+            "CanvasClaudeCard.attach: attaching to existing tmux session {} in container {}",
+            TMUX_SESSION_NAME,
+            self._effective_container,
+        )
+        # Bypass the retry loop with explicit retry_delays=() so a single
+        # PTY-creation failure is surfaced rather than retried for ~130 s.
+        await super().start(retry_delays=())
 
     # ── Session helpers ────────────────────────────────────────────────
 
@@ -436,3 +517,52 @@ class CanvasClaudeCard(TerminalCard):
         """Send /clear to the claude PTY to wipe conversation history."""
         if self._session is not None and self._session.alive:
             self._session.pty.write("/clear\n")
+
+    # ── Hydration ──────────────────────────────────────────────────────
+
+    @classmethod
+    def from_descriptor(cls, data: dict, session_manager=None, **_kwargs) -> "CanvasClaudeCard":
+        """Reconstruct a CanvasClaudeCard from a canvas-JSON snapshot entry.
+
+        Epic #254 child 6 (#261): the hydration entry point called by
+        ``hydrate_canvas_into_registry`` at server startup. Mirrors
+        ``TerminalCard.from_descriptor`` but specialised for canvas-claude:
+
+        - Accepts the descriptor keys emitted by ``to_descriptor`` —
+          ``card_id`` / ``session_id``, ``container``, ``profile``,
+          ``canvas_name``, geometry (``x``/``y``/``w``/``h``/``z_order``),
+          ``starred``.
+        - Sets ``self._hydrated = True`` so the subsequent ``start()`` call
+          dispatches to ``attach()`` (no MCP seed, no tmux new-session) —
+          per Scenario 1's invariant that hydration never creates a new
+          tmux session.
+
+        Note that the ``session_id`` from the snapshot is **not** propagated
+        to the underlying PTY — at boot the previous PTY is dead (the python
+        process restarted), so a fresh ``Session`` is allocated by ``attach``
+        and ``self.id`` is realigned to the new ``session_id`` inside
+        ``TerminalCard.start``. The card's persistent identity is the tmux
+        session ``canvas-claude`` itself, not the per-PTY id.
+        """
+        if session_manager is None:
+            raise TypeError("CanvasClaudeCard.from_descriptor requires session_manager=")
+        layout = {
+            k: data[k]
+            for k in ("x", "y", "w", "h", "z_order")
+            if isinstance(data.get(k), int) and not isinstance(data.get(k), bool)
+        }
+        card = cls(
+            session_manager=session_manager,
+            hub=data.get("hub") or None,
+            container=data.get("container") or None,
+            card_id=data.get("card_id") or data.get("session_id"),
+            layout=layout or None,
+            profile=data.get("profile") or None,
+            canvas_name=data.get("canvas_name") or None,
+        )
+        # Server-owned fields that ``to_descriptor`` emits via the
+        # TerminalCard base class. Mirror TerminalCard.from_descriptor.
+        card.starred = bool(data.get("starred", False))
+        # Activate the attach-only branch in ``start()``.
+        card._hydrated = True
+        return card

--- a/claude_rts/dev_presets/canvas-claude/canvases/canvas-claude-qa.json
+++ b/claude_rts/dev_presets/canvas-claude/canvases/canvas-claude-qa.json
@@ -7,6 +7,7 @@
   "cards": [
     {
       "type": "canvas_claude",
+      "card_id": "canvas-claude-qa-card",
       "starred": true,
       "x": 100,
       "y": 100,

--- a/claude_rts/dev_presets/container-actions-qa/canvases/container-actions-qa.json
+++ b/claude_rts/dev_presets/container-actions-qa/canvases/container-actions-qa.json
@@ -17,6 +17,7 @@
     },
     {
       "type": "canvas_claude",
+      "card_id": "container-actions-qa-cc",
       "starred": true,
       "x": 660,
       "y": 100,

--- a/claude_rts/dev_presets/human-qa/canvases/human-qa.json
+++ b/claude_rts/dev_presets/human-qa/canvases/human-qa.json
@@ -36,6 +36,7 @@
     },
     {
       "type": "canvas_claude",
+      "card_id": "human-qa-cc",
       "starred": true,
       "x": 900,
       "y": 640,

--- a/claude_rts/server.py
+++ b/claude_rts/server.py
@@ -2889,8 +2889,19 @@ async def hydrate_canvas_into_registry(
                 # ``_persist_canvas_snapshot`` with only registered (terminal)
                 # cards in the registry.
                 card = WidgetCard.from_descriptor(entry)
+            elif card_type == "canvas_claude":
+                # Child #6 (#261): canvas-claude hydration. ``from_descriptor``
+                # reconstructs the card with ``_hydrated=True`` so the
+                # subsequent ``start()`` call (issued by the
+                # ``_start_card_bg`` task below) dispatches to ``attach()``
+                # — verifying the existing tmux session and never seeding a
+                # new one. If the tmux session is gone, ``attach()`` lands
+                # the card in ``error_state`` (kind="tmux_session_missing")
+                # rather than auto-recreating; the user clicks Retry to
+                # invoke the full create path through
+                # ``/api/canvas-claude/create``.
+                card = CanvasClaudeCard.from_descriptor(entry, session_manager=session_manager)
             else:
-                # Child #6 extends dispatch here for canvas-claude.
                 logger.debug(
                     "hydrate_canvas_into_registry: canvas '{}' entry #{} type '{}' has no hydrator, skipping",
                     canvas_name,

--- a/claude_rts/static/index.html
+++ b/claude_rts/static/index.html
@@ -2183,6 +2183,14 @@ class CanvasClaudeCard extends TerminalCard {
     this.setupInput();
     this.setupResizeObserver();
     this.setupClaudeBtn();
+    // Epic #254 child 6 (#261): hydrated card whose tmux session was missing
+    // at boot. Show the no-priority overlay (which exposes the Retry button
+    // that goes through /api/canvas-claude/create) so the user can recreate
+    // the session — never auto-recreate, per the hydrate-as-starred policy.
+    if (this.errorState) {
+      this._showNoPriorityOverlay();
+      return;
+    }
     if (!this.sessionId) {
       this._showNoPriorityOverlay();
       return; // connectWs() will be called by _retryConnect() once a session exists
@@ -3336,8 +3344,23 @@ async function renderFromDescriptor(descriptor) {
     });
   }
   if (t === 'canvas_claude') {
-    // TODO Child #6 (#261): canvas_claude hydration via renderFromDescriptor.
-    return spawnFromSerialized(descriptor);
+    // Epic #254 child 6 (#261): server-authored canvas_claude hydration.
+    // The descriptor carries server-owned card_id, session_id (for the
+    // attached PTY), starred, geometry, profile, and canvas_name. The
+    // client constructs the CanvasClaudeCard from the descriptor — when
+    // session_id is present, connectWs() reattaches to the live PTY rather
+    // than going through the create-and-seed path. When error_state is
+    // present (e.g. server's attach() found the tmux session missing) the
+    // retry overlay surfaces it instead of attempting to connect.
+    return CARD_TYPE_REGISTRY.spawn('canvas_claude', {
+      x: descriptor.x, y: descriptor.y, w: descriptor.w, h: descriptor.h,
+      sessionId: descriptor.session_id,
+      profile: descriptor.profile,
+      canvasName: descriptor.canvas_name || descriptor.canvasName,
+      starred: descriptor.starred != null ? descriptor.starred : false,
+      cardId: descriptor.card_id || null,
+      errorState: descriptor.error_state || null,
+    });
   }
   return spawnFromSerialized(descriptor);
 }
@@ -4048,10 +4071,6 @@ async function handleControlCardCreated(msg) {
   const desc = msg.descriptor;
   if (!desc) return;
 
-  // canvas_claude cards always self-create via _createAndConnect() — never spawn from
-  // the control event, which would race with the in-flight fetch and create duplicate cards.
-  if (desc.type === 'canvas_claude') return;
-
   // Blueprint cards are spawned directly from context menu — skip the control event
   // to avoid duplicates. Also skip container_starter (hidden cards).
   if (desc.type === 'blueprint' || desc.type === 'container_starter') return;
@@ -4131,6 +4150,36 @@ async function handleControlCardCreated(msg) {
       refreshInterval: desc.refreshInterval,
       starred: desc.starred != null ? desc.starred : false,
       cardId: desc.card_id || null,
+    });
+  } else if (desc.type === 'canvas_claude') {
+    // Epic #254 child 6 (#261): canvas_claude broadcast renders the card
+    // from the server descriptor on hydration. Dedupe against existing
+    // cards by both session_id (legacy create-and-connect path) and card_id
+    // (server-authored hydration path) so neither the
+    // ``/api/canvas-claude/create`` self-loop nor a renderFromDescriptor
+    // pre-render can produce a duplicate.
+    if (cards.some(c =>
+      c.type === 'canvas_claude' && (
+        (desc.session_id && c.sessionId === desc.session_id) ||
+        (desc.card_id && (c.cardId === desc.card_id || c.sessionId === desc.card_id))
+      )
+    )) return;
+    const vw = viewport.clientWidth;
+    const vh = viewport.clientHeight;
+    const cx = (-pan.x + vw / 2) / zoom;
+    const cy = (-pan.y + vh / 2) / zoom;
+    const x = desc.x != null ? desc.x : cx - 480;
+    const y = desc.y != null ? desc.y : cy - 320;
+    await CARD_TYPE_REGISTRY.spawn('canvas_claude', {
+      x, y,
+      w: desc.w || 960,
+      h: desc.h || 640,
+      sessionId: desc.session_id,
+      profile: desc.profile,
+      canvasName: desc.canvas_name || desc.canvasName,
+      starred: desc.starred != null ? desc.starred : false,
+      cardId: desc.card_id || null,
+      errorState: desc.error_state || null,
     });
   }
 }

--- a/tests/test_canvas_claude_card.py
+++ b/tests/test_canvas_claude_card.py
@@ -479,3 +479,223 @@ def test_canvas_claude_card_mcp_args_include_spawner_id(monkeypatch):
     # The value must match the card's own id
     assert mcp_args[idx + 1] == card.id
     mgr.stop_all()
+
+
+# ── Hydration tests (epic #254 child 6, issue #261) ────────────────────────
+
+
+async def test_canvas_claude_from_descriptor_builds_card(monkeypatch):
+    """from_descriptor reconstructs the card with hydrated flag, no PTY started."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+    data = {
+        "type": "canvas_claude",
+        "card_id": "cc-hydrated-1",
+        "container": "my-container",
+        "profile": "alice",
+        "canvas_name": "my-canvas",
+        "starred": True,
+        "x": 10,
+        "y": 20,
+        "w": 800,
+        "h": 600,
+    }
+    card = CanvasClaudeCard.from_descriptor(data, session_manager=mgr)
+    assert card.session is None  # PTY not started
+    assert card._hydrated is True
+    assert card.profile == "alice"
+    assert card.canvas_name == "my-canvas"
+    assert card._effective_container == "my-container"
+    assert card.starred is True
+    assert card.x == 10 and card.y == 20 and card.w == 800 and card.h == 600
+    mgr.stop_all()
+
+
+async def test_canvas_claude_from_descriptor_requires_session_manager():
+    """from_descriptor without session_manager raises TypeError (mirrors TerminalCard)."""
+    with pytest.raises(TypeError):
+        CanvasClaudeCard.from_descriptor({"type": "canvas_claude"})
+
+
+async def test_canvas_claude_to_descriptor_emits_card_id(monkeypatch):
+    """to_descriptor emits card_id (Scenario 5 falsifiability check)."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    mgr = SessionManager()
+    card = CanvasClaudeCard(session_manager=mgr, container="c", card_id="cc-fixture-id", canvas_name="x")
+    desc = card.to_descriptor()
+    assert "card_id" in desc
+    assert desc["card_id"] == "cc-fixture-id"
+    mgr.stop_all()
+
+
+async def test_canvas_claude_attach_without_existing_tmux_sets_error_state(monkeypatch):
+    """attach() lands the card in error_state when tmux session is missing (Scenario 4)."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    # tmux has-session returns rc=1 (no session)
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", _mock_subprocess_run_no_tmux)
+    mgr = SessionManager()
+    card = CanvasClaudeCard.from_descriptor(
+        {"type": "canvas_claude", "container": "missing-container", "card_id": "cc-2"},
+        session_manager=mgr,
+    )
+    callbacks = []
+
+    def _on_error(c):
+        callbacks.append(c.error_state)
+
+    await card.start(on_error_state=_on_error)
+    assert card.session is None  # no PTY allocated
+    assert card.error_state is not None
+    assert card.error_state["kind"] == "tmux_session_missing"
+    assert card.error_state["container"] == "missing-container"
+    assert card.error_state["tmux_session"] == TMUX_SESSION_NAME
+    assert callbacks == [card.error_state]
+    mgr.stop_all()
+
+
+async def test_canvas_claude_attach_with_existing_tmux_starts_pty(monkeypatch):
+    """attach() with a live tmux session sets the attach cmd and allocates a PTY (Scenario 1)."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    # tmux has-session returns rc=0 (session exists)
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", _mock_subprocess_run)
+    mgr = SessionManager()
+    card = CanvasClaudeCard.from_descriptor(
+        {"type": "canvas_claude", "container": "live-container", "card_id": "cc-3"},
+        session_manager=mgr,
+    )
+    await card.start()
+    assert card.error_state is None
+    assert card.session is not None
+    assert "tmux attach-session" in card.cmd
+    assert TMUX_SESSION_NAME in card.cmd
+    await card.stop()
+    mgr.stop_all()
+
+
+async def test_canvas_claude_attach_does_not_seed_settings(monkeypatch):
+    """Hydration attach path never calls _seed_claude_settings (Scenario 1 invariant)."""
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", _mock_subprocess_run)
+    seed_calls = {"n": 0}
+
+    def counting_seed(self):
+        seed_calls["n"] += 1
+
+    monkeypatch.setattr(CanvasClaudeCard, "_seed_claude_settings", counting_seed)
+    mgr = SessionManager()
+    card = CanvasClaudeCard.from_descriptor(
+        {"type": "canvas_claude", "container": "live-container"},
+        session_manager=mgr,
+    )
+    await card.start()
+    assert seed_calls["n"] == 0
+    await card.stop()
+    mgr.stop_all()
+
+
+async def test_canvas_claude_attach_does_not_create_new_tmux_session(monkeypatch):
+    """Hydration must never call ``tmux new-session`` even when the session is missing.
+
+    Falsifiability check for Scenario 1's invariant: a hydrated card with a
+    missing tmux session lands in error_state — it must NOT silently create a
+    fresh session.
+    """
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    calls: list[list[str]] = []
+
+    def track_run(cmd_list, **kw):
+        calls.append(list(cmd_list))
+        # has-session → rc=1 (no session); any other tmux call would be an
+        # invariant violation.
+        return type("R", (), {"returncode": 1, "stderr": b""})()
+
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", track_run)
+    mgr = SessionManager()
+    card = CanvasClaudeCard.from_descriptor(
+        {"type": "canvas_claude", "container": "ghost"},
+        session_manager=mgr,
+    )
+    await card.start()
+    new_session_calls = [c for c in calls if "new-session" in c]
+    assert new_session_calls == []
+    mgr.stop_all()
+
+
+def test_preset_canvas_claude_entries_have_card_id():
+    """Every canvas_claude entry in dev_presets/*/canvases/*.json carries a stable card_id."""
+    import json as _json
+    import pathlib as _pathlib
+
+    preset_root = _pathlib.Path(__file__).resolve().parents[1] / "claude_rts" / "dev_presets"
+    missing: list[str] = []
+    for canvas_file in preset_root.glob("*/canvases/*.json"):
+        data = _json.loads(canvas_file.read_text())
+        for idx, card in enumerate(data.get("cards", [])):
+            if card.get("type") == "canvas_claude" and not card.get("card_id"):
+                missing.append(f"{canvas_file}: idx={idx}")
+    assert not missing, "canvas_claude entries without card_id:\n" + "\n".join(missing)
+
+
+async def test_hydrate_canvas_claude_into_registry(tmp_path, monkeypatch):
+    """hydrate_canvas_into_registry registers a canvas_claude entry into CardRegistry.
+
+    Covers Scenario 1: a canvas JSON containing a canvas_claude entry causes a
+    CanvasClaudeCard to exist in CardRegistry after hydration runs, attaching
+    to the existing tmux session without creating a new one.
+    """
+    import json as _json
+
+    from claude_rts import config as _config
+    from claude_rts.cards.card_registry import CardRegistry as _CR
+    from claude_rts.server import create_app as _create_app
+
+    monkeypatch.setattr("claude_rts.sessions.PtyProcess", MockPty)
+    # tmux has-session → rc=0 (alive). All other subprocess calls also succeed.
+    monkeypatch.setattr("claude_rts.cards.canvas_claude_card._subprocess.run", _mock_subprocess_run)
+
+    app_config = _config.load(tmp_path / ".sc")
+    app_config.canvases_dir.mkdir(parents=True, exist_ok=True)
+    snapshot = {
+        "name": "cc-canvas",
+        "canvas_size": [3840, 2160],
+        "cards": [
+            {
+                "type": "canvas_claude",
+                "card_id": "cc-hydrated",
+                "container": "supreme-claudemander-util",
+                "profile": "main",
+                "canvas_name": "cc-canvas",
+                "starred": True,
+                "x": 100,
+                "y": 100,
+                "w": 960,
+                "h": 640,
+            }
+        ],
+    }
+    (app_config.canvases_dir / "cc-canvas.json").write_text(_json.dumps(snapshot))
+
+    app = _create_app(app_config, test_mode=True, skip_canvas_schema_check=True)
+    app["_hydrate_retry_delays"] = [0]
+
+    import asyncio as _asyncio
+
+    for hook in app.on_startup:
+        await hook(app)
+    try:
+        await _asyncio.sleep(0.1)  # let background start() task run attach()
+        registry: _CR = app["card_registry"]
+        all_cards = registry.cards_on_canvas("cc-canvas")
+        cc_cards = [c for c in all_cards if isinstance(c, CanvasClaudeCard)]
+        assert len(cc_cards) == 1
+        cc = cc_cards[0]
+        assert cc._hydrated is True
+        assert cc.error_state is None
+        assert cc.session is not None  # PTY allocated by attach()
+        assert "tmux attach-session" in cc.cmd
+    finally:
+        for hook in app.on_shutdown:
+            try:
+                await hook(app)
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary

Closes [#261](https://github.com/hyang0129/supreme-claudemander/issues/261) — the canvas-claude branch of [epic #254](https://github.com/hyang0129/supreme-claudemander/issues/254) server-authored card spawning.

A canvas JSON containing a `canvas_claude` entry now causes a `CanvasClaudeCard` to exist in `CardRegistry` after boot, **attaching to its existing tmux session rather than creating a new one**. The client renders the hydrated card via the broadcast (no more `handleControlCardCreated` early-exit).

### Server changes

- `CanvasClaudeCard.from_descriptor(data, session_manager=...)` — reconstructs the card with `_hydrated=True` so the subsequent `start()` dispatches to `attach()`. No PTY started.
- `CanvasClaudeCard.attach(on_error_state=...)` — pure attach path:
  - verifies the named tmux session via `tmux has-session`,
  - on success, sets `cmd = docker exec -it <c> tmux attach-session -t canvas-claude` and runs `TerminalCard.start(retry_delays=())` to allocate the PTY (no retry loop — attach is immediate-or-error),
  - on failure, lands in `error_state={"kind": "tmux_session_missing", "container": ..., "tmux_session": ...}` and invokes the callback so `hydrate_canvas_into_registry` can broadcast a `card_updated` event.
  - **Never** issues `tmux new-session` and **never** calls `_seed_claude_settings` on the hydration path.
- `start()` checks `self._hydrated`; on True it delegates to `attach(**kwargs)`. Existing `**kwargs` plumbing (`retry_delays`, `on_error_state`) is forwarded so the hydration helper's contract still applies for non-hydrated start invocations.
- `hydrate_canvas_into_registry`: adds the `type == "canvas_claude"` dispatch case.

### Client changes

- `index.html` `renderFromDescriptor`: replaces the canvas_claude TODO stub with a real hydration spawn that forwards `sessionId`, `profile`, `canvasName`, `cardId`, and `errorState` from the descriptor.
- `index.html` `handleControlCardCreated`: removes the `if (desc.type === 'canvas_claude') return;` early-exit at the old line 3863 and replaces it with a hydration branch that dedupes against existing cards by both `session_id` and `card_id` (so the legacy `_createAndConnect` self-loop and the server-authored hydration broadcast cannot produce duplicates).
- `CanvasClaudeCard.onInit`: when `errorState` is set, shows the existing "no priority" overlay (which exposes the Retry button that goes through `/api/canvas-claude/create`) — never auto-recreates per the hydrate-as-starred policy in the epic intent.

### Preset fixtures

`canvas-claude-qa.json`, `container-actions-qa.json`, and `human-qa.json` get a stable `card_id` on the canvas_claude entry so hydration's registry key is deterministic across restarts (Scenario 5 falsifiability check).

## Test plan

- [x] `CanvasClaudeCard.from_descriptor` builds a card with `_hydrated=True` and no PTY started
- [x] `from_descriptor` without `session_manager` raises `TypeError` (mirrors `TerminalCard.from_descriptor`)
- [x] `to_descriptor` emits `card_id` (Scenario 5)
- [x] `attach()` with missing tmux session populates `error_state` and fires the callback (Scenario 4)
- [x] `attach()` with live tmux session allocates a PTY and sets the `tmux attach-session` cmd (Scenario 1)
- [x] `attach()` does **not** call `_seed_claude_settings` (hydration invariant)
- [x] `attach()` does **not** issue `tmux new-session` even when the session is missing (Scenario 1 hard invariant)
- [x] All preset `canvas_claude` entries carry `card_id` (Scenario 5)
- [x] `hydrate_canvas_into_registry` registers a `canvas_claude` entry into `CardRegistry` and the resulting card is in attach mode (Scenario 1)
- [x] Full test suite: 627 passed, 1 deselected
- [x] `ruff check` and `ruff format --check` clean

## Notes

- Scenario 2 (server restart preserves canvas_claude) is implicitly covered by Scenario 1 + the existing tmux-outlives-server-process behaviour — the on_startup hydration path is the same code path that runs on restart. An explicit cross-restart e2e test is deferred to Child #7's documentation slice; no production change here is needed.
- Q6-a (auto-recreate on missing tmux): resolved per the epic's hydrate-as-starred policy — `error_state` requires explicit user click on Retry, never auto-recreates. This matches the TerminalCard `error_state` precedent.
- Q6-b (re-verify MCP config on attach): resolved as **trust the existing tmux session** — the running claude process inside tmux holds whatever config it booted with; mutating the on-disk file would not retroactively fix it. Documented in the `attach()` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)