### PR TITLE
fix(#277): human-QA scenario framework

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,6 +41,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libxkbcommon0 \
     libxrandr2
 
+# noVNC display stack (Xvfb virtual framebuffer + x11vnc + websockify/noVNC web client)
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && apt-get -y install --no-install-recommends \
+    xvfb \
+    x11vnc \
+    novnc \
+    xauth \
+    libxtst6
+
 RUN npm install -g @anthropic-ai/claude-code
 
 # Create vscode user; grant passwordless chmod for fixing the Docker socket group at runtime

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   },
   "initializeCommand": ".devcontainer\\initialize.cmd",
   "postCreateCommand": ".devcontainer/post-create.sh",
-  "postStartCommand": "sudo -n chmod 666 /var/run/docker.sock 2>/dev/null || true; .devcontainer/start-cpu-poller.sh",
+  "postStartCommand": "sudo -n chmod 666 /var/run/docker.sock 2>/dev/null || true; .devcontainer/start-cpu-poller.sh; .devcontainer/start-novnc.sh",
   "remoteUser": "vscode",
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached",
@@ -18,12 +18,14 @@
 
   "containerEnv": {
     "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
-    "GH_TOKEN": "${localEnv:GH_TOKEN}"
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "DISPLAY": ":99"
   },
 
-  "forwardPorts": [3000],
+  "forwardPorts": [3000, 6081],
   "portsAttributes": {
-    "3000": { "label": "supreme-claudemander", "onAutoForward": "openBrowser" }
+    "3000": { "label": "supreme-claudemander", "onAutoForward": "openBrowser" },
+    "6081": { "label": "noVNC", "onAutoForward": "ignore" }
   },
 
   "runArgs": [

--- a/.devcontainer/start-novnc.sh
+++ b/.devcontainer/start-novnc.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Starts Xvfb + x11vnc + noVNC websockify on port 6081.
+# Safe to re-run on every container start — kills prior instances via PID files.
+set -u
+
+DISPLAY_NUM=99
+VNC_PORT=5900
+NOVNC_PORT=6081
+
+XVFB_PID=/tmp/xvfb.pid
+X11VNC_PID=/tmp/x11vnc.pid
+NOVNC_PID=/tmp/novnc.pid
+
+# Kill prior instances
+for pidfile in "$XVFB_PID" "$X11VNC_PID" "$NOVNC_PID"; do
+  if [ -f "$pidfile" ]; then
+    old=$(cat "$pidfile" 2>/dev/null || echo "")
+    if [ -n "$old" ] && [ -d "/proc/$old" ]; then
+      kill "$old" 2>/dev/null || true
+    fi
+    rm -f "$pidfile"
+  fi
+done
+sleep 1
+
+# Start Xvfb
+nohup Xvfb :${DISPLAY_NUM} -screen 0 1920x1080x24 -ac +extension GLX +render -noreset >/tmp/xvfb.log 2>&1 &
+echo $! > "$XVFB_PID"
+disown 2>/dev/null || true
+sleep 1
+
+# Start x11vnc — unset WAYLAND_DISPLAY so x11vnc targets Xvfb on :${DISPLAY_NUM}, not Wayland
+nohup env -u WAYLAND_DISPLAY x11vnc -display :${DISPLAY_NUM} -forever -nopw -quiet -rfbport ${VNC_PORT} >/tmp/x11vnc.log 2>&1 &
+echo $! > "$X11VNC_PID"
+disown 2>/dev/null || true
+sleep 0.5
+
+# Start noVNC websockify (web files at /usr/share/novnc/)
+nohup websockify --web=/usr/share/novnc/ --wrap-mode=ignore ${NOVNC_PORT} localhost:${VNC_PORT} >/tmp/novnc.log 2>&1 &
+echo $! > "$NOVNC_PID"
+disown 2>/dev/null || true
+
+echo "noVNC ready: http://localhost:${NOVNC_PORT}/vnc.html"

--- a/claude_rts/__main__.py
+++ b/claude_rts/__main__.py
@@ -63,13 +63,41 @@ def main():
     # ── 'qa' subcommand ─────────────────────────────────────────────────────
     qa_parser = subparsers.add_parser("qa", help="QA scenario runner commands")
     qa_subparsers = qa_parser.add_subparsers(dest="qa_action")
-    qa_subparsers.add_parser(
-        "next",
+
+    qa_run_parser = qa_subparsers.add_parser(
+        "run",
         help=(
-            "Run the next unverified QA scenario. Launches the app, drives Playwright "
-            "to the gate state, reads y/n/s from the human, and records the verdict. "
-            "Set HEADED=0 to run headless (default: headed)."
+            "Drive a named QA scenario to the gate state and capture a screenshot. "
+            "Headless by default; set HEADED=1 to watch via noVNC. "
+            "Use 'qa verdict <id> <verdict>' afterward to post the verdict to GitHub."
         ),
+    )
+    qa_run_parser.add_argument("scenario_id", help="Scenario ID to run (see: qa list)")
+
+    qa_subparsers.add_parser(
+        "list",
+        help="List all available QA scenario IDs and their linked debt issue numbers.",
+    )
+
+    qa_verdict_parser = qa_subparsers.add_parser(
+        "verdict",
+        help=(
+            "Post a verdict comment to the linked GitHub debt issue. "
+            "Run 'qa run <id>' first to drive the app to the gate state and capture a screenshot, "
+            "then call this command after assessing the screenshot."
+        ),
+    )
+    qa_verdict_parser.add_argument("scenario_id", help="Scenario ID (see: qa list)")
+    qa_verdict_parser.add_argument(
+        "verdict",
+        choices=["pass", "fail", "inconclusive", "blocked"],
+        help="Verdict to record",
+    )
+    qa_verdict_parser.add_argument(
+        "--notes",
+        default="",
+        metavar="TEXT",
+        help="Optional free-form notes appended to the verdict comment",
     )
 
     # ── Server arguments (only apply when no subcommand is given) ───────────
@@ -100,10 +128,20 @@ def main():
 
     # ── Dispatch qa subcommand before any server setup ───────────────────────
     if args.subcommand == "qa":
-        if args.qa_action == "next":
-            from .qa_runner import run_next
+        if args.qa_action == "run":
+            from .qa_runner import run_scenario
 
-            run_next()
+            run_scenario(args.scenario_id)
+            return
+        elif args.qa_action == "list":
+            from .qa_runner import list_scenarios
+
+            list_scenarios()
+            return
+        elif args.qa_action == "verdict":
+            from .qa_runner import post_verdict
+
+            post_verdict(args.scenario_id, args.verdict, notes=args.notes)
             return
         else:
             qa_parser.print_help()

--- a/claude_rts/__main__.py
+++ b/claude_rts/__main__.py
@@ -52,8 +52,27 @@ def _check_electron_installed():
 
 
 def main():
-    parser = argparse.ArgumentParser(description="supreme-claudemander terminal canvas")
+    parser = argparse.ArgumentParser(
+        description="supreme-claudemander terminal canvas",
+        # Allow 'qa next' subcommand without breaking bare 'python -m claude_rts'
+    )
     parser.add_argument("--version", action="version", version=f"supreme-claudemander {_get_version()}")
+
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    # ── 'qa' subcommand ─────────────────────────────────────────────────────
+    qa_parser = subparsers.add_parser("qa", help="QA scenario runner commands")
+    qa_subparsers = qa_parser.add_subparsers(dest="qa_action")
+    qa_subparsers.add_parser(
+        "next",
+        help=(
+            "Run the next unverified QA scenario. Launches the app, drives Playwright "
+            "to the gate state, reads y/n/s from the human, and records the verdict. "
+            "Set HEADED=0 to run headless (default: headed)."
+        ),
+    )
+
+    # ── Server arguments (only apply when no subcommand is given) ───────────
     parser.add_argument("--port", type=int, default=3000, help="Server port (default: 3000)")
     parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
     parser.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
@@ -78,6 +97,17 @@ def main():
         ),
     )
     args = parser.parse_args()
+
+    # ── Dispatch qa subcommand before any server setup ───────────────────────
+    if args.subcommand == "qa":
+        if args.qa_action == "next":
+            from .qa_runner import run_next
+
+            run_next()
+            return
+        else:
+            qa_parser.print_help()
+            sys.exit(1)
 
     import os
 

--- a/claude_rts/qa_runner.py
+++ b/claude_rts/qa_runner.py
@@ -1,32 +1,22 @@
-"""QA runner — ``python -m claude_rts qa next``.
+"""QA runner — ``python -m claude_rts qa run <scenario-id>`` / ``qa list`` / ``qa verdict``.
 
-Discovers authored scenarios in ``qa_scenarios/``, filters out already-verdicted
-ones, launches the app, drives Playwright to the human gate, reads y/n/s, and
-records the verdict locally and as a GitHub comment on the linked debt issue.
+The CLI is a dumb runner: it accepts a scenario ID, drives Playwright to the
+human gate state, takes a screenshot, and exits.  Verdict posting is a separate
+command so the agent can assess the screenshot first and record the human's
+judgment after.
 
-Verdict storage
----------------
-``~/.supreme-claudemander/qa-verdicts.jsonl`` — one JSON record per line:
-
-    {"scenario_id": "syn-001-...", "commit_sha": "abc1234", "verdict": "yes",
-     "timestamp": "2026-04-27T16:00:00Z", "question": "Does the terminal appear?"}
-
-A scenario is considered "discharged" when it has a record with
-``verdict in {"yes", "no"}`` for **any** commit SHA.  Skipped (``"skip"``) verdicts
-are stored for audit/ordering but do not discharge the item — the scenario
-re-appears on the next ``qa next`` invocation.
-
-Ordering
---------
-Scenarios are sorted alphabetically by filename.  The naming convention
-``<prefix>-<NNN>-<slug>.py`` naturally encodes priority order.
+GitHub issue comments are the only verdict record.  An agent reads the debt
+issue to determine which scenarios are unverified, then calls
+``python -m claude_rts qa run <id>`` for each one, reads the screenshot, and
+calls ``python -m claude_rts qa verdict <id> <verdict>`` after the human
+confirms.  See ``docs/qa-scenarios.md`` for the full agent workflow.
 
 Browser mode
 ------------
-``qa next`` launches a headed (visible) browser by default so the human can see
-the app state at the gate.  Override with the ``HEADED`` environment variable:
-  ``HEADED=0 python -m claude_rts qa next``   → headless (useful for wiring tests)
-  ``HEADED=1 python -m claude_rts qa next``   → headed (default)
+Headless by default — the screenshot is the output artifact.
+Override with the ``HEADED`` environment variable to watch via noVNC:
+  ``HEADED=1 python -m claude_rts qa run <id>``   → headed (visible in noVNC)
+  ``HEADED=0 python -m claude_rts qa run <id>``   → headless (default)
 """
 
 from __future__ import annotations
@@ -41,23 +31,26 @@ import sys
 import tempfile
 import time
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 # ---------------------------------------------------------------------------
 # Constants / paths
 # ---------------------------------------------------------------------------
 
-_VERDICTS_FILE = pathlib.Path.home() / ".supreme-claudemander" / "qa-verdicts.jsonl"
 _SCENARIOS_DIR = pathlib.Path(__file__).resolve().parent.parent / "qa_scenarios"
 
 _FALLBACK_REPO = "hyang0129/supreme-claudemander"
 
-# Port used by the qa next backend — distinct from the default 3000 so it
+# Port used by the qa runner backend — distinct from the default 3000 so it
 # does not collide with a running production server.
 _QA_PORT = 3097
+
+_VERDICT_OPTIONS = ("pass", "fail", "inconclusive", "blocked")
+_VERDICT_LABELS = {
+    "pass": "PASS ✓",
+    "fail": "FAIL ✗",
+    "inconclusive": "INCONCLUSIVE ?",
+    "blocked": "BLOCKED ⊘",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -66,11 +59,7 @@ _QA_PORT = 3097
 
 
 def _derive_repo_slug() -> str:
-    """Derive the GitHub repo slug from the git remote origin URL.
-
-    Falls back to ``hyang0129/supreme-claudemander`` with a warning if the
-    remote URL cannot be parsed.
-    """
+    """Derive the GitHub repo slug from the git remote origin URL."""
     try:
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
@@ -79,11 +68,9 @@ def _derive_repo_slug() -> str:
             timeout=5,
         )
         url = result.stdout.strip()
-        # HTTPS: https://github.com/owner/repo.git
         m = re.match(r"https?://github\.com/([^/]+/[^/]+?)(?:\.git)?$", url)
         if m:
             return m.group(1)
-        # SSH: git@github.com:owner/repo.git
         m = re.match(r"git@github\.com:([^/]+/[^/]+?)(?:\.git)?$", url)
         if m:
             return m.group(1)
@@ -111,34 +98,6 @@ def _current_commit_sha() -> str:
         return "unknown"
 
 
-def _load_verdicts() -> list[dict]:
-    """Load all verdict records from the verdicts JSONL file."""
-    if not _VERDICTS_FILE.exists():
-        return []
-    records = []
-    with _VERDICTS_FILE.open(encoding="utf-8") as fh:
-        for line in fh:
-            line = line.strip()
-            if line:
-                try:
-                    records.append(json.loads(line))
-                except json.JSONDecodeError:
-                    pass
-    return records
-
-
-def _discharged_scenario_ids(verdicts: list[dict]) -> set[str]:
-    """Return the set of scenario IDs that have been discharged (yes or no verdict)."""
-    return {r["scenario_id"] for r in verdicts if r.get("verdict") in {"yes", "no"}}
-
-
-def _append_verdict(record: dict) -> None:
-    """Append a single verdict record to the verdicts JSONL file."""
-    _VERDICTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with _VERDICTS_FILE.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(record) + "\n")
-
-
 def _post_github_comment(repo: str, issue_number: int, body: str) -> bool:
     """Post a comment on the given GitHub issue using the gh CLI.
 
@@ -153,20 +112,61 @@ def _post_github_comment(repo: str, issue_number: int, body: str) -> bool:
         )
         if result.returncode != 0:
             print(
-                f"[qa] Warning: gh issue comment failed (exit {result.returncode}): {result.stderr.strip()}",
+                f"[qa] gh issue comment failed (exit {result.returncode}): {result.stderr.strip()}",
                 file=sys.stderr,
             )
             return False
         return True
     except FileNotFoundError:
         print(
-            "[qa] Warning: 'gh' CLI not found — verdict comment not posted to GitHub.",
+            "[qa] 'gh' CLI not found — install it from https://cli.github.com/",
             file=sys.stderr,
         )
         return False
     except Exception as exc:
-        print(f"[qa] Warning: gh issue comment error: {exc}", file=sys.stderr)
+        print(f"[qa] gh issue comment error: {exc}", file=sys.stderr)
         return False
+
+
+# ---------------------------------------------------------------------------
+# Gate cache — persists gate question/expected between `qa run` and `qa verdict`
+# ---------------------------------------------------------------------------
+
+
+def _gate_cache_path(scenario_id: str) -> pathlib.Path:
+    return pathlib.Path(tempfile.gettempdir()) / f"qa-gate-{scenario_id}.json"
+
+
+def _save_gate_cache(scenario_id: str, gate) -> None:
+    data = {
+        "scenario_id": gate.scenario_id,
+        "question": gate.question,
+        "expected": gate.expected,
+    }
+    _gate_cache_path(scenario_id).write_text(json.dumps(data), encoding="utf-8")
+
+
+def _load_gate_cache(scenario_id: str):
+    """Return a HumanGate loaded from the cache, or None if not found."""
+    from claude_rts.qa_scenario import HumanGate
+
+    path = _gate_cache_path(scenario_id)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return HumanGate(**data)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Screenshot path — deterministic so caller can reference it
+# ---------------------------------------------------------------------------
+
+
+def _screenshot_path(scenario_id: str) -> pathlib.Path:
+    return pathlib.Path(tempfile.gettempdir()) / f"qa-screenshot-{scenario_id}.png"
 
 
 # ---------------------------------------------------------------------------
@@ -184,8 +184,7 @@ def _discover_scenarios() -> list[pathlib.Path]:
 def _load_scenario_class(path: pathlib.Path):
     """Import a scenario file and return its ``Scenario`` class.
 
-    The file must define a class named ``Scenario`` that implements
-    ``QAScenario``.  Returns ``None`` with a warning if loading fails.
+    Returns ``None`` with a warning if loading fails.
     """
     spec = importlib.util.spec_from_file_location(f"qa_scenario_{path.stem}", path)
     if spec is None or spec.loader is None:
@@ -202,6 +201,26 @@ def _load_scenario_class(path: pathlib.Path):
         print(f"[qa] Warning: {path} has no 'Scenario' class — skipping", file=sys.stderr)
         return None
     return cls
+
+
+def _find_scenario_class(scenario_id: str):
+    """Find and load the scenario class matching ``scenario_id``.
+
+    Returns ``(cls, available_ids)`` where ``cls`` is ``None`` if not found.
+    """
+    paths = _discover_scenarios()
+    available = []
+    for path in paths:
+        cls = _load_scenario_class(path)
+        if cls is None:
+            continue
+        sid = getattr(cls, "scenario_id", None)
+        if sid is None:
+            continue
+        available.append(sid)
+        if sid == scenario_id:
+            return cls, available
+    return None, available
 
 
 # ---------------------------------------------------------------------------
@@ -228,11 +247,7 @@ def _wait_for_server(port: int, timeout: float = 30.0) -> bool:
 def _start_server(
     preset: str, port: int
 ) -> tuple[subprocess.Popen, tempfile.NamedTemporaryFile, tempfile.NamedTemporaryFile]:  # type: ignore[type-arg]
-    """Start the backend server with the given dev-config preset.
-
-    Returns ``(proc, stdout_file, stderr_file)``.  Caller must terminate the
-    process and clean up the temp files.
-    """
+    """Start the backend server with the given dev-config preset."""
     stdout_file = tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False, prefix="qa-stdout-")
     stderr_file = tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False, prefix="qa-stderr-")
     env = os.environ.copy()
@@ -274,53 +289,14 @@ def _stop_server(
 
 
 # ---------------------------------------------------------------------------
-# Gate I/O
-# ---------------------------------------------------------------------------
-
-
-def _read_single_keystroke() -> str:
-    """Read a single keystroke from stdin without requiring Enter.
-
-    Falls back to ``input()`` if the terminal is not a TTY (e.g. tests).
-    """
-    if not sys.stdin.isatty():
-        line = sys.stdin.readline().strip().lower()
-        return line[0] if line else ""
-
-    import tty
-    import termios
-
-    fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
-    try:
-        tty.setraw(fd)
-        ch = sys.stdin.read(1)
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old)
-    return ch.lower()
-
-
-def _print_gate(gate) -> None:  # gate: HumanGate
-    """Print the human gate prompt to stdout."""
-    print("\n" + "=" * 70)
-    print("HUMAN JUDGMENT GATE")
-    print("=" * 70)
-    print(f"\nQuestion: {gate.question}")
-    print(f"Expected: {gate.expected}")
-    print("\nAnswer: [y]es  [n]o  [s]kip")
-    print("(Press a single key — no Enter needed)")
-    sys.stdout.flush()
-
-
-# ---------------------------------------------------------------------------
 # Playwright runner
 # ---------------------------------------------------------------------------
 
 
 def _run_scenario_with_playwright(scenario_instance, port: int) -> "tuple[HumanGate, str]":  # noqa: F821
-    """Launch Playwright, navigate to the app, and run the scenario setup.
+    """Launch Playwright, navigate to the app, run the scenario setup, and take a screenshot.
 
-    Returns the ``HumanGate`` from ``run_setup()``.
+    Returns ``(gate, screenshot_path)`` where ``screenshot_path`` is the saved PNG.
     """
     try:
         from playwright.sync_api import sync_playwright
@@ -332,7 +308,9 @@ def _run_scenario_with_playwright(scenario_instance, port: int) -> "tuple[HumanG
         )
         sys.exit(1)
 
-    headed = os.environ.get("HEADED", "1").lower() not in ("0", "false")
+    headed = os.environ.get("HEADED", "0").lower() not in ("0", "false")
+    sid = getattr(scenario_instance, "scenario_id", "unknown")
+    shot_path = str(_screenshot_path(sid))
 
     with sync_playwright() as pw:
         browser = pw.chromium.launch(headless=not headed)
@@ -347,60 +325,74 @@ def _run_scenario_with_playwright(scenario_instance, port: int) -> "tuple[HumanG
 
         gate = scenario_instance.run_setup(page)
 
-        # Keep the browser open so the human can see the state.
-        # The gate prompt is printed AFTER setup completes.
-        _print_gate(gate)
-
-        ch = _read_single_keystroke()
-        print(f"\nYou answered: {ch!r}")
-        sys.stdout.flush()
-
+        page.screenshot(path=shot_path, full_page=False)
         browser.close()
 
-    return gate, ch
+    return gate, shot_path
 
 
 # ---------------------------------------------------------------------------
-# Main entry point
+# Public entry points
 # ---------------------------------------------------------------------------
 
 
-def run_next() -> None:
-    """Execute the next unverified scenario.
+def list_scenarios() -> None:
+    """Print all discovered scenario IDs and their linked debt issues.
 
-    Called by ``python -m claude_rts qa next``.
+    Called by ``python -m claude_rts qa list``.
     """
-    scenario_paths = _discover_scenarios()
-    if not scenario_paths:
-        print("[qa] No scenarios found in qa_scenarios/. Nothing to run.")
+    paths = _discover_scenarios()
+    if not paths:
+        print("[qa] No scenarios found in qa_scenarios/.")
         sys.exit(0)
 
-    verdicts = _load_verdicts()
-    discharged = _discharged_scenario_ids(verdicts)
-
-    # Find the first unverified scenario (alphabetical order, skip discharged).
-    next_path = None
-    next_cls = None
-    for path in scenario_paths:
+    rows = []
+    for path in paths:
         cls = _load_scenario_class(path)
         if cls is None:
             continue
         sid = getattr(cls, "scenario_id", None)
         if sid is None:
-            print(f"[qa] Warning: {path} Scenario missing scenario_id — skipping", file=sys.stderr)
             continue
-        if sid not in discharged:
-            next_path = path
-            next_cls = cls
-            break
+        issue = getattr(cls, "debt_issue", "?")
+        preset = getattr(cls, "preset", "default")
+        rows.append((sid, issue, preset))
 
-    if next_path is None:
-        print("[qa] No unverified scenarios. All scenarios have been discharged. Exiting.")
+    if not rows:
+        print("[qa] No valid scenarios found.")
         sys.exit(0)
 
-    preset = getattr(next_cls, "preset", "default")
-    debt_issue = getattr(next_cls, "debt_issue", None)
-    scenario_id = next_cls.scenario_id
+    print(f"{'SCENARIO ID':<45} {'DEBT ISSUE':<12} PRESET")
+    print("-" * 70)
+    for sid, issue, preset in rows:
+        print(f"{sid:<45} #{issue:<11} {preset}")
+    sys.exit(0)
+
+
+def run_scenario(scenario_id: str) -> None:
+    """Drive Playwright to the gate state and save a screenshot.
+
+    Prints the gate question, expected state, and screenshot path to stdout.
+    Does NOT post a verdict comment — use ``qa verdict`` for that after
+    assessing the screenshot.
+
+    Called by ``python -m claude_rts qa run <scenario-id>``.
+
+    Exits 0 on success.
+    Exits 1 if the scenario is not found or the server fails to start.
+    """
+    cls, available = _find_scenario_class(scenario_id)
+
+    if cls is None:
+        print(f"[qa] ERROR: scenario '{scenario_id}' not found.", file=sys.stderr)
+        if available:
+            print(f"[qa] Available scenarios: {', '.join(available)}", file=sys.stderr)
+        else:
+            print("[qa] No scenarios found in qa_scenarios/.", file=sys.stderr)
+        sys.exit(1)
+
+    preset = getattr(cls, "preset", "default")
+    debt_issue = getattr(cls, "debt_issue", None)
 
     print(f"[qa] Running scenario: {scenario_id}")
     print(f"[qa] Preset: {preset}   Debt issue: #{debt_issue}")
@@ -415,49 +407,94 @@ def run_next() -> None:
 
         print(f"[qa] Server ready at http://localhost:{_QA_PORT}")
 
-        scenario_instance = next_cls()
-        gate, ch = _run_scenario_with_playwright(scenario_instance, _QA_PORT)
+        scenario_instance = cls()
+        gate, shot_path = _run_scenario_with_playwright(scenario_instance, _QA_PORT)
 
     finally:
         _stop_server(proc, stdout_file, stderr_file)
 
-    # Map keystroke to verdict
-    verdict_map = {"y": "yes", "n": "no", "s": "skip"}
-    verdict = verdict_map.get(ch)
-    if verdict is None:
-        print(f"[qa] Unrecognised key '{ch}' — treating as skip.")
-        verdict = "skip"
+    _save_gate_cache(scenario_id, gate)
+
+    print("\n" + "=" * 70)
+    print("QA GATE STATE REACHED")
+    print("=" * 70)
+    print(f"\nScenario:    {scenario_id}")
+    print(f"Question:    {gate.question}")
+    print(f"Expected:    {gate.expected}")
+    print(f"Screenshot:  {shot_path}")
+    print(
+        f"\nAssess the screenshot, then record a verdict:\n"
+        f"  python -m claude_rts qa verdict {scenario_id} <pass|fail|inconclusive|blocked>"
+        f' [--notes "..."]'
+    )
+    sys.exit(0)
+
+
+def post_verdict(scenario_id: str, verdict: str, notes: str = "") -> None:
+    """Post a verdict comment to the linked GitHub debt issue.
+
+    ``verdict`` must be one of: pass, fail, inconclusive, blocked.
+    ``notes`` is an optional free-form string appended to the comment.
+
+    Called by ``python -m claude_rts qa verdict <scenario-id> <verdict>``.
+
+    Exits 0 on success.
+    Exits 1 if the scenario is not found, verdict is invalid, or gh fails.
+    """
+    if verdict not in _VERDICT_OPTIONS:
+        print(
+            f"[qa] ERROR: verdict must be one of: {', '.join(_VERDICT_OPTIONS)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    cls, available = _find_scenario_class(scenario_id)
+
+    if cls is None:
+        print(f"[qa] ERROR: scenario '{scenario_id}' not found.", file=sys.stderr)
+        if available:
+            print(f"[qa] Available scenarios: {', '.join(available)}", file=sys.stderr)
+        sys.exit(1)
+
+    debt_issue = getattr(cls, "debt_issue", None)
+    if debt_issue is None:
+        print("[qa] ERROR: scenario has no debt_issue — cannot post verdict comment.", file=sys.stderr)
+        sys.exit(1)
+
+    gate = _load_gate_cache(scenario_id)
 
     commit_sha = _current_commit_sha()
     timestamp = datetime.now(timezone.utc).isoformat()
+    verdict_label = _VERDICT_LABELS[verdict]
 
-    record = {
-        "scenario_id": scenario_id,
-        "commit_sha": commit_sha,
-        "verdict": verdict,
-        "timestamp": timestamp,
-        "question": gate.question,
-    }
-    _append_verdict(record)
-    print(f"[qa] Verdict '{verdict}' saved to {_VERDICTS_FILE}")
+    lines = [
+        f"## QA Verdict: {verdict_label}",
+        "",
+        f"**Scenario:** `{scenario_id}`",
+    ]
+    if gate is not None:
+        lines += [
+            f"**Question:** {gate.question}",
+            f"**Expected:** {gate.expected}",
+        ]
+    lines += [
+        f"**Verdict:** {verdict}",
+    ]
+    if notes:
+        lines.append(f"**Notes:** {notes}")
+    lines += [
+        f"**Commit:** `{commit_sha}`",
+        f"**Timestamp:** {timestamp}",
+        "",
+        f"*Recorded by `python -m claude_rts qa verdict {scenario_id} {verdict}`*",
+    ]
+    body = "\n".join(lines)
 
-    if verdict in {"yes", "no"} and debt_issue is not None:
-        repo = _derive_repo_slug()
-        verdict_label = "PASS ✓" if verdict == "yes" else "FAIL ✗"
-        body = (
-            f"## QA Verdict: {verdict_label}\n\n"
-            f"**Scenario:** `{scenario_id}`\n"
-            f"**Question:** {gate.question}\n"
-            f"**Expected:** {gate.expected}\n"
-            f"**Verdict:** {verdict}\n"
-            f"**Commit:** `{commit_sha}`\n"
-            f"**Timestamp:** {timestamp}\n\n"
-            f"*Recorded by `python -m claude_rts qa next`*"
-        )
-        ok = _post_github_comment(repo, debt_issue, body)
-        if ok:
-            print(f"[qa] Verdict comment posted to {repo}#{debt_issue}")
-        else:
-            print(f"[qa] Warning: could not post verdict comment to {repo}#{debt_issue}", file=sys.stderr)
-    elif verdict == "skip":
-        print("[qa] Skipped — no GitHub comment posted. Scenario will re-appear next run.")
+    repo = _derive_repo_slug()
+    ok = _post_github_comment(repo, debt_issue, body)
+    if not ok:
+        print(f"[qa] ERROR: could not post verdict comment to {repo}#{debt_issue}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[qa] Verdict '{verdict}' posted to {repo}#{debt_issue}")
+    sys.exit(0)

--- a/claude_rts/qa_runner.py
+++ b/claude_rts/qa_runner.py
@@ -1,0 +1,463 @@
+"""QA runner — ``python -m claude_rts qa next``.
+
+Discovers authored scenarios in ``qa_scenarios/``, filters out already-verdicted
+ones, launches the app, drives Playwright to the human gate, reads y/n/s, and
+records the verdict locally and as a GitHub comment on the linked debt issue.
+
+Verdict storage
+---------------
+``~/.supreme-claudemander/qa-verdicts.jsonl`` — one JSON record per line:
+
+    {"scenario_id": "syn-001-...", "commit_sha": "abc1234", "verdict": "yes",
+     "timestamp": "2026-04-27T16:00:00Z", "question": "Does the terminal appear?"}
+
+A scenario is considered "discharged" when it has a record with
+``verdict in {"yes", "no"}`` for **any** commit SHA.  Skipped (``"skip"``) verdicts
+are stored for audit/ordering but do not discharge the item — the scenario
+re-appears on the next ``qa next`` invocation.
+
+Ordering
+--------
+Scenarios are sorted alphabetically by filename.  The naming convention
+``<prefix>-<NNN>-<slug>.py`` naturally encodes priority order.
+
+Browser mode
+------------
+``qa next`` launches a headed (visible) browser by default so the human can see
+the app state at the gate.  Override with the ``HEADED`` environment variable:
+  ``HEADED=0 python -m claude_rts qa next``   → headless (useful for wiring tests)
+  ``HEADED=1 python -m claude_rts qa next``   → headed (default)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+# ---------------------------------------------------------------------------
+# Constants / paths
+# ---------------------------------------------------------------------------
+
+_VERDICTS_FILE = pathlib.Path.home() / ".supreme-claudemander" / "qa-verdicts.jsonl"
+_SCENARIOS_DIR = pathlib.Path(__file__).resolve().parent.parent / "qa_scenarios"
+
+_FALLBACK_REPO = "hyang0129/supreme-claudemander"
+
+# Port used by the qa next backend — distinct from the default 3000 so it
+# does not collide with a running production server.
+_QA_PORT = 3097
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _derive_repo_slug() -> str:
+    """Derive the GitHub repo slug from the git remote origin URL.
+
+    Falls back to ``hyang0129/supreme-claudemander`` with a warning if the
+    remote URL cannot be parsed.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        url = result.stdout.strip()
+        # HTTPS: https://github.com/owner/repo.git
+        m = re.match(r"https?://github\.com/([^/]+/[^/]+?)(?:\.git)?$", url)
+        if m:
+            return m.group(1)
+        # SSH: git@github.com:owner/repo.git
+        m = re.match(r"git@github\.com:([^/]+/[^/]+?)(?:\.git)?$", url)
+        if m:
+            return m.group(1)
+    except Exception:
+        pass
+    print(
+        f"[qa] Warning: could not derive repo slug from git remote; using fallback '{_FALLBACK_REPO}'",
+        file=sys.stderr,
+    )
+    return _FALLBACK_REPO
+
+
+def _current_commit_sha() -> str:
+    """Return the short HEAD commit SHA, or 'unknown' on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        sha = result.stdout.strip()
+        return sha if sha else "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _load_verdicts() -> list[dict]:
+    """Load all verdict records from the verdicts JSONL file."""
+    if not _VERDICTS_FILE.exists():
+        return []
+    records = []
+    with _VERDICTS_FILE.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+    return records
+
+
+def _discharged_scenario_ids(verdicts: list[dict]) -> set[str]:
+    """Return the set of scenario IDs that have been discharged (yes or no verdict)."""
+    return {r["scenario_id"] for r in verdicts if r.get("verdict") in {"yes", "no"}}
+
+
+def _append_verdict(record: dict) -> None:
+    """Append a single verdict record to the verdicts JSONL file."""
+    _VERDICTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with _VERDICTS_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def _post_github_comment(repo: str, issue_number: int, body: str) -> bool:
+    """Post a comment on the given GitHub issue using the gh CLI.
+
+    Returns True on success, False on failure.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "comment", str(issue_number), "--repo", repo, "--body", body],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            print(
+                f"[qa] Warning: gh issue comment failed (exit {result.returncode}): {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+            return False
+        return True
+    except FileNotFoundError:
+        print(
+            "[qa] Warning: 'gh' CLI not found — verdict comment not posted to GitHub.",
+            file=sys.stderr,
+        )
+        return False
+    except Exception as exc:
+        print(f"[qa] Warning: gh issue comment error: {exc}", file=sys.stderr)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Scenario discovery
+# ---------------------------------------------------------------------------
+
+
+def _discover_scenarios() -> list[pathlib.Path]:
+    """Return sorted list of scenario Python files in ``qa_scenarios/``."""
+    if not _SCENARIOS_DIR.exists():
+        return []
+    return sorted(_SCENARIOS_DIR.glob("*.py"))
+
+
+def _load_scenario_class(path: pathlib.Path):
+    """Import a scenario file and return its ``Scenario`` class.
+
+    The file must define a class named ``Scenario`` that implements
+    ``QAScenario``.  Returns ``None`` with a warning if loading fails.
+    """
+    spec = importlib.util.spec_from_file_location(f"qa_scenario_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        print(f"[qa] Warning: could not load scenario from {path}", file=sys.stderr)
+        return None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+    except Exception as exc:
+        print(f"[qa] Warning: error loading {path}: {exc}", file=sys.stderr)
+        return None
+    cls = getattr(module, "Scenario", None)
+    if cls is None:
+        print(f"[qa] Warning: {path} has no 'Scenario' class — skipping", file=sys.stderr)
+        return None
+    return cls
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_server(port: int, timeout: float = 30.0) -> bool:
+    """Poll until the backend responds on the given port."""
+    import urllib.error
+    import urllib.request
+
+    deadline = time.monotonic() + timeout
+    url = f"http://localhost:{port}/api/config"
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(url, timeout=2)
+            return True
+        except (urllib.error.URLError, OSError):
+            time.sleep(0.3)
+    return False
+
+
+def _start_server(
+    preset: str, port: int
+) -> tuple[subprocess.Popen, tempfile.NamedTemporaryFile, tempfile.NamedTemporaryFile]:  # type: ignore[type-arg]
+    """Start the backend server with the given dev-config preset.
+
+    Returns ``(proc, stdout_file, stderr_file)``.  Caller must terminate the
+    process and clean up the temp files.
+    """
+    stdout_file = tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False, prefix="qa-stdout-")
+    stderr_file = tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False, prefix="qa-stderr-")
+    env = os.environ.copy()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "claude_rts",
+            "--port",
+            str(port),
+            "--no-browser",
+            "--dev-config",
+            preset,
+        ],
+        env=env,
+        stdout=stdout_file,
+        stderr=stderr_file,
+    )
+    return proc, stdout_file, stderr_file
+
+
+def _stop_server(
+    proc: subprocess.Popen,  # type: ignore[type-arg]
+    stdout_file: tempfile.NamedTemporaryFile,  # type: ignore[type-arg]
+    stderr_file: tempfile.NamedTemporaryFile,  # type: ignore[type-arg]
+) -> None:
+    """Terminate the server process and clean up temp log files."""
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    for f in (stdout_file, stderr_file):
+        try:
+            f.close()
+            os.unlink(f.name)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Gate I/O
+# ---------------------------------------------------------------------------
+
+
+def _read_single_keystroke() -> str:
+    """Read a single keystroke from stdin without requiring Enter.
+
+    Falls back to ``input()`` if the terminal is not a TTY (e.g. tests).
+    """
+    if not sys.stdin.isatty():
+        line = sys.stdin.readline().strip().lower()
+        return line[0] if line else ""
+
+    import tty
+    import termios
+
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        ch = sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    return ch.lower()
+
+
+def _print_gate(gate) -> None:  # gate: HumanGate
+    """Print the human gate prompt to stdout."""
+    print("\n" + "=" * 70)
+    print("HUMAN JUDGMENT GATE")
+    print("=" * 70)
+    print(f"\nQuestion: {gate.question}")
+    print(f"Expected: {gate.expected}")
+    print("\nAnswer: [y]es  [n]o  [s]kip")
+    print("(Press a single key — no Enter needed)")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Playwright runner
+# ---------------------------------------------------------------------------
+
+
+def _run_scenario_with_playwright(scenario_instance, port: int) -> "HumanGate":  # noqa: F821
+    """Launch Playwright, navigate to the app, and run the scenario setup.
+
+    Returns the ``HumanGate`` from ``run_setup()``.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print(
+            "[qa] Playwright is not installed.\n"
+            "Install it with:  pip install -e '.[e2e]' && python -m playwright install chromium",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    headed = os.environ.get("HEADED", "1").lower() not in ("0", "false")
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=not headed)
+        page = browser.new_page()
+        page.goto(f"http://localhost:{port}")
+        page.wait_for_load_state("networkidle")
+        page.wait_for_selector("#canvas", timeout=15000)
+        page.wait_for_function(
+            "() => window.__claudeRtsBootComplete === true",
+            timeout=15000,
+        )
+
+        gate = scenario_instance.run_setup(page)
+
+        # Keep the browser open so the human can see the state.
+        # The gate prompt is printed AFTER setup completes.
+        _print_gate(gate)
+
+        ch = _read_single_keystroke()
+        print(f"\nYou answered: {ch!r}")
+        sys.stdout.flush()
+
+        browser.close()
+
+    return gate, ch
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def run_next() -> None:
+    """Execute the next unverified scenario.
+
+    Called by ``python -m claude_rts qa next``.
+    """
+    scenario_paths = _discover_scenarios()
+    if not scenario_paths:
+        print("[qa] No scenarios found in qa_scenarios/. Nothing to run.")
+        sys.exit(0)
+
+    verdicts = _load_verdicts()
+    discharged = _discharged_scenario_ids(verdicts)
+
+    # Find the first unverified scenario (alphabetical order, skip discharged).
+    next_path = None
+    next_cls = None
+    for path in scenario_paths:
+        cls = _load_scenario_class(path)
+        if cls is None:
+            continue
+        sid = getattr(cls, "scenario_id", None)
+        if sid is None:
+            print(f"[qa] Warning: {path} Scenario missing scenario_id — skipping", file=sys.stderr)
+            continue
+        if sid not in discharged:
+            next_path = path
+            next_cls = cls
+            break
+
+    if next_path is None:
+        print("[qa] No unverified scenarios. All scenarios have been discharged. Exiting.")
+        sys.exit(0)
+
+    preset = getattr(next_cls, "preset", "default")
+    debt_issue = getattr(next_cls, "debt_issue", None)
+    scenario_id = next_cls.scenario_id
+
+    print(f"[qa] Running scenario: {scenario_id}")
+    print(f"[qa] Preset: {preset}   Debt issue: #{debt_issue}")
+    print(f"[qa] Starting server on port {_QA_PORT} (preset={preset}) ...")
+
+    proc, stdout_file, stderr_file = _start_server(preset, _QA_PORT)
+    try:
+        if not _wait_for_server(_QA_PORT, timeout=30.0):
+            _stop_server(proc, stdout_file, stderr_file)
+            print("[qa] ERROR: Server did not start within 30 seconds. Aborting.", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"[qa] Server ready at http://localhost:{_QA_PORT}")
+
+        scenario_instance = next_cls()
+        gate, ch = _run_scenario_with_playwright(scenario_instance, _QA_PORT)
+
+    finally:
+        _stop_server(proc, stdout_file, stderr_file)
+
+    # Map keystroke to verdict
+    verdict_map = {"y": "yes", "n": "no", "s": "skip"}
+    verdict = verdict_map.get(ch)
+    if verdict is None:
+        print(f"[qa] Unrecognised key '{ch}' — treating as skip.")
+        verdict = "skip"
+
+    commit_sha = _current_commit_sha()
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    record = {
+        "scenario_id": scenario_id,
+        "commit_sha": commit_sha,
+        "verdict": verdict,
+        "timestamp": timestamp,
+        "question": gate.question,
+    }
+    _append_verdict(record)
+    print(f"[qa] Verdict '{verdict}' saved to {_VERDICTS_FILE}")
+
+    if verdict in {"yes", "no"} and debt_issue is not None:
+        repo = _derive_repo_slug()
+        verdict_label = "PASS ✓" if verdict == "yes" else "FAIL ✗"
+        body = (
+            f"## QA Verdict: {verdict_label}\n\n"
+            f"**Scenario:** `{scenario_id}`\n"
+            f"**Question:** {gate.question}\n"
+            f"**Expected:** {gate.expected}\n"
+            f"**Verdict:** {verdict}\n"
+            f"**Commit:** `{commit_sha}`\n"
+            f"**Timestamp:** {timestamp}\n\n"
+            f"*Recorded by `python -m claude_rts qa next`*"
+        )
+        ok = _post_github_comment(repo, debt_issue, body)
+        if ok:
+            print(f"[qa] Verdict comment posted to {repo}#{debt_issue}")
+        else:
+            print(f"[qa] Warning: could not post verdict comment to {repo}#{debt_issue}", file=sys.stderr)
+    elif verdict == "skip":
+        print("[qa] Skipped — no GitHub comment posted. Scenario will re-appear next run.")

--- a/claude_rts/qa_runner.py
+++ b/claude_rts/qa_runner.py
@@ -317,7 +317,7 @@ def _print_gate(gate) -> None:  # gate: HumanGate
 # ---------------------------------------------------------------------------
 
 
-def _run_scenario_with_playwright(scenario_instance, port: int) -> "HumanGate":  # noqa: F821
+def _run_scenario_with_playwright(scenario_instance, port: int) -> "tuple[HumanGate, str]":  # noqa: F821
     """Launch Playwright, navigate to the app, and run the scenario setup.
 
     Returns the ``HumanGate`` from ``run_setup()``.

--- a/claude_rts/qa_scenario.py
+++ b/claude_rts/qa_scenario.py
@@ -1,0 +1,79 @@
+"""QA scenario contract — HumanGate dataclass and QAScenario protocol.
+
+Scenario files placed in ``qa_scenarios/<id>.py`` must implement the
+``QAScenario`` protocol.  The runner (``qa_runner.py``) imports each file,
+instantiates the class, calls ``run_setup(page)`` with a live Playwright
+``Page`` object, and then presents the returned ``HumanGate`` to the human.
+
+Example minimal scenario
+------------------------
+```python
+from claude_rts.qa_scenario import HumanGate, QAScenario
+
+class Scenario(QAScenario):
+    scenario_id = "pr220-s1-container-label"
+    debt_issue = 221
+    preset = "default"
+
+    def run_setup(self, page) -> HumanGate:
+        # Drive the app to the gate state using real UI interactions.
+        page.wait_for_selector("#canvas")
+        return HumanGate(
+            scenario_id=self.scenario_id,
+            question="Does the Container Manager widget title say 'Container Manager' (not VM Manager)?",
+            expected="Title text reads 'Container Manager'",
+        )
+```
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass
+class HumanGate:
+    """Returned by a scenario's ``run_setup()`` to describe the human judgment gate.
+
+    Attributes:
+        scenario_id: Identifier matching the scenario class's ``scenario_id``.
+        question:    Question printed to the terminal for the human to answer.
+        expected:    Description of what a passing ("yes") state looks like.
+                     Printed alongside the question for context.
+    """
+
+    scenario_id: str
+    question: str
+    expected: str
+
+
+@runtime_checkable
+class QAScenario(Protocol):
+    """Protocol that every ``qa_scenarios/<id>.py`` file must satisfy.
+
+    Class attributes (declare as class-level variables, not instance):
+
+        scenario_id: str   — Unique identifier, e.g. "syn-001-container-terminal".
+                             Used as the key in the verdicts JSONL and GitHub comments.
+        debt_issue:  int   — GitHub issue number of the linked qa-debt issue (e.g. 221).
+        preset:      str   — Dev-config preset name to start the server with.
+                             Defaults to "default" if not declared.
+
+    Instance method:
+
+        run_setup(page: Page) -> HumanGate
+            Drive the Playwright ``page`` to the visual state where human
+            judgment is needed.  The page is already connected to the running
+            app when this method is called.  Must use real app pathways — no
+            ``/api/test/...`` endpoints.  Returns a ``HumanGate`` describing
+            the question to present to the human.
+    """
+
+    scenario_id: str
+    debt_issue: int
+    preset: str
+
+    def run_setup(self, page: Any) -> HumanGate:
+        """Drive the app to the gate state. Return the HumanGate to present."""
+        ...

--- a/docs/qa-scenarios.md
+++ b/docs/qa-scenarios.md
@@ -1,7 +1,7 @@
 # QA Scenarios — Runnable Discharge Path for QA Debt
 
-This document describes the scenario format, naming convention, authoring contract,
-and verdict semantics for `python -m claude_rts qa next`.
+This document describes the scenario format, CLI commands, verdict comment format,
+and the Claude agent workflow for iterating through unverified scenarios.
 
 See issue #277 for the design rationale.
 
@@ -11,22 +11,88 @@ See issue #277 for the design rationale.
 
 `/e2e-qa` records residual human-QA items as markdown checkboxes on a debt issue
 (e.g. #221).  The *discharge path* converts those items into runnable scenarios:
-a coding agent authors a Playwright Python file, and the human runs `qa next` to
-be driven to the judgment gate.
+a coding agent authors a Playwright Python file, Claude runs `qa run <id>` to
+drive the app to the gate state and capture a screenshot, then records the human's
+verdict with `qa verdict <id> <verdict>`.
+
+**The GitHub issue is the only source of truth.** A scenario is verified when a
+verdict comment exists on its linked debt issue. There is no local verdicts file.
+
+**The CLI is a dumb runner.** `qa run` drives Playwright to the gate state and
+takes a screenshot.  `qa verdict` posts the verdict comment.  Neither command
+auto-selects scenarios or reads prior verdicts.
+
+**A Claude agent is the orchestrator.** The agent reads the debt issue to find
+unverified scenarios, calls `qa run <id>` for each, reads the screenshot, asks the
+human what they saw, and calls `qa verdict <id> <verdict>`. See the
+[Agent workflow](#agent-workflow) section.
 
 ```
 qa_scenarios/<id>.py   — Playwright scenario file (authored by coding agent)
                 │
                 ▼
-python -m claude_rts qa next
+python -m claude_rts qa run <scenario-id>
                 │
-                ├─ launches app (--dev-config <preset>)
+                ├─ starts app (--dev-config <preset>, port 3097)
                 ├─ drives Playwright to gate state
-                ├─ prints HumanGate question
-                ├─ reads y / n / s keystroke
-                ├─ appends verdict to ~/.supreme-claudemander/qa-verdicts.jsonl
-                └─ posts GitHub comment on debt_issue (y/n only)
+                ├─ saves screenshot → /tmp/qa-screenshot-<id>.png
+                ├─ prints gate question + expected
+                └─ exits 0  (no verdict posted)
+
+Claude reads screenshot, asks human what they saw
+                │
+                ▼
+python -m claude_rts qa verdict <scenario-id> <verdict> [--notes "..."]
+                │
+                └─ posts verdict comment on debt_issue
 ```
+
+---
+
+## CLI reference
+
+```bash
+# List all available scenario IDs and their linked debt issues
+python -m claude_rts qa list
+
+# Drive the app to the gate state and capture a screenshot
+python -m claude_rts qa run <scenario-id>
+
+# Watch via noVNC while running (optional)
+HEADED=1 python -m claude_rts qa run <scenario-id>
+
+# Post a verdict after assessing the screenshot
+python -m claude_rts qa verdict <scenario-id> <verdict> [--notes "..."]
+```
+
+Verdict options for `qa verdict`:
+
+| Verdict | Meaning |
+|---|---|
+| `pass` | Gate state matches expected; feature works |
+| `fail` | Gate state does not match; bug found |
+| `inconclusive` | Cannot determine — screenshot unclear or ambiguous |
+| `blocked` | Could not reach gate state (server error, missing dependency, etc.) |
+
+Prerequisites:
+```bash
+pip install -e ".[e2e]"
+python -m playwright install chromium
+```
+
+For headed mode, a display server is required. In the devcontainer, start it with:
+```bash
+bash .devcontainer/start-novnc.sh
+# then open http://localhost:6081/vnc.html to view the browser window
+```
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | `qa run`: screenshot captured successfully |
+| 0 | `qa verdict`: verdict comment posted |
+| 1 | Scenario not found, server failed to start, invalid verdict, or GitHub comment failed |
 
 ---
 
@@ -63,8 +129,8 @@ class Scenario(QAScenario):
 
 | Attribute | Type | Required | Description |
 |---|---|---|---|
-| `scenario_id` | `str` | Yes | Unique identifier used as the JSONL key and in GitHub comments |
-| `debt_issue` | `int` | Yes | GitHub issue number where the verdict comment will be posted |
+| `scenario_id` | `str` | Yes | Unique identifier used in the verdict comment |
+| `debt_issue` | `int` | Yes | GitHub issue number where the verdict comment is posted |
 | `preset` | `str` | No | Dev-config preset name (default: `"default"`) |
 
 ### `run_setup(page) -> HumanGate`
@@ -72,14 +138,13 @@ class Scenario(QAScenario):
 - Called with a Playwright `Page` already navigated to the running app.
 - Must use **real app pathways only** — no `/api/test/...` endpoints.
 - Must return a `HumanGate(scenario_id, question, expected)`.
-- The browser window stays open until the human answers at the gate.
+- A screenshot is taken immediately after `run_setup` returns.
 
 ---
 
 ## Naming convention
 
-Files are sorted **alphabetically** to determine run order.  Use the prefix
-`<type>-<NNN>-<slug>.py` to encode priority:
+Files are sorted **alphabetically** by filename — naming encodes priority:
 
 | Prefix | Meaning |
 |---|---|
@@ -92,48 +157,63 @@ Examples:
 
 ---
 
-## Verdict semantics
+## Verdict comment format
 
-| Key | Stored in JSONL | GitHub comment posted |
-|---|---|---|
-| `y` | Yes (`verdict: "yes"`) | Yes — "PASS ✓" |
-| `n` | Yes (`verdict: "no"`) | Yes — "FAIL ✗" |
-| `s` | Yes (`verdict: "skip"`) | **No** |
+Posted to the linked debt issue by `qa verdict`:
 
-A scenario is **discharged** when it has a JSONL record with `verdict in {"yes", "no"}`.
-Skipped scenarios re-appear on every subsequent `qa next` invocation until they
-receive `y` or `n`.
+```markdown
+## QA Verdict: PASS ✓
 
-### Verdicts file schema
+**Scenario:** `syn-001-container-terminal`
+**Question:** Does the Container Manager widget say 'Container Manager'...
+**Expected:** Widget title reads 'Container Manager'...
+**Verdict:** pass
+**Notes:** Label correct, terminal card visible on canvas
+**Commit:** `abc1234`
+**Timestamp:** 2026-04-28T16:00:00+00:00
 
-`~/.supreme-claudemander/qa-verdicts.jsonl` — one JSON object per line:
-
-```json
-{
-  "scenario_id": "syn-001-container-terminal",
-  "commit_sha": "abc1234",
-  "verdict": "yes",
-  "timestamp": "2026-04-27T16:00:00+00:00",
-  "question": "Does the new terminal card appear on the canvas?"
-}
+*Recorded by `python -m claude_rts qa verdict syn-001-container-terminal pass`*
 ```
+
+An agent can determine whether a scenario is verified by searching issue comments
+for a block matching `## QA Verdict` + `**Scenario:** \`<id>\``.
+
+### Verdict semantics
+
+| Verdict | Label in comment | Meaning |
+|---|---|---|
+| `pass` | PASS ✓ | Gate state matches expected |
+| `fail` | FAIL ✗ | Gate state does not match |
+| `inconclusive` | INCONCLUSIVE ? | Cannot determine from screenshot |
+| `blocked` | BLOCKED ⊘ | Could not reach gate state |
 
 ---
 
-## Running scenarios
+## Agent workflow
 
-```bash
-# Run the next unverified scenario (headed browser — human can see the app)
-python -m claude_rts qa next
+The following prompt instructs a Claude agent to iterate through all unverified
+scenarios on a debt issue and run each one:
 
-# Run headless (wiring test only — human cannot see the UI)
-HEADED=0 python -m claude_rts qa next
 ```
+You are discharging QA debt on GitHub issue #<N> in the hyang0129/supreme-claudemander repo.
 
-Prerequisites:
-```bash
-pip install -e ".[e2e]"
-python -m playwright install chromium
+Steps:
+1. Read the issue comments with: gh issue view <N> --repo hyang0129/supreme-claudemander --comments
+2. Run: python -m claude_rts qa list
+   This gives you all available scenario IDs.
+3. For each scenario ID, check whether the issue comments already contain a block
+   matching "## QA Verdict" and "**Scenario:** `<id>`".
+   If a matching comment exists, the scenario is verified — skip it.
+4. For each unverified scenario:
+   a. Run: python -m claude_rts qa run <scenario-id>
+      This drives the app to the gate state and saves a screenshot.
+   b. Read the screenshot at the printed path with your image tool.
+   c. Describe what you see to the human and ask whether it matches the expected state.
+   d. Based on the human's response, run:
+      python -m claude_rts qa verdict <scenario-id> <pass|fail|inconclusive|blocked> \
+        --notes "<what the human said>"
+5. After all scenarios are run, re-read the issue comments to confirm all verdict
+   comments are present.
 ```
 
 ---
@@ -143,18 +223,15 @@ python -m playwright install chromium
 1. Identify a debt item from the linked `qa-debt` issue.
 2. Create `qa_scenarios/<prefix>-<NNN>-<slug>.py` with a `Scenario` class.
 3. Implement `run_setup(page)` using real app pathways (no test endpoints).
-4. Smoke-check: run `HEADED=0 python -m claude_rts qa next` to verify Playwright
-   reaches the gate state without error (keystroke prompt appears).
+4. Smoke-check: run `python -m claude_rts qa run <id>` to verify
+   Playwright reaches the gate state without error and a screenshot is saved.
 5. Commit the scenario file.
-
-The coding agent handles steps 1–4; the human only needs to judge at the gate.
 
 ---
 
 ## What NOT to do
 
 - Do NOT call `/api/test/...` endpoints in `run_setup()`.
-- Do NOT add `auto_start: true` to a preset config just for a scenario — use
-  the existing `human-qa` or `default` preset unless a new preset is strictly required.
+- Do NOT rely on local files for verdict state — read the GitHub issue comments.
 - Do NOT write `qa_scenarios/__init__.py` — the runner imports files directly.
 - Do NOT add scenario files to `tests/` — they live in `qa_scenarios/` only.

--- a/docs/qa-scenarios.md
+++ b/docs/qa-scenarios.md
@@ -1,0 +1,160 @@
+# QA Scenarios — Runnable Discharge Path for QA Debt
+
+This document describes the scenario format, naming convention, authoring contract,
+and verdict semantics for `python -m claude_rts qa next`.
+
+See issue #277 for the design rationale.
+
+---
+
+## Overview
+
+`/e2e-qa` records residual human-QA items as markdown checkboxes on a debt issue
+(e.g. #221).  The *discharge path* converts those items into runnable scenarios:
+a coding agent authors a Playwright Python file, and the human runs `qa next` to
+be driven to the judgment gate.
+
+```
+qa_scenarios/<id>.py   — Playwright scenario file (authored by coding agent)
+                │
+                ▼
+python -m claude_rts qa next
+                │
+                ├─ launches app (--dev-config <preset>)
+                ├─ drives Playwright to gate state
+                ├─ prints HumanGate question
+                ├─ reads y / n / s keystroke
+                ├─ appends verdict to ~/.supreme-claudemander/qa-verdicts.jsonl
+                └─ posts GitHub comment on debt_issue (y/n only)
+```
+
+---
+
+## Scenario file format
+
+Every file in `qa_scenarios/` must define a class named `Scenario` that satisfies
+the `QAScenario` protocol from `claude_rts.qa_scenario`.
+
+```python
+from claude_rts.qa_scenario import HumanGate, QAScenario
+
+class Scenario(QAScenario):
+    # Required class attributes
+    scenario_id = "pr220-s1-container-label"   # unique identifier
+    debt_issue  = 221                           # GitHub issue number of the debt backlog
+    preset      = "default"                    # dev-config preset to start the server with
+
+    def run_setup(self, page) -> HumanGate:
+        """Drive the app to the visual state where human judgment is needed.
+
+        ``page`` is a live Playwright ``Page`` already connected to the running app.
+        Use ONLY real app pathways — no /api/test/... endpoints.
+        """
+        page.wait_for_selector("#canvas")
+        # ... real UI interactions here ...
+        return HumanGate(
+            scenario_id=self.scenario_id,
+            question="Does the Container Manager widget title say 'Container Manager'?",
+            expected="Title text reads 'Container Manager', not 'VM Manager'",
+        )
+```
+
+### Class attributes
+
+| Attribute | Type | Required | Description |
+|---|---|---|---|
+| `scenario_id` | `str` | Yes | Unique identifier used as the JSONL key and in GitHub comments |
+| `debt_issue` | `int` | Yes | GitHub issue number where the verdict comment will be posted |
+| `preset` | `str` | No | Dev-config preset name (default: `"default"`) |
+
+### `run_setup(page) -> HumanGate`
+
+- Called with a Playwright `Page` already navigated to the running app.
+- Must use **real app pathways only** — no `/api/test/...` endpoints.
+- Must return a `HumanGate(scenario_id, question, expected)`.
+- The browser window stays open until the human answers at the gate.
+
+---
+
+## Naming convention
+
+Files are sorted **alphabetically** to determine run order.  Use the prefix
+`<type>-<NNN>-<slug>.py` to encode priority:
+
+| Prefix | Meaning |
+|---|---|
+| `syn-NNN-` | Synthetic scenario (not tied to a specific PR) |
+| `pr<N>-sN-` | Scenario for PR #N, item N in that PR's checklist |
+
+Examples:
+- `syn-001-container-terminal.py` — first synthetic scenario
+- `pr220-s1-container-label.py` — PR #220, item 1
+
+---
+
+## Verdict semantics
+
+| Key | Stored in JSONL | GitHub comment posted |
+|---|---|---|
+| `y` | Yes (`verdict: "yes"`) | Yes — "PASS ✓" |
+| `n` | Yes (`verdict: "no"`) | Yes — "FAIL ✗" |
+| `s` | Yes (`verdict: "skip"`) | **No** |
+
+A scenario is **discharged** when it has a JSONL record with `verdict in {"yes", "no"}`.
+Skipped scenarios re-appear on every subsequent `qa next` invocation until they
+receive `y` or `n`.
+
+### Verdicts file schema
+
+`~/.supreme-claudemander/qa-verdicts.jsonl` — one JSON object per line:
+
+```json
+{
+  "scenario_id": "syn-001-container-terminal",
+  "commit_sha": "abc1234",
+  "verdict": "yes",
+  "timestamp": "2026-04-27T16:00:00+00:00",
+  "question": "Does the new terminal card appear on the canvas?"
+}
+```
+
+---
+
+## Running scenarios
+
+```bash
+# Run the next unverified scenario (headed browser — human can see the app)
+python -m claude_rts qa next
+
+# Run headless (wiring test only — human cannot see the UI)
+HEADED=0 python -m claude_rts qa next
+```
+
+Prerequisites:
+```bash
+pip install -e ".[e2e]"
+python -m playwright install chromium
+```
+
+---
+
+## Authoring a new scenario
+
+1. Identify a debt item from the linked `qa-debt` issue.
+2. Create `qa_scenarios/<prefix>-<NNN>-<slug>.py` with a `Scenario` class.
+3. Implement `run_setup(page)` using real app pathways (no test endpoints).
+4. Smoke-check: run `HEADED=0 python -m claude_rts qa next` to verify Playwright
+   reaches the gate state without error (keystroke prompt appears).
+5. Commit the scenario file.
+
+The coding agent handles steps 1–4; the human only needs to judge at the gate.
+
+---
+
+## What NOT to do
+
+- Do NOT call `/api/test/...` endpoints in `run_setup()`.
+- Do NOT add `auto_start: true` to a preset config just for a scenario — use
+  the existing `human-qa` or `default` preset unless a new preset is strictly required.
+- Do NOT write `qa_scenarios/__init__.py` — the runner imports files directly.
+- Do NOT add scenario files to `tests/` — they live in `qa_scenarios/` only.

--- a/qa_scenarios/syn-001-container-terminal.py
+++ b/qa_scenarios/syn-001-container-terminal.py
@@ -1,0 +1,110 @@
+"""Synthetic Phase 1 QA scenario — Container Manager + terminal card.
+
+Debt issue: #221 (PR #220 — Container Manager epic)
+Scenario:   Verify the Container Manager widget renders and a terminal card
+            can be spawned through the Claude API, then appears on the canvas.
+
+This scenario targets the following item from the #221 debt backlog:
+  "Start server with --dev-config default, spawn a Container Manager widget —
+   verify it shows 'Container Manager' (not VM Manager)"
+
+It also exercises the terminal creation API so a real card appears on canvas
+and accepts keyboard input, satisfying the Phase 1 end-to-end wiring test.
+
+Real-app pathway:
+  1. Start server with --dev-config default (no test endpoints used).
+  2. Open canvas in Playwright.
+  3. Right-click to open context menu — spawn a Container Manager widget.
+  4. Verify the widget body DOM is loaded (widget title area rendered).
+  5. Use the REST API (real production endpoint, not /api/test/...) to
+     create a terminal card: POST /api/claude/terminal/create.
+  6. Wait for the terminal card to appear on the canvas DOM.
+  7. Present human gate: "Does the Container Manager widget say
+     'Container Manager' and does the terminal card appear?"
+"""
+
+from __future__ import annotations
+
+
+from claude_rts.qa_scenario import HumanGate, QAScenario
+
+
+class Scenario(QAScenario):
+    scenario_id = "syn-001-container-terminal"
+    debt_issue = 221
+    preset = "default"
+
+    def run_setup(self, page) -> HumanGate:
+        """Drive the app to the gate state.
+
+        Steps:
+        1. Confirm canvas is loaded.
+        2. Right-click the viewport and spawn a Container Manager widget.
+        3. Create a terminal card via POST /api/claude/terminal/create (real endpoint).
+        4. Wait for the terminal card DOM element to appear.
+        """
+        # Step 1: Confirm canvas is ready (boot complete signal already waited
+        # by the runner before calling run_setup).
+        page.wait_for_selector("#canvas", timeout=15000)
+
+        # Step 2: Spawn a Container Manager widget via right-click context menu.
+        # The context menu is opened at the center of the viewport.
+        page.evaluate("() => { if (typeof hideContextMenu === 'function') hideContextMenu(); }")
+        page.locator("#viewport").click(button="right", position={"x": 500, "y": 400})
+
+        # Wait for context menu to be visible.
+        page.wait_for_selector("#context-menu.visible", timeout=5000)
+
+        # Click the "Container Manager" widget item. The label is rendered as a
+        # .ctx-item element with data-widget="container-manager".
+        cm_item = page.locator("#context-menu .ctx-item[data-widget='container-manager']")
+        cm_item.wait_for(state="visible", timeout=5000)
+        cm_item.click()
+
+        # Close any residual context menu.
+        page.evaluate("() => { if (typeof hideContextMenu === 'function') hideContextMenu(); }")
+
+        # Wait for the Container Manager card body to render (widget loads asynchronously).
+        # The Container Manager card injects a [data-container-search] input when rendered.
+        page.wait_for_selector("[data-container-search]", timeout=10000)
+
+        # Step 3: Create a terminal card via the real production Claude API.
+        # This endpoint is the standard terminal creation path used by Canvas Claude.
+        response = page.evaluate(
+            """async () => {
+                const r = await fetch('/api/claude/terminal/create', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({cmd: 'bash', x: 200, y: 200, w: 600, h: 400})
+                });
+                if (!r.ok) return {ok: false, status: r.status};
+                const data = await r.json();
+                return {ok: true, card_id: data.card_id};
+            }"""
+        )
+
+        if not response.get("ok"):
+            # Non-fatal: the terminal spawn may fail if bash is not available in
+            # the dev-config server process (e.g. test env).  The Container Manager
+            # widget is still the primary judgment target.
+            pass
+        else:
+            card_id = response.get("card_id")
+            if card_id:
+                # Step 4: Wait for the terminal card DOM element to appear.
+                page.wait_for_selector(f'[data-card-id="{card_id}"]', timeout=10000)
+
+        # Gate: the human judges both the Container Manager label and the
+        # terminal card presence.
+        return HumanGate(
+            scenario_id=self.scenario_id,
+            question=(
+                "1. Does the Container Manager widget title say 'Container Manager' "
+                "(not 'VM Manager' or any other label)?\n"
+                "   2. Does a terminal card appear on the canvas?"
+            ),
+            expected=(
+                "Widget title reads 'Container Manager'. "
+                "A terminal card is visible on the canvas and accepts keyboard input."
+            ),
+        )

--- a/tests/test_qa_runner.py
+++ b/tests/test_qa_runner.py
@@ -4,13 +4,18 @@ These tests mock Playwright and subprocess so they run without a browser or
 running server.  They verify:
 
 - Scenario discovery and ordering (alphabetical)
-- Verdict filtering (discharged = yes/no only; skip re-queues)
-- Verdict JSONL append
-- GitHub comment posting (y/n posts; skip does not)
-- Repo slug derivation (https + ssh remotes + fallback)
 - Scenario class loading (valid, missing Scenario class, exec error)
+- GitHub comment posting (success, gh failure, gh missing)
+- Repo slug derivation (https + ssh remotes + fallback)
+- list_scenarios() output
+- run_scenario() not-found exits 1 with available IDs
+- run_scenario() success saves gate cache and exits 0
+- post_verdict() valid verdicts post structured GitHub comments
+- post_verdict() invalid verdict exits 1
+- post_verdict() gh failure exits 1
+- post_verdict() includes notes when provided
+- Gate cache round-trip (_save_gate_cache / _load_gate_cache)
 - HumanGate and QAScenario protocol
-- run_next() exits 0 with "no unverified scenarios" when all discharged
 """
 
 from __future__ import annotations
@@ -21,6 +26,7 @@ import textwrap
 import unittest.mock as mock
 
 import pytest
+
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -35,16 +41,6 @@ def tmp_scenarios_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "_SCENARIOS_DIR", tmp_path / "qa_scenarios")
     (tmp_path / "qa_scenarios").mkdir()
     return tmp_path / "qa_scenarios"
-
-
-@pytest.fixture()
-def tmp_verdicts(tmp_path, monkeypatch):
-    """Redirect _VERDICTS_FILE to a temp file."""
-    import claude_rts.qa_runner as runner
-
-    verdicts_path = tmp_path / "qa-verdicts.jsonl"
-    monkeypatch.setattr(runner, "_VERDICTS_FILE", verdicts_path)
-    return verdicts_path
 
 
 def _write_scenario_file(
@@ -73,19 +69,6 @@ def _write_scenario_file(
         encoding="utf-8",
     )
     return path
-
-
-def _write_verdict(verdicts_path: pathlib.Path, scenario_id: str, verdict: str) -> None:
-    """Append a verdict record to the verdicts file."""
-    record = {
-        "scenario_id": scenario_id,
-        "commit_sha": "abc1234",
-        "verdict": verdict,
-        "timestamp": "2026-01-01T00:00:00+00:00",
-        "question": "Test question?",
-    }
-    with verdicts_path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(record) + "\n")
 
 
 # ---------------------------------------------------------------------------
@@ -186,86 +169,6 @@ def test_load_scenario_class_exec_error(tmp_scenarios_dir):
 
 
 # ---------------------------------------------------------------------------
-# Verdict loading and filtering
-# ---------------------------------------------------------------------------
-
-
-def test_load_verdicts_empty(tmp_verdicts):
-    import claude_rts.qa_runner as runner
-
-    assert runner._load_verdicts() == []
-
-
-def test_load_verdicts_records(tmp_verdicts):
-    import claude_rts.qa_runner as runner
-
-    _write_verdict(tmp_verdicts, "s1", "yes")
-    _write_verdict(tmp_verdicts, "s2", "no")
-    _write_verdict(tmp_verdicts, "s3", "skip")
-
-    records = runner._load_verdicts()
-    assert len(records) == 3
-
-
-def test_discharged_scenario_ids_yes_and_no(tmp_verdicts):
-    import claude_rts.qa_runner as runner
-
-    _write_verdict(tmp_verdicts, "s1", "yes")
-    _write_verdict(tmp_verdicts, "s2", "no")
-
-    discharged = runner._discharged_scenario_ids(runner._load_verdicts())
-    assert discharged == {"s1", "s2"}
-
-
-def test_skip_does_not_discharge(tmp_verdicts):
-    import claude_rts.qa_runner as runner
-
-    _write_verdict(tmp_verdicts, "s1", "skip")
-    discharged = runner._discharged_scenario_ids(runner._load_verdicts())
-    assert discharged == set()
-
-
-def test_skip_then_yes_discharges(tmp_verdicts):
-    import claude_rts.qa_runner as runner
-
-    _write_verdict(tmp_verdicts, "s1", "skip")
-    _write_verdict(tmp_verdicts, "s1", "yes")
-    discharged = runner._discharged_scenario_ids(runner._load_verdicts())
-    assert "s1" in discharged
-
-
-# ---------------------------------------------------------------------------
-# Verdict append
-# ---------------------------------------------------------------------------
-
-
-def test_append_verdict_creates_file(tmp_verdicts):
-    import claude_rts.qa_runner as runner
-
-    assert not tmp_verdicts.exists()
-    runner._append_verdict(
-        {"scenario_id": "s1", "verdict": "yes", "commit_sha": "abc", "timestamp": "t", "question": "q"}
-    )
-    assert tmp_verdicts.exists()
-    records = runner._load_verdicts()
-    assert len(records) == 1
-    assert records[0]["scenario_id"] == "s1"
-
-
-def test_append_verdict_appends(tmp_verdicts):
-    import claude_rts.qa_runner as runner
-
-    runner._append_verdict(
-        {"scenario_id": "s1", "verdict": "yes", "commit_sha": "abc", "timestamp": "t", "question": "q"}
-    )
-    runner._append_verdict(
-        {"scenario_id": "s2", "verdict": "no", "commit_sha": "def", "timestamp": "t", "question": "q"}
-    )
-    records = runner._load_verdicts()
-    assert len(records) == 2
-
-
-# ---------------------------------------------------------------------------
 # GitHub comment posting
 # ---------------------------------------------------------------------------
 
@@ -346,32 +249,354 @@ def test_derive_repo_slug_fallback(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# run_next() — no scenarios
+# Gate cache
 # ---------------------------------------------------------------------------
 
 
-def test_run_next_no_scenarios(tmp_scenarios_dir, tmp_verdicts):
+def test_gate_cache_round_trip(tmp_path, monkeypatch):
+    import claude_rts.qa_runner as runner
+    from claude_rts.qa_scenario import HumanGate
+
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"qa-gate-{sid}.json")
+
+    gate = HumanGate(scenario_id="s1", question="q?", expected="e")
+    runner._save_gate_cache("s1", gate)
+
+    loaded = runner._load_gate_cache("s1")
+    assert loaded is not None
+    assert loaded.scenario_id == "s1"
+    assert loaded.question == "q?"
+    assert loaded.expected == "e"
+
+
+def test_gate_cache_missing_returns_none(tmp_path, monkeypatch):
+    import claude_rts.qa_runner as runner
+
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"qa-gate-{sid}.json")
+    assert runner._load_gate_cache("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# list_scenarios()
+# ---------------------------------------------------------------------------
+
+
+def test_list_scenarios_empty(tmp_scenarios_dir):
     import claude_rts.qa_runner as runner
 
     with pytest.raises(SystemExit) as exc_info:
-        runner.run_next()
+        runner.list_scenarios()
     assert exc_info.value.code == 0
 
 
-# ---------------------------------------------------------------------------
-# run_next() — all discharged
-# ---------------------------------------------------------------------------
-
-
-def test_run_next_all_discharged(tmp_scenarios_dir, tmp_verdicts):
+def test_list_scenarios_prints_ids(tmp_scenarios_dir, capsys):
     import claude_rts.qa_runner as runner
 
-    _write_scenario_file(tmp_scenarios_dir, "syn-001.py", "syn-001")
-    _write_verdict(tmp_verdicts, "syn-001", "yes")
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-alpha.py", "syn-001-alpha", debt_issue=100)
+    _write_scenario_file(tmp_scenarios_dir, "syn-002-beta.py", "syn-002-beta", debt_issue=200)
+
+    with pytest.raises(SystemExit):
+        runner.list_scenarios()
+
+    out = capsys.readouterr().out
+    assert "syn-001-alpha" in out
+    assert "syn-002-beta" in out
+    assert "#100" in out
+    assert "#200" in out
+
+
+# ---------------------------------------------------------------------------
+# run_scenario() — not found
+# ---------------------------------------------------------------------------
+
+
+def test_run_scenario_not_found_exits_1(tmp_scenarios_dir):
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-real.py", "syn-001-real")
 
     with pytest.raises(SystemExit) as exc_info:
-        runner.run_next()
+        runner.run_scenario("does-not-exist")
+    assert exc_info.value.code == 1
+
+
+def test_run_scenario_not_found_lists_available(tmp_scenarios_dir, capsys):
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-real.py", "syn-001-real")
+
+    with pytest.raises(SystemExit):
+        runner.run_scenario("does-not-exist")
+
+    err = capsys.readouterr().err
+    assert "syn-001-real" in err
+
+
+# ---------------------------------------------------------------------------
+# run_scenario() — success saves gate cache and exits 0
+# ---------------------------------------------------------------------------
+
+
+def test_run_scenario_success_exits_0(tmp_scenarios_dir, tmp_path, monkeypatch):
+    """Successful run saves gate cache and exits 0."""
+    import claude_rts.qa_runner as runner
+    from claude_rts.qa_scenario import HumanGate
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-ok.py", "syn-001-ok", debt_issue=221)
+
+    monkeypatch.setattr(runner, "_start_server", lambda *a: (mock.Mock(), mock.Mock(), mock.Mock()))
+    monkeypatch.setattr(runner, "_wait_for_server", lambda *a, **kw: True)
+    monkeypatch.setattr(runner, "_stop_server", lambda *a: None)
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"qa-gate-{sid}.json")
+
+    gate = HumanGate(scenario_id="syn-001-ok", question="Does it look right?", expected="Yes.")
+    shot = str(tmp_path / "screenshot.png")
+    monkeypatch.setattr(runner, "_run_scenario_with_playwright", lambda inst, port: (gate, shot))
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.run_scenario("syn-001-ok")
+
     assert exc_info.value.code == 0
+
+
+def test_run_scenario_saves_gate_cache(tmp_scenarios_dir, tmp_path, monkeypatch, capsys):
+    """Gate question and expected are saved to the cache file."""
+    import claude_rts.qa_runner as runner
+    from claude_rts.qa_scenario import HumanGate
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-cache.py", "syn-001-cache", debt_issue=221)
+
+    monkeypatch.setattr(runner, "_start_server", lambda *a: (mock.Mock(), mock.Mock(), mock.Mock()))
+    monkeypatch.setattr(runner, "_wait_for_server", lambda *a, **kw: True)
+    monkeypatch.setattr(runner, "_stop_server", lambda *a: None)
+
+    cache_path = tmp_path / "qa-gate-syn-001-cache.json"
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: cache_path)
+
+    gate = HumanGate(scenario_id="syn-001-cache", question="Visible?", expected="Yes visible.")
+    shot = str(tmp_path / "shot.png")
+    monkeypatch.setattr(runner, "_run_scenario_with_playwright", lambda inst, port: (gate, shot))
+
+    with pytest.raises(SystemExit):
+        runner.run_scenario("syn-001-cache")
+
+    assert cache_path.exists()
+    data = json.loads(cache_path.read_text())
+    assert data["question"] == "Visible?"
+    assert data["expected"] == "Yes visible."
+
+
+def test_run_scenario_prints_screenshot_path(tmp_scenarios_dir, tmp_path, monkeypatch, capsys):
+    """Screenshot path is printed to stdout."""
+    import claude_rts.qa_runner as runner
+    from claude_rts.qa_scenario import HumanGate
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-shot.py", "syn-001-shot", debt_issue=221)
+
+    monkeypatch.setattr(runner, "_start_server", lambda *a: (mock.Mock(), mock.Mock(), mock.Mock()))
+    monkeypatch.setattr(runner, "_wait_for_server", lambda *a, **kw: True)
+    monkeypatch.setattr(runner, "_stop_server", lambda *a: None)
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"qa-gate-{sid}.json")
+
+    gate = HumanGate(scenario_id="syn-001-shot", question="q?", expected="e")
+    shot = "/tmp/qa-screenshot-syn-001-shot.png"
+    monkeypatch.setattr(runner, "_run_scenario_with_playwright", lambda inst, port: (gate, shot))
+
+    with pytest.raises(SystemExit):
+        runner.run_scenario("syn-001-shot")
+
+    out = capsys.readouterr().out
+    assert shot in out
+
+
+def test_run_scenario_server_fail_exits_1(tmp_scenarios_dir, monkeypatch):
+    """If server doesn't start, exit 1."""
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-sfail.py", "syn-001-sfail")
+
+    monkeypatch.setattr(runner, "_start_server", lambda *a: (mock.Mock(), mock.Mock(), mock.Mock()))
+    monkeypatch.setattr(runner, "_wait_for_server", lambda *a, **kw: False)
+    monkeypatch.setattr(runner, "_stop_server", lambda *a: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.run_scenario("syn-001-sfail")
+
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# post_verdict() — valid verdicts
+# ---------------------------------------------------------------------------
+
+
+def test_post_verdict_pass_posts_comment(tmp_scenarios_dir, tmp_path, monkeypatch):
+    """pass verdict posts PASS comment and exits 0."""
+    import claude_rts.qa_runner as runner
+    from claude_rts.qa_scenario import HumanGate
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-v.py", "syn-001-v", debt_issue=221)
+
+    comment_calls = []
+    monkeypatch.setattr(runner, "_post_github_comment", lambda r, i, b: comment_calls.append((r, i, b)) or True)
+    monkeypatch.setattr(runner, "_derive_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(runner, "_current_commit_sha", lambda: "abc1234")
+
+    gate = HumanGate(scenario_id="syn-001-v", question="Is it right?", expected="Yes.")
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"qa-gate-{sid}.json")
+    runner._save_gate_cache("syn-001-v", gate)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.post_verdict("syn-001-v", "pass")
+
+    assert exc_info.value.code == 0
+    assert len(comment_calls) == 1
+    repo, issue, body = comment_calls[0]
+    assert issue == 221
+    assert "PASS" in body
+    assert "syn-001-v" in body
+    assert "abc1234" in body
+
+
+def test_post_verdict_fail_posts_fail_comment(tmp_scenarios_dir, tmp_path, monkeypatch):
+    """fail verdict posts FAIL comment."""
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-f.py", "syn-001-f", debt_issue=221)
+
+    bodies = []
+    monkeypatch.setattr(runner, "_post_github_comment", lambda r, i, b: bodies.append(b) or True)
+    monkeypatch.setattr(runner, "_derive_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(runner, "_current_commit_sha", lambda: "abc1234")
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"no-cache-{sid}.json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.post_verdict("syn-001-f", "fail")
+
+    assert exc_info.value.code == 0
+    assert "FAIL" in bodies[0]
+
+
+def test_post_verdict_inconclusive(tmp_scenarios_dir, tmp_path, monkeypatch):
+    """inconclusive verdict posts INCONCLUSIVE comment."""
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-i.py", "syn-001-i", debt_issue=221)
+
+    bodies = []
+    monkeypatch.setattr(runner, "_post_github_comment", lambda r, i, b: bodies.append(b) or True)
+    monkeypatch.setattr(runner, "_derive_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(runner, "_current_commit_sha", lambda: "abc1234")
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"no-cache-{sid}.json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.post_verdict("syn-001-i", "inconclusive")
+
+    assert exc_info.value.code == 0
+    assert "INCONCLUSIVE" in bodies[0]
+
+
+def test_post_verdict_blocked(tmp_scenarios_dir, tmp_path, monkeypatch):
+    """blocked verdict posts BLOCKED comment."""
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-b.py", "syn-001-b", debt_issue=221)
+
+    bodies = []
+    monkeypatch.setattr(runner, "_post_github_comment", lambda r, i, b: bodies.append(b) or True)
+    monkeypatch.setattr(runner, "_derive_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(runner, "_current_commit_sha", lambda: "abc1234")
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"no-cache-{sid}.json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.post_verdict("syn-001-b", "blocked")
+
+    assert exc_info.value.code == 0
+    assert "BLOCKED" in bodies[0]
+
+
+def test_post_verdict_includes_notes(tmp_scenarios_dir, tmp_path, monkeypatch):
+    """Notes are included in the posted comment body."""
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-n.py", "syn-001-n", debt_issue=221)
+
+    bodies = []
+    monkeypatch.setattr(runner, "_post_github_comment", lambda r, i, b: bodies.append(b) or True)
+    monkeypatch.setattr(runner, "_derive_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(runner, "_current_commit_sha", lambda: "abc1234")
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"no-cache-{sid}.json")
+
+    with pytest.raises(SystemExit):
+        runner.post_verdict("syn-001-n", "pass", notes="Widget label looks correct to me")
+
+    assert "Widget label looks correct to me" in bodies[0]
+
+
+def test_post_verdict_invalid_verdict_exits_1(tmp_scenarios_dir, monkeypatch):
+    """Unknown verdict string exits 1 without posting."""
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-inv.py", "syn-001-inv")
+
+    calls = []
+    monkeypatch.setattr(runner, "_post_github_comment", lambda *a: calls.append(a) or True)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.post_verdict("syn-001-inv", "maybe")
+
+    assert exc_info.value.code == 1
+    assert calls == []
+
+
+def test_post_verdict_not_found_exits_1(tmp_scenarios_dir, monkeypatch):
+    """Unknown scenario ID exits 1."""
+    import claude_rts.qa_runner as runner
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.post_verdict("does-not-exist", "pass")
+
+    assert exc_info.value.code == 1
+
+
+def test_post_verdict_gh_failure_exits_1(tmp_scenarios_dir, tmp_path, monkeypatch):
+    """If gh comment fails, exit 1."""
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-ghf.py", "syn-001-ghf", debt_issue=221)
+
+    monkeypatch.setattr(runner, "_post_github_comment", lambda *a: False)
+    monkeypatch.setattr(runner, "_derive_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(runner, "_current_commit_sha", lambda: "abc1234")
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"no-cache-{sid}.json")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.post_verdict("syn-001-ghf", "pass")
+
+    assert exc_info.value.code == 1
+
+
+def test_post_verdict_includes_gate_question_when_cache_present(tmp_scenarios_dir, tmp_path, monkeypatch):
+    """Gate question and expected appear in the comment when cache is available."""
+    import claude_rts.qa_runner as runner
+    from claude_rts.qa_scenario import HumanGate
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001-gq.py", "syn-001-gq", debt_issue=221)
+
+    bodies = []
+    monkeypatch.setattr(runner, "_post_github_comment", lambda r, i, b: bodies.append(b) or True)
+    monkeypatch.setattr(runner, "_derive_repo_slug", lambda: "owner/repo")
+    monkeypatch.setattr(runner, "_current_commit_sha", lambda: "abc1234")
+
+    gate = HumanGate(scenario_id="syn-001-gq", question="Is the label correct?", expected="Label reads X.")
+    monkeypatch.setattr(runner, "_gate_cache_path", lambda sid: tmp_path / f"qa-gate-{sid}.json")
+    runner._save_gate_cache("syn-001-gq", gate)
+
+    with pytest.raises(SystemExit):
+        runner.post_verdict("syn-001-gq", "pass")
+
+    assert "Is the label correct?" in bodies[0]
+    assert "Label reads X." in bodies[0]
 
 
 # ---------------------------------------------------------------------------
@@ -392,7 +617,7 @@ def test_synthetic_scenario_loads():
     assert cls.preset == "default"
 
 
-def test_synthetic_scenario_run_setup_returns_human_gate(monkeypatch):
+def test_synthetic_scenario_run_setup_returns_human_gate():
     """run_setup should return a HumanGate when given a mock page."""
     import claude_rts.qa_runner as runner
     from claude_rts.qa_scenario import HumanGate
@@ -401,7 +626,6 @@ def test_synthetic_scenario_run_setup_returns_human_gate(monkeypatch):
     cls = runner._load_scenario_class(path)
     assert cls is not None
 
-    # Build a minimal mock Playwright page.
     mock_page = mock.Mock()
     mock_page.evaluate.return_value = {"ok": True, "card_id": "card-abc"}
 

--- a/tests/test_qa_runner.py
+++ b/tests/test_qa_runner.py
@@ -1,0 +1,414 @@
+"""Unit tests for claude_rts.qa_runner and claude_rts.qa_scenario.
+
+These tests mock Playwright and subprocess so they run without a browser or
+running server.  They verify:
+
+- Scenario discovery and ordering (alphabetical)
+- Verdict filtering (discharged = yes/no only; skip re-queues)
+- Verdict JSONL append
+- GitHub comment posting (y/n posts; skip does not)
+- Repo slug derivation (https + ssh remotes + fallback)
+- Scenario class loading (valid, missing Scenario class, exec error)
+- HumanGate and QAScenario protocol
+- run_next() exits 0 with "no unverified scenarios" when all discharged
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import textwrap
+import unittest.mock as mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_scenarios_dir(tmp_path, monkeypatch):
+    """Redirect _SCENARIOS_DIR to a temp directory."""
+    import claude_rts.qa_runner as runner
+
+    monkeypatch.setattr(runner, "_SCENARIOS_DIR", tmp_path / "qa_scenarios")
+    (tmp_path / "qa_scenarios").mkdir()
+    return tmp_path / "qa_scenarios"
+
+
+@pytest.fixture()
+def tmp_verdicts(tmp_path, monkeypatch):
+    """Redirect _VERDICTS_FILE to a temp file."""
+    import claude_rts.qa_runner as runner
+
+    verdicts_path = tmp_path / "qa-verdicts.jsonl"
+    monkeypatch.setattr(runner, "_VERDICTS_FILE", verdicts_path)
+    return verdicts_path
+
+
+def _write_scenario_file(
+    scenarios_dir: pathlib.Path, filename: str, scenario_id: str, debt_issue: int = 221
+) -> pathlib.Path:
+    """Write a minimal valid scenario Python file."""
+    path = scenarios_dir / filename
+    path.write_text(
+        textwrap.dedent(
+            f"""
+            from claude_rts.qa_scenario import HumanGate, QAScenario
+
+            class Scenario(QAScenario):
+                scenario_id = "{scenario_id}"
+                debt_issue = {debt_issue}
+                preset = "default"
+
+                def run_setup(self, page) -> HumanGate:
+                    return HumanGate(
+                        scenario_id=self.scenario_id,
+                        question="Test question?",
+                        expected="Expected state.",
+                    )
+            """
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_verdict(verdicts_path: pathlib.Path, scenario_id: str, verdict: str) -> None:
+    """Append a verdict record to the verdicts file."""
+    record = {
+        "scenario_id": scenario_id,
+        "commit_sha": "abc1234",
+        "verdict": verdict,
+        "timestamp": "2026-01-01T00:00:00+00:00",
+        "question": "Test question?",
+    }
+    with verdicts_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# HumanGate and QAScenario protocol
+# ---------------------------------------------------------------------------
+
+
+def test_human_gate_fields():
+    from claude_rts.qa_scenario import HumanGate
+
+    gate = HumanGate(scenario_id="s1", question="q?", expected="e")
+    assert gate.scenario_id == "s1"
+    assert gate.question == "q?"
+    assert gate.expected == "e"
+
+
+def test_qa_scenario_protocol_satisfied():
+    from claude_rts.qa_scenario import HumanGate, QAScenario
+
+    class S(QAScenario):
+        scenario_id = "test-1"
+        debt_issue = 100
+        preset = "default"
+
+        def run_setup(self, page) -> HumanGate:
+            return HumanGate(scenario_id=self.scenario_id, question="q", expected="e")
+
+    assert isinstance(S(), QAScenario)
+
+
+# ---------------------------------------------------------------------------
+# Scenario discovery and ordering
+# ---------------------------------------------------------------------------
+
+
+def test_discover_scenarios_empty(tmp_scenarios_dir):
+    import claude_rts.qa_runner as runner
+
+    assert runner._discover_scenarios() == []
+
+
+def test_discover_scenarios_sorted(tmp_scenarios_dir):
+    import claude_rts.qa_runner as runner
+
+    (tmp_scenarios_dir / "syn-003-z.py").write_text("", encoding="utf-8")
+    (tmp_scenarios_dir / "syn-001-a.py").write_text("", encoding="utf-8")
+    (tmp_scenarios_dir / "syn-002-m.py").write_text("", encoding="utf-8")
+
+    paths = runner._discover_scenarios()
+    names = [p.name for p in paths]
+    assert names == ["syn-001-a.py", "syn-002-m.py", "syn-003-z.py"]
+
+
+def test_discover_scenarios_ignores_non_py(tmp_scenarios_dir):
+    import claude_rts.qa_runner as runner
+
+    (tmp_scenarios_dir / "syn-001.py").write_text("", encoding="utf-8")
+    (tmp_scenarios_dir / "README.md").write_text("", encoding="utf-8")
+    (tmp_scenarios_dir / "data.json").write_text("", encoding="utf-8")
+
+    paths = runner._discover_scenarios()
+    assert len(paths) == 1
+    assert paths[0].name == "syn-001.py"
+
+
+# ---------------------------------------------------------------------------
+# Scenario loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_scenario_class_valid(tmp_scenarios_dir):
+    import claude_rts.qa_runner as runner
+
+    path = _write_scenario_file(tmp_scenarios_dir, "syn-001-test.py", "syn-001-test")
+    cls = runner._load_scenario_class(path)
+    assert cls is not None
+    assert cls.scenario_id == "syn-001-test"
+    assert cls.debt_issue == 221
+    assert cls.preset == "default"
+
+
+def test_load_scenario_class_missing_class(tmp_scenarios_dir):
+    import claude_rts.qa_runner as runner
+
+    path = tmp_scenarios_dir / "bad.py"
+    path.write_text("x = 1\n", encoding="utf-8")
+    cls = runner._load_scenario_class(path)
+    assert cls is None
+
+
+def test_load_scenario_class_exec_error(tmp_scenarios_dir):
+    import claude_rts.qa_runner as runner
+
+    path = tmp_scenarios_dir / "broken.py"
+    path.write_text("raise RuntimeError('boom')\n", encoding="utf-8")
+    cls = runner._load_scenario_class(path)
+    assert cls is None
+
+
+# ---------------------------------------------------------------------------
+# Verdict loading and filtering
+# ---------------------------------------------------------------------------
+
+
+def test_load_verdicts_empty(tmp_verdicts):
+    import claude_rts.qa_runner as runner
+
+    assert runner._load_verdicts() == []
+
+
+def test_load_verdicts_records(tmp_verdicts):
+    import claude_rts.qa_runner as runner
+
+    _write_verdict(tmp_verdicts, "s1", "yes")
+    _write_verdict(tmp_verdicts, "s2", "no")
+    _write_verdict(tmp_verdicts, "s3", "skip")
+
+    records = runner._load_verdicts()
+    assert len(records) == 3
+
+
+def test_discharged_scenario_ids_yes_and_no(tmp_verdicts):
+    import claude_rts.qa_runner as runner
+
+    _write_verdict(tmp_verdicts, "s1", "yes")
+    _write_verdict(tmp_verdicts, "s2", "no")
+
+    discharged = runner._discharged_scenario_ids(runner._load_verdicts())
+    assert discharged == {"s1", "s2"}
+
+
+def test_skip_does_not_discharge(tmp_verdicts):
+    import claude_rts.qa_runner as runner
+
+    _write_verdict(tmp_verdicts, "s1", "skip")
+    discharged = runner._discharged_scenario_ids(runner._load_verdicts())
+    assert discharged == set()
+
+
+def test_skip_then_yes_discharges(tmp_verdicts):
+    import claude_rts.qa_runner as runner
+
+    _write_verdict(tmp_verdicts, "s1", "skip")
+    _write_verdict(tmp_verdicts, "s1", "yes")
+    discharged = runner._discharged_scenario_ids(runner._load_verdicts())
+    assert "s1" in discharged
+
+
+# ---------------------------------------------------------------------------
+# Verdict append
+# ---------------------------------------------------------------------------
+
+
+def test_append_verdict_creates_file(tmp_verdicts):
+    import claude_rts.qa_runner as runner
+
+    assert not tmp_verdicts.exists()
+    runner._append_verdict(
+        {"scenario_id": "s1", "verdict": "yes", "commit_sha": "abc", "timestamp": "t", "question": "q"}
+    )
+    assert tmp_verdicts.exists()
+    records = runner._load_verdicts()
+    assert len(records) == 1
+    assert records[0]["scenario_id"] == "s1"
+
+
+def test_append_verdict_appends(tmp_verdicts):
+    import claude_rts.qa_runner as runner
+
+    runner._append_verdict(
+        {"scenario_id": "s1", "verdict": "yes", "commit_sha": "abc", "timestamp": "t", "question": "q"}
+    )
+    runner._append_verdict(
+        {"scenario_id": "s2", "verdict": "no", "commit_sha": "def", "timestamp": "t", "question": "q"}
+    )
+    records = runner._load_verdicts()
+    assert len(records) == 2
+
+
+# ---------------------------------------------------------------------------
+# GitHub comment posting
+# ---------------------------------------------------------------------------
+
+
+def test_post_github_comment_calls_gh(monkeypatch):
+    import claude_rts.qa_runner as runner
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return mock.Mock(returncode=0, stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    ok = runner._post_github_comment("owner/repo", 221, "verdict body")
+    assert ok is True
+    assert calls[0][:4] == ["gh", "issue", "comment", "221"]
+    assert "--repo" in calls[0]
+    assert "owner/repo" in calls[0]
+
+
+def test_post_github_comment_returns_false_on_nonzero(monkeypatch):
+    import claude_rts.qa_runner as runner
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: mock.Mock(returncode=1, stderr="error"),
+    )
+    ok = runner._post_github_comment("owner/repo", 221, "body")
+    assert ok is False
+
+
+def test_post_github_comment_returns_false_when_gh_missing(monkeypatch):
+    import claude_rts.qa_runner as runner
+
+    def raise_fnf(*a, **kw):
+        raise FileNotFoundError("gh not found")
+
+    monkeypatch.setattr("subprocess.run", raise_fnf)
+    ok = runner._post_github_comment("owner/repo", 221, "body")
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# REPO slug derivation
+# ---------------------------------------------------------------------------
+
+
+def test_derive_repo_slug_https(monkeypatch):
+    import claude_rts.qa_runner as runner
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout="https://github.com/owner/myrepo.git\n"),
+    )
+    assert runner._derive_repo_slug() == "owner/myrepo"
+
+
+def test_derive_repo_slug_ssh(monkeypatch):
+    import claude_rts.qa_runner as runner
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout="git@github.com:owner/myrepo.git\n"),
+    )
+    assert runner._derive_repo_slug() == "owner/myrepo"
+
+
+def test_derive_repo_slug_fallback(monkeypatch):
+    import claude_rts.qa_runner as runner
+
+    def raise_exc(*a, **kw):
+        raise OSError("no git")
+
+    monkeypatch.setattr("subprocess.run", raise_exc)
+    slug = runner._derive_repo_slug()
+    assert slug == runner._FALLBACK_REPO
+
+
+# ---------------------------------------------------------------------------
+# run_next() — no scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_run_next_no_scenarios(tmp_scenarios_dir, tmp_verdicts):
+    import claude_rts.qa_runner as runner
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.run_next()
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# run_next() — all discharged
+# ---------------------------------------------------------------------------
+
+
+def test_run_next_all_discharged(tmp_scenarios_dir, tmp_verdicts):
+    import claude_rts.qa_runner as runner
+
+    _write_scenario_file(tmp_scenarios_dir, "syn-001.py", "syn-001")
+    _write_verdict(tmp_verdicts, "syn-001", "yes")
+
+    with pytest.raises(SystemExit) as exc_info:
+        runner.run_next()
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Synthetic scenario file — smoke-load
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_scenario_loads():
+    """Verify syn-001-container-terminal.py can be imported without error."""
+    import claude_rts.qa_runner as runner
+
+    path = pathlib.Path(__file__).resolve().parent.parent / "qa_scenarios" / "syn-001-container-terminal.py"
+    assert path.exists(), f"Scenario file not found: {path}"
+    cls = runner._load_scenario_class(path)
+    assert cls is not None
+    assert cls.scenario_id == "syn-001-container-terminal"
+    assert cls.debt_issue == 221
+    assert cls.preset == "default"
+
+
+def test_synthetic_scenario_run_setup_returns_human_gate(monkeypatch):
+    """run_setup should return a HumanGate when given a mock page."""
+    import claude_rts.qa_runner as runner
+    from claude_rts.qa_scenario import HumanGate
+
+    path = pathlib.Path(__file__).resolve().parent.parent / "qa_scenarios" / "syn-001-container-terminal.py"
+    cls = runner._load_scenario_class(path)
+    assert cls is not None
+
+    # Build a minimal mock Playwright page.
+    mock_page = mock.Mock()
+    mock_page.evaluate.return_value = {"ok": True, "card_id": "card-abc"}
+
+    instance = cls()
+    gate = instance.run_setup(mock_page)
+
+    assert isinstance(gate, HumanGate)
+    assert gate.scenario_id == "syn-001-container-terminal"
+    assert len(gate.question) > 10
+    assert len(gate.expected) > 10


### PR DESCRIPTION
Closes #277

## What changed (retooled design)

The original implementation used a local \`~/.supreme-claudemander/qa-verdicts.jsonl\` file as the source of truth and an auto-selecting \`qa next\` command. This PR retools to the revised design from issue #277:

- **\`qa run <scenario-id>\`** replaces \`qa next\` — the CLI takes an explicit scenario ID rather than auto-selecting
- **GitHub issue comments are the only verdict record** — no local JSONL file; an agent reads the debt issue to determine what's verified
- **CLI is a dumb runner** — starts server, drives Playwright to gate state, reads y/n/s, posts structured verdict comment to the debt issue, exits
- **Agent workflow is the orchestrator** — documented in \`docs/qa-scenarios.md\`; the agent reads the issue, picks unverified scenarios, calls \`qa run\`, iterates

## Implementation

### CLI surface

\`\`\`
python -m claude_rts qa run <scenario-id>   # run one scenario by ID
python -m claude_rts qa list                # list all scenario IDs + debt issues
\`\`\`

### Components

**\`claude_rts/qa_scenario.py\`** — \`HumanGate\` dataclass and \`QAScenario\` protocol (unchanged from original).

**\`claude_rts/qa_runner.py\`** — \`run_scenario(scenario_id)\` and \`list_scenarios()\`. Verdict is posted as a structured GitHub issue comment on the debt issue. No JSONL read/write.

**\`claude_rts/__main__.py\`** — \`qa run <id>\` and \`qa list\` subcommands dispatching to the runner.

**\`qa_scenarios/syn-001-container-terminal.py\`** — Synthetic Phase 1 scenario targeting debt issue #221. Right-clicks canvas to spawn Container Manager widget, calls \`POST /api/claude/terminal/create\` (real production endpoint), waits for card DOM element, presents human gate.

**\`docs/qa-scenarios.md\`** — Documents scenario format, CLI commands, verdict comment format, and the Claude agent workflow prompt for iterating through unverified scenarios.

### Verdict comment format

Posted to the linked debt issue on every y/n verdict:

\`\`\`markdown
## QA Verdict: PASS ✓

**Scenario:** \`syn-001-container-terminal\`
**Question:** Does the Container Manager widget say 'Container Manager'...
**Expected:** Widget title reads 'Container Manager'...
**Verdict:** yes
**Commit:** \`abc1234\`
**Timestamp:** 2026-04-28T...
\`\`\`

An agent searching for \`## QA Verdict\` + \`**Scenario:** \`<id>\`` in issue comments can determine verified vs unverified without any local state.

### Default execution path

\`python -m claude_rts qa run syn-001-container-terminal\` → loads scenario class → starts backend on port 3097 with \`--dev-config default\` → waits for server ready → launches headed Chromium → navigates, waits for boot complete → calls \`scenario.run_setup(page)\` → prints gate question → reads single keystroke → posts verdict comment to debt issue → exits 0.

### Edge cases

- **Scenario ID not found:** exits 1 with available scenario IDs listed
- **Server fails to start within 30s:** exits 1; server process cleaned up
- **\`gh\` CLI not installed:** exits 1 with instructions (no local fallback)
- **Unrecognised keystroke:** re-prompts or treats as skip with warning
- **\`HEADED=0\`:** headless mode for wiring tests